### PR TITLE
feat: Fetch version from package.json in useConnection hook

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -26,6 +26,7 @@ import { SESSION_KEYS } from "../constants";
 import { Notification, StdErrNotificationSchema } from "../notificationTypes";
 import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
 import { authProvider } from "../auth";
+import packageJson from "../../../package.json";
 
 const params = new URLSearchParams(window.location.search);
 const DEFAULT_REQUEST_TIMEOUT_MSEC =
@@ -205,7 +206,7 @@ export function useConnection({
       const client = new Client<Request, Notification, Result>(
         {
           name: "mcp-inspector",
-          version: "0.0.1",
+          version: packageJson.version,
         },
         {
           capabilities: {


### PR DESCRIPTION
I noticed that the version of the client was hardcoded to 0.0.1 while developing a sdk solution for ruby on rails.

after this modification , the client send the correct version 
```
 "clientInfo" => {"name" => "mcp-inspector", "version" => "0.6.0"}
 ```