### PR TITLE
improve inspector startup message

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -34,16 +34,17 @@ const serverCommand = [
   .filter(Boolean)
   .join(" ");
 
-console.log(serverCommand);
+const CLIENT_PORT = process.env.CLIENT_PORT ?? "";
+const SERVER_PORT = process.env.SERVER_PORT ?? "";
 
 const { result } = concurrently(
   [
     {
-      command: serverCommand,
+      command: `PORT=${SERVER_PORT} ${serverCommand}`,
       name: "server",
     },
     {
-      command: `node ${inspectorClientPath}`,
+      command: `PORT=${CLIENT_PORT} node ${inspectorClientPath}`,
       name: "client",
     },
   ],
@@ -52,6 +53,10 @@ const { result } = concurrently(
     killOthers: ["failure", "success"],
     restartTries: 3,
   },
+);
+
+console.log(
+  `\n🔍 MCP Inspector is up and running at http://localhost:${CLIENT_PORT || 5173} 🚀`,
 );
 
 result.catch((err) => {

--- a/client/bin/cli.js
+++ b/client/bin/cli.js
@@ -13,6 +13,4 @@ const server = http.createServer((request, response) => {
 });
 
 const port = process.env.PORT || 5173;
-server.listen(port, () => {
-  console.log(`MCP inspector client running at http://localhost:${port}`);
-});
+server.listen(port, () => {});

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-client",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "Client-side application for the Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-server",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "Server-side application for the Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -121,6 +121,4 @@ app.get("/config", (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
-});
+app.listen(PORT, () => {});


### PR DESCRIPTION
Condensed the startup output so that it now only shows the client URL instead of both the server and client URLs.

![CleanShot 2024-11-19 at 16 57 29@2x](https://github.com/user-attachments/assets/0b228110-4fd9-47f6-bc44-d3e323f0bae6)