### PR TITLE
fix: add dark mode support to SamplingTab JSON display (#181)

### DIFF
--- a/client/src/components/SamplingTab.tsx
+++ b/client/src/components/SamplingTab.tsx
@@ -43,7 +43,7 @@ const SamplingTab = ({ pendingRequests, onApprove, onReject }: Props) => {
         <h3 className="text-lg font-semibold">Recent Requests</h3>
         {pendingRequests.map((request) => (
           <div key={request.id} className="p-4 border rounded-lg space-y-4">
-            <pre className="bg-gray-50 p-2 rounded">
+            <pre className="bg-gray-50 dark:bg-gray-800 dark:text-gray-100 p-2 rounded">
               {JSON.stringify(request.request, null, 2)}
             </pre>
             <div className="flex space-x-2">


### PR DESCRIPTION
Add `dark` variant styles to SamplingTab display. The added styles (`dark:bg-gray-800 dark:text-gray-100`) match other similar components.

## Motivation and Context
Fixes: https://github.com/modelcontextprotocol/inspector/issues/181

## How Has This Been Tested?
Tested locally using repro steps in https://github.com/modelcontextprotocol/inspector/issues/181

## Breaking Changes
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
