### PR TITLE
Fix OAuth callback route in production builds

### DIFF
--- a/client/bin/cli.js
+++ b/client/bin/cli.js
@@ -9,7 +9,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const distPath = join(__dirname, "../dist");
 
 const server = http.createServer((request, response) => {
-  return handler(request, response, { public: distPath });
+  return handler(request, response, {
+    public: distPath,
+    rewrites: [{ source: "/**", destination: "/index.html" }],
+  });
 });
 
 const port = process.env.PORT || 5173;

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -86,9 +86,9 @@ export async function handleOAuthCallback(
   const response = await fetch(metadata.token_endpoint, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
     },
-    body: JSON.stringify({
+    body: new URLSearchParams({
       grant_type: "authorization_code",
       code,
       code_verifier: codeVerifier,
@@ -117,9 +117,9 @@ export async function refreshAccessToken(
   const response = await fetch(metadata.token_endpoint, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
     },
-    body: JSON.stringify({
+    body: new URLSearchParams({
       grant_type: "refresh_token",
       refresh_token: refreshToken,
     }),


### PR DESCRIPTION
## Summary
- Fix OAuth callback routes in production builds by configuring serve-handler with proper SPA routing
- Adds a rewrite rule to serve index.html for all routes, allowing React Router to handle client-side routing

## Test plan
- Verify that OAuth callback works correctly in production builds
- Ensure that directly accessing /oauth/callback does not result in a 404 error