### PR TITLE
fix(server) Avoid modifying path resolution for executables on MacOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@modelcontextprotocol/inspector-server": "0.3.0",
         "concurrently": "^9.0.1",
         "shell-quote": "^1.8.2",
-        "spawn-rx": "^5.1.0",
+        "spawn-rx": "^5.1.2",
         "ts-node": "^10.9.2"
       },
       "bin": {
@@ -5748,9 +5748,9 @@
       }
     },
     "node_modules/spawn-rx": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-5.1.0.tgz",
-      "integrity": "sha512-b4HX44hI0usMiHu6LNaZUVg0BGqHuBcl+81iEhZwhvKHz1efTqD/CHBcUbm/uIe5TARy9pJolxU2NMfh6GuQBA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-5.1.2.tgz",
+      "integrity": "sha512-/y7tJKALVZ1lPzeZZB9jYnmtrL7d0N2zkorii5a7r7dhHkWIuLTzZpZzMJLK1dmYRgX/NCc4iarTO3F7BS2c/A==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.7",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@modelcontextprotocol/inspector-server": "0.3.0",
     "concurrently": "^9.0.1",
     "shell-quote": "^1.8.2",
-    "spawn-rx": "^5.1.0",
+    "spawn-rx": "^5.1.2",
     "ts-node": "^10.9.2"
   },
   "devDependencies": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import cors from "cors";
 import EventSource from "eventsource";
 import { parseArgs } from "node:util";
 import { parse as shellParseArgs } from "shell-quote";
+import { platform } from "node:os";
 
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import {
@@ -42,7 +43,12 @@ const createTransport = async (query: express.Request["query"]) => {
     const origArgs = shellParseArgs(query.args as string) as string[];
     const env = query.env ? JSON.parse(query.env as string) : undefined;
 
-    const { cmd, args } = findActualExecutable(command, origArgs);
+    // On Windows, we need to find the actual executable to run
+    // On other platforms, we can just use the command as-is
+    const { cmd, args } =
+      platform() === "win32"
+        ? findActualExecutable(command, origArgs)
+        : { cmd: command, args: origArgs };
 
     console.log(
       `Stdio transport: command=${cmd}, args=${args}, env=${JSON.stringify(env)}`,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,7 +4,6 @@ import cors from "cors";
 import EventSource from "eventsource";
 import { parseArgs } from "node:util";
 import { parse as shellParseArgs } from "shell-quote";
-import { platform } from "node:os";
 
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import {
@@ -43,12 +42,7 @@ const createTransport = async (query: express.Request["query"]) => {
     const origArgs = shellParseArgs(query.args as string) as string[];
     const env = query.env ? JSON.parse(query.env as string) : undefined;
 
-    // On Windows, we need to find the actual executable to run
-    // On other platforms, we can just use the command as-is
-    const { cmd, args } =
-      platform() === "win32"
-        ? findActualExecutable(command, origArgs)
-        : { cmd: command, args: origArgs };
+    const { cmd, args } = findActualExecutable(command, origArgs);
 
     console.log(
       `Stdio transport: command=${cmd}, args=${args}, env=${JSON.stringify(env)}`,


### PR DESCRIPTION
## Motivation and Context
`spawn-rx` follows symlinks when resolving executables, which breaks version manager shims on macOS. For example, when using Volta, `bun` incorrectly resolves to `volta-shim` instead of the `bun` executable. This PR works around the issue by bypassing `spawn-rx`'s path resolution on non-Windows platforms.

Closes #114

## How Has This Been Tested?
- Verified direct command execution works with Volta-managed `bun` on macOS
- Confirmed Windows path resolution remains untouched

## Breaking Changes
None. This restores expected behavior on macOS while maintaining existing Windows functionality.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This could be a temporary fix while we investigate the underlying `spawn-rx` path resolution behavior. We may want to upstream a fix that handles Windows PATH resolution without affecting Unix shims.

## To Reproduce
Steps to reproduce the behavior:
1. On MacOS, use Volta or another Node version management tool that uses symlinks to install Node or Bun.
2. In the MPC inspector UI, enter your command: `bun` or `node`.
3. Use the MPC inspector to launch your server.
<img width="308" alt="image" src="https://github.com/user-attachments/assets/c54468af-4ac9-48ae-a9b9-8053d8adbf95" />

## Expected behavior
The inspector should spawn the command as entered in the UI. 

## Logs
I'm getting this error:
```sh
Volta error: 'volta-shim' should not be called directly. Please use the existing shims provided by Volta (node, yarn, etc.) to run tools.
```
Note that the command `bun` is resolved incorrectly.
```sh
Stdio transport: command=/Users/jacksteam/.volta/bin/volta-shim, args=src/index.ts, env={"HOME":"/Users/jacksteam","LOGNAME":"jacksteam","PATH":"/Users/jacksteam/.npm/_npx/5a9d879542beca3a/node_modules/.bin:/Users/jacksteam/Documents/Cline/MCP/zettelkasten-server/node_modules/.bin:/Users/jacksteam/Documents/Cline/MCP/node_modules/.bin:/Users/jacksteam/Documents/Cline/node_modules/.bin:/Users/jacksteam/Documents/node_modules/.bin:/Users/jacksteam/node_modules/.bin:/Users/node_modules/.bin:/node_modules/.bin:/Users/jacksteam/.volta/tools/image/node/20.16.0/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/node-gyp-bin:/Users/jacksteam/.volta/tools/image/node/20.16.0/bin:/Users/jacksteam/perl5/bin:/Users/jacksteam/Library/pnpm:/Users/jacksteam/.volta/bin:/opt/homebrew/opt/openjdk/bin:/Users/jacksteam/.jenv/shims:/Users/jacksteam/.jenv/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/jacksteam/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand","SHELL":"/bin/zsh","TERM":"xterm-256color","USER":"jacksteam"}
```

---
Edit: rephrase to be more clear and concise, add additional context