### PR TITLE
Fix argument splitting to work on spaces

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -23,7 +23,7 @@ const createTransport = async (query: express.Request["query"]) => {
 
   if (transportType === "stdio") {
     const command = query.command as string;
-    const args = (query.args as string).split(",");
+    const args = (query.args as string).split(/\s+/);
     console.log(`Stdio transport: command=${command}, args=${args}`);
     const transport = new StdioClientTransport({ command, args });
     await transport.start();


### PR DESCRIPTION
The UI specifies that stdio arguments should be space-separated, but the code was looking for commas. I think spaces is more natural (although it makes embedding strings hard—we can solve that later), so this fixes the server-side behavior accordingly.