### PR TITLE
Fix ToolsTab Textarea value for clearing when switch tool

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -181,6 +181,7 @@ const ToolsTab = ({
                           id={key}
                           name={key}
                           placeholder={prop.description}
+                          value={(params[key] as string) ?? ""}
                           onChange={(e) =>
                             setParams({
                               ...params,


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Fix an issue where string-values in the textarea did not change when using the Tools tab of the MCP Inspector (usually http://localhost:5173/#tools) and changing the selected tool.

The original problem triggered a tool manipulation error.

https://github.com/user-attachments/assets/1479965b-d045-477e-b3fa-f6d1bc3c0cc9


## How Has This Been Tested?
Attached is a recording that was tested operating in a browser.

https://github.com/user-attachments/assets/8d501e6d-947f-4ca7-9ed7-bd6cc5caefc5



## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
