### PR TITLE
fix: set default value for input fields in ToolsTab component

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -229,6 +229,7 @@ const ToolsTab = ({
                           id={key}
                           name={key}
                           placeholder={prop.description}
+                          value={(params[key] as string) ?? ""}
                           onChange={(e) =>
                             setParams({
                               ...params,


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This fixes: https://github.com/modelcontextprotocol/inspector/issues/197

## Motivation and Context
The other data types were reset, but an input was missed during implementation.

## How Has This Been Tested?
Created 2 tool
```ts
server.tool('add', { a: z.number(), b: z.number() }, async ({ a, b }) => ({
    content: [{ type: 'text', text: String(a + b) }],
}))
server.tool('multiply', { a: z.number(), b: z.number() }, async ({ a, b }) => ({
    content: [{ type: 'text', text: String(a * b) }],
}))
```

- Open the MCP Inspector app (version 0.6.0).
- Connect to the server via SSE (e.g., Transport Type: SSE, URL: http://localhost:3333/sse).
- In the "Tools" section, select the "add" tool (designed to add two numbers).
- Enter values in the input fields (e.g., a = 10, b = 5).
- Click "Run Tool" multiple times to confirm the "add" tool works consistently.
- Switch to the "multiply" tool (designed to multiply two numbers), keeping the same input values (a = 10, b = 5) as they are retained by default.
- The input values are reset


## Breaking Changes
Nope

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
