### PR TITLE
Removing the all the hype from the ping button.

### DIFF
--- a/client/src/components/PingTab.tsx
+++ b/client/src/components/PingTab.tsx
@@ -7,11 +7,9 @@ const PingTab = ({ onPingClick }: { onPingClick: () => void }) => {
       <div className="col-span-2 flex justify-center items-center">
         <Button
           onClick={onPingClick}
-          className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-6 px-12 rounded-full shadow-lg transform transition duration-300 hover:scale-110 focus:outline-none focus:ring-4 focus:ring-purple-300 animate-pulse"
+          className="font-bold py-6 px-12 rounded-full"
         >
-          <span className="text-3xl mr-2">🚀</span>
-          MEGA PING
-          <span className="text-3xl ml-2">💥</span>
+          Ping Server
         </Button>
       </div>
     </TabsContent>


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Removed color gradient flashing and focus effects from ping button and retitled it "Ping Server"

## Motivation and Context
Not only was the the ping button style far out of step with the rest of the app's components, its bright color and rapid flashing draws the eye and can cause convulsions in individuals with photosensitive epilepsy.

Also the title "MEGA PING" with rockets and explosions seems incongruous with the actual function of the button, making me wonder the first time I used it if I was missing something, if it should be blasting pings at the server like a load test or something.  

## Previous Discussion
A gif of the existing implementation can be found here:
https://github.com/orgs/modelcontextprotocol/discussions/186

## How Has This Been Tested?
Yes.
![ping](https://github.com/user-attachments/assets/05954a66-c816-430d-8164-5f293c2bdf4d)

## Breaking Changes
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- ~~I have added appropriate error handling~~
- ~~I have added or updated documentation as needed~~

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
