### PR TITLE
fix: move OAuth callback logic to outer AppWrapper component

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -49,7 +49,7 @@ const params = new URLSearchParams(window.location.search);
 const PROXY_PORT = params.get("proxyPort") ?? "3000";
 const PROXY_SERVER_URL = `http://localhost:${PROXY_PORT}`;
 
-const App = () => {
+const AppWrapper = () => {
   // Handle OAuth callback route
   if (window.location.pathname === "/oauth/callback") {
     const OAuthCallback = React.lazy(
@@ -61,6 +61,11 @@ const App = () => {
       </Suspense>
     );
   }
+
+  return <App />;
+};
+
+const App = () => {
   const [resources, setResources] = useState<Resource[]>([]);
   const [resourceTemplates, setResourceTemplates] = useState<
     ResourceTemplate[]
@@ -592,4 +597,4 @@ const App = () => {
   );
 };
 
-export default App;
+export default AppWrapper;


### PR DESCRIPTION
- Extract OAuth callback logic to improve code organization
- Fix ESLint error about conditional React Hook usage

## Motivation and Context
Fixed ESLint error: "React Hook 'useState' is called conditionally. React Hooks must be called in the exact same order in every component render". 

The original implementation had conditional hook calls within the App component due to the OAuth callback logic, which violates React Hooks rules. By extracting the OAuth callback handling to a higher-level AppWrapper component, we ensure hooks are called unconditionally.

## How Has This Been Tested?
- Verified that ESLint no longer reports hook-related errors
- Confirmed that the main application renders correctly

## Breaking Changes
No breaking changes. This is an internal refactoring that does not affect the external API or user experience.

## Types of changes
- [✓] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [✓] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [✓] My code follows the repository's style guidelines
- [✓] New and existing tests pass locally (no new lint errors introduced)
- [✓] I have added appropriate error handling
- [✓] I have added or updated documentation as needed

## Additional context
The refactoring ensures React Hooks are called unconditionally and in the same order by:
1. Moving route-specific logic to a wrapper component
2. Keeping the App component's hook calls consistent
