### PR TITLE
feat: implement capability negotiation for UI tabs

### DIFF
--- a/client/src/components/PromptsTab.tsx
+++ b/client/src/components/PromptsTab.tsx
@@ -6,8 +6,9 @@ import { TabsContent } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { ListPromptsResult } from "@modelcontextprotocol/sdk/types.js";
 import { AlertCircle } from "lucide-react";
-import { useState } from "react";
+import { useState, useContext } from "react";
 import ListPane from "./ListPane";
+import { CapabilityContext } from "@/lib/contexts";
 
 export type Prompt = {
   name: string;
@@ -40,6 +41,7 @@ const PromptsTab = ({
   nextCursor: ListPromptsResult["nextCursor"];
   error: string | null;
 }) => {
+  const capabilities = useContext(CapabilityContext);
   const [promptArgs, setPromptArgs] = useState<Record<string, string>>({});
 
   const handleInputChange = (argName: string, value: string) => {
@@ -54,86 +56,98 @@ const PromptsTab = ({
 
   return (
     <TabsContent value="prompts" className="grid grid-cols-2 gap-4">
-      <ListPane
-        items={prompts}
-        listItems={listPrompts}
-        clearItems={clearPrompts}
-        setSelectedItem={(prompt) => {
-          setSelectedPrompt(prompt);
-          setPromptArgs({});
-        }}
-        renderItem={(prompt) => (
-          <>
-            <span className="flex-1">{prompt.name}</span>
-            <span className="text-sm text-gray-500">{prompt.description}</span>
-          </>
-        )}
-        title="Prompts"
-        buttonText={nextCursor ? "List More Prompts" : "List Prompts"}
-        isButtonDisabled={!nextCursor && prompts.length > 0}
-      />
+      {!capabilities?.prompts ? (
+        <Alert variant="destructive" className="col-span-2">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Feature Not Available</AlertTitle>
+          <AlertDescription>
+            The connected server does not support prompts.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <>
+          <ListPane
+            items={prompts}
+            listItems={listPrompts}
+            clearItems={clearPrompts}
+            setSelectedItem={(prompt) => {
+              setSelectedPrompt(prompt);
+              setPromptArgs({});
+            }}
+            renderItem={(prompt) => (
+              <>
+                <span className="flex-1">{prompt.name}</span>
+                <span className="text-sm text-gray-500">{prompt.description}</span>
+              </>
+            )}
+            title="Prompts"
+            buttonText={nextCursor ? "List More Prompts" : "List Prompts"}
+            isButtonDisabled={!nextCursor && prompts.length > 0}
+          />
 
-      <div className="bg-card rounded-lg shadow">
-        <div className="p-4 border-b border-gray-200">
-          <h3 className="font-semibold">
-            {selectedPrompt ? selectedPrompt.name : "Select a prompt"}
-          </h3>
-        </div>
-        <div className="p-4">
-          {error ? (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>Error</AlertTitle>
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          ) : selectedPrompt ? (
-            <div className="space-y-4">
-              {selectedPrompt.description && (
-                <p className="text-sm text-gray-600">
-                  {selectedPrompt.description}
-                </p>
-              )}
-              {selectedPrompt.arguments?.map((arg) => (
-                <div key={arg.name}>
-                  <Label htmlFor={arg.name}>{arg.name}</Label>
-                  <Input
-                    id={arg.name}
-                    placeholder={`Enter ${arg.name}`}
-                    value={promptArgs[arg.name] || ""}
-                    onChange={(e) =>
-                      handleInputChange(arg.name, e.target.value)
-                    }
-                  />
-                  {arg.description && (
-                    <p className="text-xs text-gray-500 mt-1">
-                      {arg.description}
-                      {arg.required && (
-                        <span className="text-xs mt-1 ml-1">(Required)</span>
-                      )}
+          <div className="bg-card rounded-lg shadow">
+            <div className="p-4 border-b border-gray-200">
+              <h3 className="font-semibold">
+                {selectedPrompt ? selectedPrompt.name : "Select a prompt"}
+              </h3>
+            </div>
+            <div className="p-4">
+              {error ? (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertTitle>Error</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              ) : selectedPrompt ? (
+                <div className="space-y-4">
+                  {selectedPrompt.description && (
+                    <p className="text-sm text-gray-600">
+                      {selectedPrompt.description}
                     </p>
                   )}
+                  {selectedPrompt.arguments?.map((arg) => (
+                    <div key={arg.name}>
+                      <Label htmlFor={arg.name}>{arg.name}</Label>
+                      <Input
+                        id={arg.name}
+                        placeholder={`Enter ${arg.name}`}
+                        value={promptArgs[arg.name] || ""}
+                        onChange={(e) =>
+                          handleInputChange(arg.name, e.target.value)
+                        }
+                      />
+                      {arg.description && (
+                        <p className="text-xs text-gray-500 mt-1">
+                          {arg.description}
+                          {arg.required && (
+                            <span className="text-xs mt-1 ml-1">(Required)</span>
+                          )}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                  <Button onClick={handleGetPrompt} className="w-full">
+                    Get Prompt
+                  </Button>
+                  {promptContent && (
+                    <Textarea
+                      value={promptContent}
+                      readOnly
+                      className="h-64 font-mono"
+                    />
+                  )}
                 </div>
-              ))}
-              <Button onClick={handleGetPrompt} className="w-full">
-                Get Prompt
-              </Button>
-              {promptContent && (
-                <Textarea
-                  value={promptContent}
-                  readOnly
-                  className="h-64 font-mono"
-                />
+              ) : (
+                <Alert>
+                  <AlertDescription>
+                    Select a prompt from the list to view and use it
+                  </AlertDescription>
+                </Alert>
               )}
             </div>
-          ) : (
-            <Alert>
-              <AlertDescription>
-                Select a prompt from the list to view and use it
-              </AlertDescription>
-            </Alert>
-          )}
-        </div>
-      </div>
+          </div>
+        </>
+      )}
     </TabsContent>
   );
 };

--- a/client/src/components/ResourcesTab.tsx
+++ b/client/src/components/ResourcesTab.tsx
@@ -10,7 +10,8 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { AlertCircle, ChevronRight, FileText, RefreshCw } from "lucide-react";
 import ListPane from "./ListPane";
-import { useState } from "react";
+import { useState, useContext } from "react";
+import { CapabilityContext } from "@/lib/contexts";
 
 const ResourcesTab = ({
   resources,
@@ -41,6 +42,7 @@ const ResourcesTab = ({
   nextTemplateCursor: ListResourceTemplatesResult["nextCursor"];
   error: string | null;
 }) => {
+  const capabilities = useContext(CapabilityContext);
   const [selectedTemplate, setSelectedTemplate] =
     useState<ResourceTemplate | null>(null);
   const [templateValues, setTemplateValues] = useState<Record<string, string>>(
@@ -62,142 +64,153 @@ const ResourcesTab = ({
       const uri = fillTemplate(selectedTemplate.uriTemplate, templateValues);
       readResource(uri);
       setSelectedTemplate(null);
-      // We don't have the full Resource object here, so we create a partial one
       setSelectedResource({ uri, name: uri } as Resource);
     }
   };
 
   return (
     <TabsContent value="resources" className="grid grid-cols-3 gap-4">
-      <ListPane
-        items={resources}
-        listItems={listResources}
-        clearItems={clearResources}
-        setSelectedItem={(resource) => {
-          setSelectedResource(resource);
-          readResource(resource.uri);
-          setSelectedTemplate(null);
-        }}
-        renderItem={(resource) => (
-          <div className="flex items-center w-full">
-            <FileText className="w-4 h-4 mr-2 flex-shrink-0 text-gray-500" />
-            <span className="flex-1 truncate" title={resource.uri.toString()}>
-              {resource.name}
-            </span>
-            <ChevronRight className="w-4 h-4 flex-shrink-0 text-gray-400" />
-          </div>
-        )}
-        title="Resources"
-        buttonText={nextCursor ? "List More Resources" : "List Resources"}
-        isButtonDisabled={!nextCursor && resources.length > 0}
-      />
+      {!capabilities?.resources ? (
+        <Alert variant="destructive" className="col-span-3">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Feature Not Available</AlertTitle>
+          <AlertDescription>
+            The connected server does not support resources.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <>
+          <ListPane
+            items={resources}
+            listItems={listResources}
+            clearItems={clearResources}
+            setSelectedItem={(resource) => {
+              setSelectedResource(resource);
+              readResource(resource.uri);
+              setSelectedTemplate(null);
+            }}
+            renderItem={(resource) => (
+              <div className="flex items-center w-full">
+                <FileText className="w-4 h-4 mr-2 flex-shrink-0 text-gray-500" />
+                <span className="flex-1 truncate" title={resource.uri.toString()}>
+                  {resource.name}
+                </span>
+                <ChevronRight className="w-4 h-4 flex-shrink-0 text-gray-400" />
+              </div>
+            )}
+            title="Resources"
+            buttonText={nextCursor ? "List More Resources" : "List Resources"}
+            isButtonDisabled={!nextCursor && resources.length > 0}
+          />
 
-      <ListPane
-        items={resourceTemplates}
-        listItems={listResourceTemplates}
-        clearItems={clearResourceTemplates}
-        setSelectedItem={(template) => {
-          setSelectedTemplate(template);
-          setSelectedResource(null);
-          setTemplateValues({});
-        }}
-        renderItem={(template) => (
-          <div className="flex items-center w-full">
-            <FileText className="w-4 h-4 mr-2 flex-shrink-0 text-gray-500" />
-            <span className="flex-1 truncate" title={template.uriTemplate}>
-              {template.name}
-            </span>
-            <ChevronRight className="w-4 h-4 flex-shrink-0 text-gray-400" />
-          </div>
-        )}
-        title="Resource Templates"
-        buttonText={
-          nextTemplateCursor ? "List More Templates" : "List Templates"
-        }
-        isButtonDisabled={!nextTemplateCursor && resourceTemplates.length > 0}
-      />
+          <ListPane
+            items={resourceTemplates}
+            listItems={listResourceTemplates}
+            clearItems={clearResourceTemplates}
+            setSelectedItem={(template) => {
+              setSelectedTemplate(template);
+              setSelectedResource(null);
+              setTemplateValues({});
+            }}
+            renderItem={(template) => (
+              <div className="flex items-center w-full">
+                <FileText className="w-4 h-4 mr-2 flex-shrink-0 text-gray-500" />
+                <span className="flex-1 truncate" title={template.uriTemplate}>
+                  {template.name}
+                </span>
+                <ChevronRight className="w-4 h-4 flex-shrink-0 text-gray-400" />
+              </div>
+            )}
+            title="Resource Templates"
+            buttonText={
+              nextTemplateCursor ? "List More Templates" : "List Templates"
+            }
+            isButtonDisabled={!nextTemplateCursor && resourceTemplates.length > 0}
+          />
 
-      <div className="bg-card rounded-lg shadow">
-        <div className="p-4 border-b border-gray-200 flex justify-between items-center">
-          <h3
-            className="font-semibold truncate"
-            title={selectedResource?.name || selectedTemplate?.name}
-          >
-            {selectedResource
-              ? selectedResource.name
-              : selectedTemplate
-                ? selectedTemplate.name
-                : "Select a resource or template"}
-          </h3>
-          {selectedResource && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => readResource(selectedResource.uri)}
-            >
-              <RefreshCw className="w-4 h-4 mr-2" />
-              Refresh
-            </Button>
-          )}
-        </div>
-        <div className="p-4">
-          {error ? (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>Error</AlertTitle>
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          ) : selectedResource ? (
-            <pre className="bg-gray-50 dark:bg-gray-800 p-4 rounded text-sm overflow-auto max-h-96 whitespace-pre-wrap break-words text-gray-900 dark:text-gray-100">
-              {resourceContent}
-            </pre>
-          ) : selectedTemplate ? (
-            <div className="space-y-4">
-              <p className="text-sm text-gray-600">
-                {selectedTemplate.description}
-              </p>
-              {selectedTemplate.uriTemplate
-                .match(/{([^}]+)}/g)
-                ?.map((param) => {
-                  const key = param.slice(1, -1);
-                  return (
-                    <div key={key}>
-                      <label
-                        htmlFor={key}
-                        className="block text-sm font-medium text-gray-700"
-                      >
-                        {key}
-                      </label>
-                      <Input
-                        id={key}
-                        value={templateValues[key] || ""}
-                        onChange={(e) =>
-                          setTemplateValues({
-                            ...templateValues,
-                            [key]: e.target.value,
-                          })
-                        }
-                        className="mt-1"
-                      />
-                    </div>
-                  );
-                })}
-              <Button
-                onClick={handleReadTemplateResource}
-                disabled={Object.keys(templateValues).length === 0}
+          <div className="bg-card rounded-lg shadow">
+            <div className="p-4 border-b border-gray-200 flex justify-between items-center">
+              <h3
+                className="font-semibold truncate"
+                title={selectedResource?.name || selectedTemplate?.name}
               >
-                Read Resource
-              </Button>
+                {selectedResource
+                  ? selectedResource.name
+                  : selectedTemplate
+                    ? selectedTemplate.name
+                    : "Select a resource or template"}
+              </h3>
+              {selectedResource && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => readResource(selectedResource.uri)}
+                >
+                  <RefreshCw className="w-4 h-4 mr-2" />
+                  Refresh
+                </Button>
+              )}
             </div>
-          ) : (
-            <Alert>
-              <AlertDescription>
-                Select a resource or template from the list to view its contents
-              </AlertDescription>
-            </Alert>
-          )}
-        </div>
-      </div>
+            <div className="p-4">
+              {error ? (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertTitle>Error</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              ) : selectedResource ? (
+                <pre className="bg-gray-50 dark:bg-gray-800 p-4 rounded text-sm overflow-auto max-h-96 whitespace-pre-wrap break-words text-gray-900 dark:text-gray-100">
+                  {resourceContent}
+                </pre>
+              ) : selectedTemplate ? (
+                <div className="space-y-4">
+                  <p className="text-sm text-gray-600">
+                    {selectedTemplate.description}
+                  </p>
+                  {selectedTemplate.uriTemplate
+                    .match(/{([^}]+)}/g)
+                    ?.map((param) => {
+                      const key = param.slice(1, -1);
+                      return (
+                        <div key={key}>
+                          <label
+                            htmlFor={key}
+                            className="block text-sm font-medium text-gray-700"
+                          >
+                            {key}
+                          </label>
+                          <Input
+                            id={key}
+                            value={templateValues[key] || ""}
+                            onChange={(e) =>
+                              setTemplateValues({
+                                ...templateValues,
+                                [key]: e.target.value,
+                              })
+                            }
+                            className="mt-1"
+                          />
+                        </div>
+                      );
+                    })}
+                  <Button
+                    onClick={handleReadTemplateResource}
+                    disabled={Object.keys(templateValues).length === 0}
+                  >
+                    Read Resource
+                  </Button>
+                </div>
+              ) : (
+                <Alert>
+                  <AlertDescription>
+                    Select a resource or template from the list to view its contents
+                  </AlertDescription>
+                </Alert>
+              )}
+            </div>
+          </div>
+        </>
+      )}
     </TabsContent>
   );
 };

--- a/client/src/lib/contexts.ts
+++ b/client/src/lib/contexts.ts
@@ -1,0 +1,12 @@
+import { createContext, useContext } from "react";
+import { ServerCapabilitiesSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { z } from "zod";
+
+export type ServerCapabilities = z.infer<typeof ServerCapabilitiesSchema>;
+
+export const CapabilityContext = createContext<ServerCapabilities | null>(null);
+
+export function useServerCapability(capability: keyof ServerCapabilities): boolean {
+  const capabilities = useContext(CapabilityContext);
+  return !!capabilities?.[capability];
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

This PR addresses https://github.com/modelcontextprotocol/inspector/issues/85 and implements the capability negotiation for a new server, disabling the features which are not supported.

Changes:

- Add CapabilityContext to manage server capabilities
- Disable tabs when server doesn't support feature
- Show error message in tab content when capability missing

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Addresses https://github.com/modelcontextprotocol/inspector/issues/85

[Devin](https://devin.ai) wrote all of this code! I am happy to touch up as needed.

## How Has This Been Tested?

Devin tested this in its browser with `mcp-server-git`.

<img width="1044" alt="Screenshot 2024-12-06 at 11 52 39 PM" src="https://github.com/user-attachments/assets/b82753d6-f69b-4a02-9dc6-da3105b87b2e">

I have also manually tested this locally with `mcp-server-git`, `mcp-server-sqlite`, and `mcp-server-filesystem`.

<img width="1415" alt="Screenshot 2024-12-06 at 11 52 55 PM" src="https://github.com/user-attachments/assets/474fffe9-53eb-4695-9948-05b0899e4a4c">

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

Link to Devin run: https://preview.devin.ai/devin/266955553baf40cfa7fdd32d42ab219d