### PR TITLE
Add Runtime Type Validation for Tool Results

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -49,8 +49,11 @@ const ToolsTab = ({
               {JSON.stringify(toolResult, null, 2)}
             </pre>
             <h4 className="font-semibold mb-2">Errors:</h4>
-            {parsedResult.error.errors.map((error) => (
-              <pre className="bg-gray-50 dark:bg-gray-800 dark:text-gray-100 p-4 rounded text-sm overflow-auto max-h-64">
+            {parsedResult.error.errors.map((error, idx) => (
+              <pre 
+                key={idx}
+                className="bg-gray-50 dark:bg-gray-800 dark:text-gray-100 p-4 rounded text-sm overflow-auto max-h-64"
+              >
                 {JSON.stringify(error, null, 2)}
               </pre>
             ))}

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -8,6 +8,7 @@ import {
   CallToolResult,
   ListToolsResult,
   Tool,
+  CallToolResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { AlertCircle, Send } from "lucide-react";
 import { useState } from "react";
@@ -40,7 +41,7 @@ const ToolsTab = ({
     if (!toolResult) return null;
 
     if ("content" in toolResult) {
-      const structuredResult = toolResult as CallToolResult;
+      const structuredResult = CallToolResultSchema.parse(toolResult);
       const isError = structuredResult.isError ?? false;
 
       return (

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -5,7 +5,6 @@ import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import {
-  CallToolResult,
   ListToolsResult,
   Tool,
   CallToolResultSchema,
@@ -41,7 +40,24 @@ const ToolsTab = ({
     if (!toolResult) return null;
 
     if ("content" in toolResult) {
-      const structuredResult = CallToolResultSchema.parse(toolResult);
+      const parsedResult = CallToolResultSchema.safeParse(toolResult);
+      if (!parsedResult.success) {
+        return (
+          <>
+            <h4 className="font-semibold mb-2">Invalid Tool Result:</h4>
+            <pre className="bg-gray-50 dark:bg-gray-800 dark:text-gray-100 p-4 rounded text-sm overflow-auto max-h-64">
+              {JSON.stringify(toolResult, null, 2)}
+            </pre>
+            <h4 className="font-semibold mb-2">Errors:</h4>
+            {parsedResult.error.errors.map((error) => (
+              <pre className="bg-gray-50 dark:bg-gray-800 dark:text-gray-100 p-4 rounded text-sm overflow-auto max-h-64">
+                {JSON.stringify(error, null, 2)}
+              </pre>
+            ))}
+          </>
+        );
+      }
+      const structuredResult = parsedResult.data;
       const isError = structuredResult.isError ?? false;
 
       return (


### PR DESCRIPTION
Fixes #80

## Problem
The inspector crashes when tool handlers return malformed responses. Specifically, when following the weather example from the docs, the inspector throws `TypeError: f.content.map is not a function` because the response structure doesn't match expectations.

## Solution
- Replace type assertions with Zod schema validation to catch malformed responses
- Add error UI to display validation failures and help debug incorrect tool responses
- Update imports to use CallToolResultSchema for runtime type checking

## Changes
- Uses `safeParse()` to validate without throwing
- Shows both invalid data and validation errors in the UI
- Maintains dark mode compatibility

## Testing
- [ ] Follow weather example from docs to verify fix
- [ ] Test various malformed response scenarios
- [ ] Check error display formatting
- [ ] Verify dark mode styles