### PR TITLE
Add Refresh Token Support for OAuth

### DIFF
--- a/client/src/components/OAuthCallback.tsx
+++ b/client/src/components/OAuthCallback.tsx
@@ -24,9 +24,12 @@ const OAuthCallback = () => {
       }
 
       try {
-        const accessToken = await handleOAuthCallback(serverUrl, code);
-        // Store the access token for future use
-        sessionStorage.setItem(SESSION_KEYS.ACCESS_TOKEN, accessToken);
+        const tokens = await handleOAuthCallback(serverUrl, code);
+        // Store both access and refresh tokens
+        sessionStorage.setItem(SESSION_KEYS.ACCESS_TOKEN, tokens.access_token);
+        if (tokens.refresh_token) {
+          sessionStorage.setItem(SESSION_KEYS.REFRESH_TOKEN, tokens.refresh_token);
+        }
         // Redirect back to the main app with server URL to trigger auto-connect
         window.location.href = `/?serverUrl=${encodeURIComponent(serverUrl)}`;
       } catch (error) {

--- a/client/src/components/OAuthCallback.tsx
+++ b/client/src/components/OAuthCallback.tsx
@@ -28,7 +28,10 @@ const OAuthCallback = () => {
         // Store both access and refresh tokens
         sessionStorage.setItem(SESSION_KEYS.ACCESS_TOKEN, tokens.access_token);
         if (tokens.refresh_token) {
-          sessionStorage.setItem(SESSION_KEYS.REFRESH_TOKEN, tokens.refresh_token);
+          sessionStorage.setItem(
+            SESSION_KEYS.REFRESH_TOKEN,
+            tokens.refresh_token,
+          );
         }
         // Redirect back to the main app with server URL to trigger auto-connect
         window.location.href = `/?serverUrl=${encodeURIComponent(serverUrl)}`;

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 export const OAuthMetadataSchema = z.object({
   authorization_endpoint: z.string(),
-  token_endpoint: z.string()
+  token_endpoint: z.string(),
 });
 
 export type OAuthMetadata = z.infer<typeof OAuthMetadataSchema>;
@@ -12,7 +12,7 @@ export type OAuthMetadata = z.infer<typeof OAuthMetadataSchema>;
 export const OAuthTokensSchema = z.object({
   access_token: z.string(),
   refresh_token: z.string().optional(),
-  expires_in: z.number().optional()
+  expires_in: z.number().optional(),
 });
 
 export type OAuthTokens = z.infer<typeof OAuthTokensSchema>;

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,16 +1,21 @@
 import pkceChallenge from "pkce-challenge";
 import { SESSION_KEYS } from "./constants";
+import { z } from "zod";
 
-export interface OAuthMetadata {
-  authorization_endpoint: string;
-  token_endpoint: string;
-}
+export const OAuthMetadataSchema = z.object({
+  authorization_endpoint: z.string(),
+  token_endpoint: z.string()
+});
 
-export interface OAuthTokens {
-  access_token: string;
-  refresh_token?: string;
-  expires_in?: number;
-}
+export type OAuthMetadata = z.infer<typeof OAuthMetadataSchema>;
+
+export const OAuthTokensSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string().optional(),
+  expires_in: z.number().optional()
+});
+
+export type OAuthTokens = z.infer<typeof OAuthTokensSchema>;
 
 export async function discoverOAuthMetadata(
   serverUrl: string,
@@ -93,8 +98,7 @@ export async function handleOAuthCallback(
     throw new Error("Token exchange failed");
   }
 
-  const data = await response.json();
-  return data;
+  return await response.json();
 }
 
 export async function refreshAccessToken(
@@ -122,6 +126,5 @@ export async function refreshAccessToken(
     throw new Error("Token refresh failed");
   }
 
-  const data = await response.json();
-  return data;
+  return await response.json();
 }

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -97,14 +97,16 @@ export async function handleOAuthCallback(
   return data;
 }
 
-export async function refreshAccessToken(serverUrl: string): Promise<OAuthTokens> {
+export async function refreshAccessToken(
+  serverUrl: string,
+): Promise<OAuthTokens> {
   const refreshToken = sessionStorage.getItem(SESSION_KEYS.REFRESH_TOKEN);
   if (!refreshToken) {
     throw new Error("No refresh token available");
   }
 
   const metadata = await discoverOAuthMetadata(serverUrl);
-  
+
   const response = await fetch(metadata.token_endpoint, {
     method: "POST",
     headers: {
@@ -112,7 +114,7 @@ export async function refreshAccessToken(serverUrl: string): Promise<OAuthTokens
     },
     body: JSON.stringify({
       grant_type: "refresh_token",
-      refresh_token: refreshToken
+      refresh_token: refreshToken,
     }),
   });
 

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -3,4 +3,5 @@ export const SESSION_KEYS = {
   CODE_VERIFIER: "mcp_code_verifier",
   SERVER_URL: "mcp_server_url",
   ACCESS_TOKEN: "mcp_access_token",
+  REFRESH_TOKEN: "mcp_refresh_token",
 } as const;

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -225,7 +225,12 @@ export function useConnection({
         if (shouldRetry) {
           return connect(undefined, retryCount + 1);
         }
-        return;
+
+        if (error instanceof SseError && error.code === 401) {
+          // Don't set error state if we're about to redirect for auth
+          return;
+        }
+        throw error;
       }
 
       const capabilities = client.getServerCapabilities();

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -225,12 +225,6 @@ export function useConnection({
         if (shouldRetry) {
           return connect(undefined, retryCount + 1);
         }
-
-        if (error instanceof SseError && error.code === 401) {
-          // Don't set error state if we're about to redirect for auth
-          return;
-        }
-        setConnectionStatus("error");
         return;
       }
 

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -134,7 +134,10 @@ export function useConnection({
       const tokens = await refreshAccessToken(sseUrl);
       sessionStorage.setItem(SESSION_KEYS.ACCESS_TOKEN, tokens.access_token);
       if (tokens.refresh_token) {
-        sessionStorage.setItem(SESSION_KEYS.REFRESH_TOKEN, tokens.refresh_token);
+        sessionStorage.setItem(
+          SESSION_KEYS.REFRESH_TOKEN,
+          tokens.refresh_token,
+        );
       }
       return tokens.access_token;
     } catch (error) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
This PR adds refresh token support to the MCP Inspector's OAuth auth flow. When an access token expires, the inspector will now automatically attempt to refresh it using the stored refresh token before initiating a new OAuth flow. This improves the user experience by reducing unnecessary re-authentication prompts.

It also handles the case where:
1. An access token exists but is expired with no refresh token
2. The access token is invalid and refresh token is expired but exists

OAuth will start automatically upon clicking of "connect" in both cases. It already starts automatically if it receives a 401 and no access token exists.

## How Has This Been Tested?
The changes have been tested with an SSE server with OAuth implemented via Descope, specifically testing:
- Token expiration scenarios
- Missing refresh token scenarios
- Expired refresh token scenarios
- Invalid access token handling
- Automatic OAuth flow initiation on connection attempts
- If MCP Server keeps returning 401 after access token refresh we max retries at 1 attempt

## Breaking Changes
No breaking changes. Just improves on the existing OAuth flow

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A