### PR TITLE
Add subscribe to resource functionality

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -308,6 +308,31 @@ const App = () => {
     setResourceContent(JSON.stringify(response, null, 2));
   };
 
+  const subscribeToResource = async (uri: string) => {
+
+    await makeRequest(
+      {
+        method: "resources/subscribe" as const,
+        params: { uri },
+      },
+      z.object({}),
+      "resources",
+    );
+  };
+
+  const unsubscribeFromResource = async (uri: string) => {
+
+    await makeRequest(
+      {
+        method: "resources/unsubscribe" as const,
+        params: { uri },
+      },
+      z.object({}),
+      "resources",
+    );
+  };
+
+
   const listPrompts = async () => {
     const response = await makeRequest(
       {
@@ -484,6 +509,14 @@ const App = () => {
                       setSelectedResource={(resource) => {
                         clearError("resources");
                         setSelectedResource(resource);
+                      }}
+                      subscribeToResource={(uri) => {
+                        clearError("resources");
+                        subscribeToResource(uri);
+                      }}
+                      unsubscribeFromResource={(uri) => {
+                        clearError("resources");
+                        unsubscribeFromResource(uri);
                       }}
                       handleCompletion={handleCompletion}
                       completionsSupported={completionsSupported}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -128,7 +128,9 @@ const App = () => {
   const [selectedResource, setSelectedResource] = useState<Resource | null>(
     null,
   );
-  const [resourceSubscriptions, setResourceSubscriptions] = useState<Set<string>>(new Set<string>());
+  const [resourceSubscriptions, setResourceSubscriptions] = useState<
+    Set<string>
+  >(new Set<string>());
 
   const [selectedPrompt, setSelectedPrompt] = useState<Prompt | null>(null);
   const [selectedTool, setSelectedTool] = useState<Tool | null>(null);
@@ -311,7 +313,6 @@ const App = () => {
   };
 
   const subscribeToResource = async (uri: string) => {
-
     if (!resourceSubscriptions.has(uri)) {
       await makeRequest(
         {
@@ -325,11 +326,9 @@ const App = () => {
       clone.add(uri);
       setResourceSubscriptions(clone);
     }
-
   };
 
   const unsubscribeFromResource = async (uri: string) => {
-
     if (resourceSubscriptions.has(uri)) {
       await makeRequest(
         {
@@ -344,7 +343,6 @@ const App = () => {
       setResourceSubscriptions(clone);
     }
   };
-
 
   const listPrompts = async () => {
     const response = await makeRequest(
@@ -523,7 +521,9 @@ const App = () => {
                         clearError("resources");
                         setSelectedResource(resource);
                       }}
-                      resourceSubscriptionsSupported={serverCapabilities?.resources?.subscribe || false}
+                      resourceSubscriptionsSupported={
+                        serverCapabilities?.resources?.subscribe || false
+                      }
                       resourceSubscriptions={resourceSubscriptions}
                       subscribeToResource={(uri) => {
                         clearError("resources");

--- a/client/src/components/ResourcesTab.tsx
+++ b/client/src/components/ResourcesTab.tsx
@@ -26,6 +26,8 @@ const ResourcesTab = ({
   readResource,
   selectedResource,
   setSelectedResource,
+  resourceSubscriptionsSupported,
+  resourceSubscriptions,
   subscribeToResource,
   unsubscribeFromResource,
   handleCompletion,
@@ -54,6 +56,8 @@ const ResourcesTab = ({
   nextCursor: ListResourcesResult["nextCursor"];
   nextTemplateCursor: ListResourceTemplatesResult["nextCursor"];
   error: string | null;
+  resourceSubscriptionsSupported: boolean;
+  resourceSubscriptions: Set<string>;
   subscribeToResource: (uri: string) => void;
   unsubscribeFromResource: (uri: string) => void;
 }) => {
@@ -168,14 +172,16 @@ const ResourcesTab = ({
                 : "Select a resource or template"}
           </h3>
           {selectedResource && (
-            <>
-              <Button
+            <div className="flex row-auto gap-1 justify-end w-2/5">
+            { resourceSubscriptionsSupported && !resourceSubscriptions.has(selectedResource.uri) && <Button
                 variant="outline"
                 size="sm"
                 onClick={() => subscribeToResource(selectedResource.uri)}
               >
                 Subscribe
               </Button>
+            }
+            { resourceSubscriptionsSupported && resourceSubscriptions.has(selectedResource.uri) &&
               <Button
                 variant="outline"
                 size="sm"
@@ -183,6 +189,7 @@ const ResourcesTab = ({
               >
                 Unsubscribe
               </Button>
+            }
               <Button
                 variant="outline"
                 size="sm"
@@ -191,7 +198,7 @@ const ResourcesTab = ({
                 <RefreshCw className="w-4 h-4 mr-2" />
                 Refresh
               </Button>
-            </>
+            </div>
           )}
         </div>
         <div className="p-4">

--- a/client/src/components/ResourcesTab.tsx
+++ b/client/src/components/ResourcesTab.tsx
@@ -26,6 +26,8 @@ const ResourcesTab = ({
   readResource,
   selectedResource,
   setSelectedResource,
+  subscribeToResource,
+  unsubscribeFromResource,
   handleCompletion,
   completionsSupported,
   resourceContent,
@@ -52,6 +54,8 @@ const ResourcesTab = ({
   nextCursor: ListResourcesResult["nextCursor"];
   nextTemplateCursor: ListResourceTemplatesResult["nextCursor"];
   error: string | null;
+  subscribeToResource: (uri: string) => void;
+  unsubscribeFromResource: (uri: string) => void;
 }) => {
   const [selectedTemplate, setSelectedTemplate] =
     useState<ResourceTemplate | null>(null);
@@ -164,14 +168,30 @@ const ResourcesTab = ({
                 : "Select a resource or template"}
           </h3>
           {selectedResource && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => readResource(selectedResource.uri)}
-            >
-              <RefreshCw className="w-4 h-4 mr-2" />
-              Refresh
-            </Button>
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => subscribeToResource(selectedResource.uri)}
+              >
+                Subscribe
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => unsubscribeFromResource(selectedResource.uri)}
+              >
+                Unsubscribe
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => readResource(selectedResource.uri)}
+              >
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Refresh
+              </Button>
+            </>
           )}
         </div>
         <div className="p-4">

--- a/client/src/components/ResourcesTab.tsx
+++ b/client/src/components/ResourcesTab.tsx
@@ -173,23 +173,28 @@ const ResourcesTab = ({
           </h3>
           {selectedResource && (
             <div className="flex row-auto gap-1 justify-end w-2/5">
-            { resourceSubscriptionsSupported && !resourceSubscriptions.has(selectedResource.uri) && <Button
-                variant="outline"
-                size="sm"
-                onClick={() => subscribeToResource(selectedResource.uri)}
-              >
-                Subscribe
-              </Button>
-            }
-            { resourceSubscriptionsSupported && resourceSubscriptions.has(selectedResource.uri) &&
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => unsubscribeFromResource(selectedResource.uri)}
-              >
-                Unsubscribe
-              </Button>
-            }
+              {resourceSubscriptionsSupported &&
+                !resourceSubscriptions.has(selectedResource.uri) && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => subscribeToResource(selectedResource.uri)}
+                  >
+                    Subscribe
+                  </Button>
+                )}
+              {resourceSubscriptionsSupported &&
+                resourceSubscriptions.has(selectedResource.uri) && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      unsubscribeFromResource(selectedResource.uri)
+                    }
+                  >
+                    Unsubscribe
+                  </Button>
+                )}
               <Button
                 variant="outline"
                 size="sm"

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -9,6 +9,7 @@ import {
   CreateMessageRequestSchema,
   ListRootsRequestSchema,
   ProgressNotificationSchema,
+  ResourceUpdatedNotificationSchema,
   Request,
   Result,
   ServerCapabilities,
@@ -245,6 +246,11 @@ export function useConnection({
       if (onNotification) {
         client.setNotificationHandler(
           ProgressNotificationSchema,
+          onNotification,
+        );
+
+        client.setNotificationHandler(
+          ResourceUpdatedNotificationSchema,
           onNotification,
         );
       }

--- a/client/src/lib/notificationTypes.ts
+++ b/client/src/lib/notificationTypes.ts
@@ -12,9 +12,9 @@ export const StdErrNotificationSchema = BaseNotificationSchema.extend({
   }),
 });
 
-export const NotificationSchema = ClientNotificationSchema
-  .or(StdErrNotificationSchema)
-  .or(ServerNotificationSchema);
+export const NotificationSchema = ClientNotificationSchema.or(
+  StdErrNotificationSchema,
+).or(ServerNotificationSchema);
 
 export type StdErrNotification = z.infer<typeof StdErrNotificationSchema>;
 export type Notification = z.infer<typeof NotificationSchema>;

--- a/client/src/lib/notificationTypes.ts
+++ b/client/src/lib/notificationTypes.ts
@@ -1,6 +1,7 @@
 import {
   NotificationSchema as BaseNotificationSchema,
   ClientNotificationSchema,
+  ServerNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
@@ -11,9 +12,9 @@ export const StdErrNotificationSchema = BaseNotificationSchema.extend({
   }),
 });
 
-export const NotificationSchema = ClientNotificationSchema.or(
-  StdErrNotificationSchema,
-);
+export const NotificationSchema = ClientNotificationSchema
+  .or(StdErrNotificationSchema)
+  .or(ServerNotificationSchema);
 
 export type StdErrNotification = z.infer<typeof StdErrNotificationSchema>;
 export type Notification = z.infer<typeof NotificationSchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "server"
       ],
       "dependencies": {
-        "@modelcontextprotocol/inspector-client": "0.4.1",
-        "@modelcontextprotocol/inspector-server": "0.4.1",
+        "@modelcontextprotocol/inspector-client": "^0.5.1",
+        "@modelcontextprotocol/inspector-server": "^0.5.1",
         "concurrently": "^9.0.1",
         "shell-quote": "^1.8.2",
         "spawn-rx": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "publish-all": "npm publish --workspaces --access public && npm publish --access public"
   },
   "dependencies": {
-    "@modelcontextprotocol/inspector-client": "0.4.1",
-    "@modelcontextprotocol/inspector-server": "0.4.1",
+    "@modelcontextprotocol/inspector-client": "^0.5.1",
+    "@modelcontextprotocol/inspector-server": "^0.5.1",
     "concurrently": "^9.0.1",
     "shell-quote": "^1.8.2",
     "spawn-rx": "^5.1.2",


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
**When the connected MCP server's capabilities include resource subscriptions:**
  - Show a **Subscribe** or **Unsubscribe** button at the top of the selected resource panel of the Resources tab.
  - Send subscribe/unsubscribe requests to the server according to the protocol spec.
  - Track and manage subscribed resource URIs so that the UI knows which button to display for the selected resource.
  - Allow `ServerNotificationSchema` messages to be handled.

**Incidental out-of band update:** Jetbrains IDE falls into a loop prompting for `npm install` to be run because these versions were not up to date.
  - In package.json, package.lock.json, updated client and server versions to match inspector
    - `"@modelcontextprotocol/inspector-client": "^0.5.1"`
    - `"@modelcontextprotocol/inspector-server": "^0.5.1"`
  
This fixes https://github.com/modelcontextprotocol/inspector/issues/166
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Dynamic resources can change over time and the protocol specifies [a way for clients to subscribe to individual resources](https://modelcontextprotocol.io/docs/concepts/resources#content-changes) so they can be updated when those resources change. 

However the existing reference client - the MCP Inspector - does not provide any affordance for the user to subscribe to a resource. It provides a way to list resources and read resources. 

### Implementation
There is a panel for displaying the selected resource, and that panel's header already contained a **Refresh** button. This PR adds a **Subscribe** or **Unsubscribe** button there, _but only if the server supports resource subscriptions._

When clicked, it passes the selected resource's URI to the subscribe or unsubscribe handler, which in turn sends the appropriate message to the server.

A slight modification was made to `useConnection` and `notificationTypes` to support handling `ServerNotificationSchema` messages, a union of which `ResourceUpdatedNotificationSchema` is a member.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

### Button placement
The buttons are in a right justified div that is 2/5 wide in the panel header. Just large enough to contain the buttons, leaving 3/5 width to the heading without overlap.

<img width="541" alt="Button positioning" src="https://github.com/user-attachments/assets/713867dd-ce30-4a1e-8aa3-4633c3a6e2ed" />

### Server capabilities
I have an SSE-based MCP server called [puzzlebox](https://github.com/cliffhall/puzzlebox). It hosts finite state machines (called puzzles) and allows clients to perform actions on them to change their states. The puzzles are exposed as dynamic resources with a resource template. They could already be listed and read, but there was no way to test that clients could subscribe to individual puzzles for updates. Puzzlebox provided the perfect test server for this functionality, since I had handy local access to both projects for troubleshooting.

### Test 1 - Check for no subscription support on server
#### 1A) Turn OFF subscriptions on the server
<img width="345" alt="Screenshot 2025-03-08 at 12 38 46 PM" src="https://github.com/user-attachments/assets/e3da746c-1862-4700-b637-7885f1a700ef" />

#### 1B) Observe NO subscription button on selected resource
<img width="538" alt="Screenshot 2025-03-08 at 12 38 04 PM" src="https://github.com/user-attachments/assets/8843f3da-8027-40b6-b42c-03d9259e6cf4" />

___


### Test 2 - Check for subscription support on server
#### 2A) Turn ON subscriptions on the server
<img width="333" alt="Screenshot 2025-03-08 at 12 40 29 PM" src="https://github.com/user-attachments/assets/8df2225f-0b13-4b16-8dec-5f6df9bd40d8" />

#### 2B) Observe subscription button on selected resource
<img width="526" alt="Screenshot 2025-03-08 at 12 40 06 PM" src="https://github.com/user-attachments/assets/961dbe9d-df92-4edc-a82c-f8721ab4a7a3" />

___


### Test 3 - Test outgoing requests and appropriate button display
#### 3A) Click **Subscribe** button, observe **Unsubscribe** button 
<img width="529" alt="subscribe-clicked" src="https://github.com/user-attachments/assets/ecba4450-835c-4ec7-a1ea-dce1f258429d" />

#### 3B) Observe subscribe request
<img width="792" alt="resource-subscribed" src="https://github.com/user-attachments/assets/8cf5b6f7-cb58-4fcf-af17-e5116973e878" />

#### 3C) Click **Unsubscribe** button, observe **Subscribe** button again
<img width="537" alt="unsub-clicked" src="https://github.com/user-attachments/assets/1f76683b-a15e-4cd9-baf9-054f849ef2bb" />

#### 3D) Observe unsubscribe request
<img width="806" alt="resource-unsubbed" src="https://github.com/user-attachments/assets/e3b1459c-9b84-4d34-a67d-41e87ade6299" />

___


### Test 4 - Check notifications when subscribed resource changes
#### 4A) Use `perform_action_on_puzzle` tool to change subscribed puzzle's state
<img width="1592" alt="perform-action" src="https://github.com/user-attachments/assets/468df8ec-ceda-4040-8b4a-51cdae73b1e4" />

#### 4B) Observe resource updated notification from server
<img width="798" alt="resource-updated" src="https://github.com/user-attachments/assets/480de0c6-ce53-4929-8105-66a45fed64ad" />

### Test 5 - Check notifications no longer sent when unsubscribed resource changes
#### 5A) Click **Unsubscribe** button on same puzzle, 
<img width="535" alt="unsubscribed" src="https://github.com/user-attachments/assets/b9218178-84ab-42f6-8292-aba5920ca9c9" />

#### 5B) Use `perform_action_on_puzzle` tool to change unsubscribed puzzle's state, observe NO new server notification
<img width="1602" alt="not-notified" src="https://github.com/user-attachments/assets/d0e7ed40-3fa9-448c-844b-7a2508f33c8e" />

___

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
