### PR TITLE
Add stdio error

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -32,12 +32,8 @@ interface UseConnectionOptions {
   requestTimeout?: number;
   onNotification?: (notification: Notification) => void;
   onStdErrNotification?: (notification: Notification) => void;
-  onPendingRequest?: (
-    request: z.infer<typeof CreateMessageRequestSchema>,
-    resolve: (value: z.infer<typeof CreateMessageRequestSchema>) => void,
-    reject: (reason?: Error) => void,
-  ) => void;
-  getRoots?: () => Array<{ id: string; name: string }>;
+  onPendingRequest?: (request: any, resolve: any, reject: any) => void;
+  getRoots?: () => any[];
 }
 
 export function useConnection({

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -229,8 +229,8 @@ export function useConnection({
       } catch (error) {
         console.error("Failed to connect to MCP server:", error);
 
-        // Extract detailed error message from SSE error response
-        if (error instanceof SseError) {
+        // Extract detailed error message from SSE error response when we use stdio transport
+        if (error instanceof SseError && transportType === "stdio") {
           try {
             const response = await fetch(backendUrl.toString(), { headers });
             const errorData = await response.text();


### PR DESCRIPTION


## Motivation and Context
Right now, when connecting to stdio server and something is not right, only generic sse error is shown
```
useConnection.ts:230 Failed to connect to MCP server: SseError: SSE error: Non-200 status code (500)
``` 

## How Has This Been Tested?
Connecting to a misconfigured mcp server - see the error
Connecting to SSE - no toast

## Breaking Changes
nope

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
<img width="1446" alt="image" src="https://github.com/user-attachments/assets/7bb8a877-d613-421e-81b7-120020c1375b" />