### PR TITLE
Add server startup logging

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node build/index.js",
-    "dev": "node --import tsx --watch --watch-preserve-output src/index.ts"
+    "dev": "tsx watch --clear-screen=false src/index.ts"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node build/index.js",
-    "dev": "tsx watch --clear-screen=false src/index.ts"
+    "dev": "node --import tsx --watch --watch-preserve-output src/index.ts"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -159,7 +159,7 @@ try {
   server.on('listening', () => {
     const addr = server.address();
     const port = typeof addr === 'string' ? addr : addr?.port;
-    console.log(`Server listening on port ${port}`);
+    console.log(`Proxy server listening on port ${port}`);
   });
 
 } catch (error) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -152,4 +152,36 @@ app.get("/config", (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {});
+
+try {
+  const server = app.listen(PORT);
+  
+  server.on('listening', () => {
+    const addr = server.address();
+    const port = typeof addr === 'string' ? addr : addr?.port;
+    console.log(`Server listening on port ${port}`);
+  });
+  
+  server.on('error', (error: any) => {
+    if (error.code === 'EADDRINUSE') {
+      console.error(`Port ${PORT} is already in use`);
+      process.exit(1);
+    } else {
+      console.error('Error starting server:', error);
+      process.exit(1);
+    }
+  });
+
+  process.on('uncaughtException', (error) => {
+    console.error('Uncaught exception:', error);
+    process.exit(1);
+  });
+
+  process.on('unhandledRejection', (error) => {
+    console.error('Unhandled rejection:', error);
+    process.exit(1);
+  });
+} catch (error) {
+  console.error('Failed to start server:', error);
+  process.exit(1);
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -161,26 +161,7 @@ try {
     const port = typeof addr === 'string' ? addr : addr?.port;
     console.log(`Server listening on port ${port}`);
   });
-  
-  server.on('error', (error: any) => {
-    if (error.code === 'EADDRINUSE') {
-      console.error(`Port ${PORT} is already in use`);
-      process.exit(1);
-    } else {
-      console.error('Error starting server:', error);
-      process.exit(1);
-    }
-  });
 
-  process.on('uncaughtException', (error) => {
-    console.error('Uncaught exception:', error);
-    process.exit(1);
-  });
-
-  process.on('unhandledRejection', (error) => {
-    console.error('Unhandled rejection:', error);
-    process.exit(1);
-  });
 } catch (error) {
   console.error('Failed to start server:', error);
   process.exit(1);


### PR DESCRIPTION
## Motivation and Context

While debugging an issue with starting the proxy server, its helpful to see a log when the app is listening successfully.

## How Has This Been Tested?

Tested on my Windows and Mac OS machines.

## Breaking Changes

None

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

None
