### PR TITLE
Support overriding proxy server url

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -47,7 +47,7 @@ import ToolsTab from "./components/ToolsTab";
 
 const params = new URLSearchParams(window.location.search);
 const PROXY_PORT = params.get("proxyPort") ?? "3000";
-const PROXY_SERVER_URL = `http://localhost:${PROXY_PORT}`;
+const PROXY_SERVER_URL = `${params.get("proxyServerUrl") ?? "http://localhost"}:${PROXY_PORT}`;
 
 const App = () => {
   // Handle OAuth callback route


### PR DESCRIPTION
This pull request includes a change to the `client/src/App.tsx` file to improve the flexibility of the proxy server URL configuration.

Configuration improvement:

* [`client/src/App.tsx`](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L50-R50): Modified the `PROXY_SERVER_URL` to allow the proxy server URL to be configurable via URL parameters, defaulting to `http://localhost` if not provided. 

## Motivation and Context
Developers that develop in a remote development machine may need to override the proxy server url for the inspector to call the correct url -- the remote development machine, and not localhost.

## How Has This Been Tested?
Tested locally by overriding the proxy server url

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed