### PR TITLE
Add dark mode support for the legacy Tool Result display

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -100,7 +100,7 @@ const ToolsTab = ({
       return (
         <>
           <h4 className="font-semibold mb-2">Tool Result (Legacy):</h4>
-          <pre className="bg-gray-50 p-4 rounded text-sm overflow-auto max-h-64">
+          <pre className="bg-gray-50 dark:bg-gray-800 dark:text-gray-100 p-4 rounded text-sm overflow-auto max-h-64">
             {JSON.stringify(toolResult.toolResult, null, 2)}
           </pre>
         </>


### PR DESCRIPTION
Small fix for the legacy Tool Result result view. It does not have tailwind classes for dark mode, makes the result look like it's empty, since you get white text on a white background. Was walking through some examples from the documentation that still uses toolResult - initially tripped me up into thinking that there was a problem with my mcp server.

## Motivation and Context
The legacy tool result does not have tailwind classes for dark mode.

## How Has This Been Tested?
Verified visually that the changes look the way they are supposed to visually.

Without fix:
![image](https://github.com/user-attachments/assets/61491972-08db-40c6-b862-196fd677592a)

With fix applied:
![image](https://github.com/user-attachments/assets/779d0d20-aa03-46a3-9aa0-ab1cdaaa9ee6)



## Breaking Changes
(none)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

