### PR TITLE
Allow setting the timeout with the "timeout" URL parameter

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -59,6 +59,7 @@ const DEFAULT_REQUEST_TIMEOUT_MSEC = 10000;
 
 const params = new URLSearchParams(window.location.search);
 const PROXY_PORT = params.get("proxyPort") ?? "3000";
+const REQUEST_TIMEOUT = parseInt(params.get("timeout") ?? "") || DEFAULT_REQUEST_TIMEOUT_MSEC;
 const PROXY_SERVER_URL = `http://localhost:${PROXY_PORT}`;
 
 const App = () => {
@@ -243,7 +244,7 @@ const App = () => {
       const abortController = new AbortController();
       const timeoutId = setTimeout(() => {
         abortController.abort("Request timed out");
-      }, DEFAULT_REQUEST_TIMEOUT_MSEC);
+      }, REQUEST_TIMEOUT);
 
       let response;
       try {


### PR DESCRIPTION
Allows setting the Request Timeout in milliseconds with a "timeout" URL parameter

## Motivation and Context

Enables testing of tools which take > 10s to respond.

## How Has This Been Tested?

This has been tested using the mcp-everything server 

![image](https://github.com/user-attachments/assets/f3c0c3bc-fe44-4f81-b1ae-3125ec7f50c2)

## Breaking Changes

No breaking changes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context

@ashwin-ant this is intended to cover simple cases - I considered matching progress updates to requestids to reset the timer - but that seems over-engineered for the need.