### PR TITLE
Refactor notification handling to include all notifications

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -8,9 +8,6 @@ import {
   ClientRequest,
   CreateMessageRequestSchema,
   ListRootsRequestSchema,
-  ProgressNotificationSchema,
-  ResourceUpdatedNotificationSchema,
-  LoggingMessageNotificationSchema,
   Request,
   Result,
   ServerCapabilities,
@@ -250,20 +247,12 @@ export function useConnection({
       });
 
       if (onNotification) {
-        client.setNotificationHandler(
-          ProgressNotificationSchema,
-          onNotification,
-        );
-
-        client.setNotificationHandler(
-          ResourceUpdatedNotificationSchema,
-          onNotification,
-        );
-
-        client.setNotificationHandler(
-          LoggingMessageNotificationSchema,
-          onNotification,
-        );
+        client.fallbackNotificationHandler = (
+          notification: Notification,
+        ): Promise<void> => {
+          onNotification(notification);
+          return Promise.resolve();
+        };
       }
 
       if (onStdErrNotification) {

--- a/client/src/lib/notificationTypes.ts
+++ b/client/src/lib/notificationTypes.ts
@@ -14,7 +14,9 @@ export const StdErrNotificationSchema = BaseNotificationSchema.extend({
 
 export const NotificationSchema = ClientNotificationSchema.or(
   StdErrNotificationSchema,
-).or(ServerNotificationSchema);
+)
+  .or(ServerNotificationSchema)
+  .or(BaseNotificationSchema);
 
 export type StdErrNotification = z.infer<typeof StdErrNotificationSchema>;
 export type Notification = z.infer<typeof NotificationSchema>;


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This fixes https://github.com/modelcontextprotocol/inspector/issues/190
## Motivation and Context
Previously, not all notifications were displayed, leading to potential missed updates and crucial information.

## How Has This Been Tested?
On any notification
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/ac03ab84-58d1-44b7-ae5b-2d9cc842edfe" />
Error warning no impact / change
![image](https://github.com/user-attachments/assets/527a20e9-fa91-45fc-8acf-1f196a3e9a9c)

## Breaking Changes
Nope

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
