### PR TITLE
refactor: remove hardcoded example server path

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -69,10 +69,7 @@ const App = () => {
     );
   });
   const [args, setArgs] = useState<string>(() => {
-    return (
-      localStorage.getItem("lastArgs") ||
-      "/Users/ashwin/code/mcp/example-servers/build/everything/stdio.js"
-    );
+    return localStorage.getItem("lastArgs") || "";
   });
   const [url, setUrl] = useState<string>("http://localhost:3001/sse");
   const [transportType, setTransportType] = useState<"stdio" | "sse">("stdio");


### PR DESCRIPTION
Remove hardcoded path to example server from default args state, replacing with empty string. This makes the initial state more generic and allows users to specify their own server path without preset assumptions.
