### PR TITLE
Add enum support

### DIFF
--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -17,6 +17,7 @@ export type JsonSchemaType = {
   description?: string;
   properties?: Record<string, JsonSchemaType>;
   items?: JsonSchemaType;
+  enum?: string[];
 };
 
 type JsonObject = { [key: string]: JsonValue };

--- a/client/src/components/StringInput.tsx
+++ b/client/src/components/StringInput.tsx
@@ -1,0 +1,51 @@
+import { Textarea } from "@/components/ui/textarea";
+import { JsonSchemaType } from "./DynamicJsonForm";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+
+interface Props {
+  id: string;
+  name: string;
+  property: JsonSchemaType;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export const StringInput = ({ id, name, property, value, onChange }: Props) => {
+  if (property.enum?.length) {
+    return (
+      <Select
+        value={value}
+        onValueChange={(value) => {
+          onChange(value);
+        }}
+      >
+        <SelectTrigger id={id} name={name}>
+          <SelectValue placeholder={property.description} />
+        </SelectTrigger>
+        <SelectContent>
+          {property.enum.map((item) => (
+            <SelectItem key={item} value={item}>
+              {item}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  return (
+    <Textarea
+      id={id}
+      name={name}
+      placeholder={property.description}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+};

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -4,7 +4,6 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
-import { Textarea } from "@/components/ui/textarea";
 import DynamicJsonForm, { JsonSchemaType, JsonValue } from "./DynamicJsonForm";
 import {
   ListToolsResult,
@@ -16,6 +15,7 @@ import { useEffect, useState } from "react";
 import ListPane from "./ListPane";
 
 import { CompatibilityCallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { StringInput } from "./StringInput";
 
 const ToolsTab = ({
   tools,
@@ -192,19 +192,17 @@ const ToolsTab = ({
                           </label>
                         </div>
                       ) : prop.type === "string" ? (
-                        <Textarea
-                          id={key}
-                          name={key}
-                          placeholder={prop.description}
-                          value={(params[key] as string) ?? ""}
-                          onChange={(e) =>
-                            setParams({
-                              ...params,
-                              [key]: e.target.value,
-                            })
-                          }
-                          className="mt-1"
-                        />
+                        <div className="mt-1">
+                          <StringInput
+                            id={key}
+                            name={key}
+                            property={prop}
+                            value={(params[key] as string) ?? ""}
+                            onChange={(value) =>
+                              setParams({ ...params, [key]: value })
+                            }
+                          />
+                        </div>
                       ) : prop.type === "object" || prop.type === "array" ? (
                         <div className="mt-1">
                           <DynamicJsonForm


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

This adds support for [enum](https://json-schema.org/understanding-json-schema/reference/enum) on `string` property.

## How Has This Been Tested?

| Before    | After |
| -------- | ------- |
|  <img width="1591" alt="image" src="https://github.com/user-attachments/assets/87521ae2-df32-411b-b849-9372bc71b7fa" /> | <img width="1578" alt="image" src="https://github.com/user-attachments/assets/9e1560bd-2289-433c-a110-1dfc3ccb456e" />   |

## Breaking Changes

None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
