### PR TITLE
Bump prismjs from 1.29.0 to 1.30.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,7 @@
     "cmdk": "^1.0.4",
     "lucide-react": "^0.447.0",
     "pkce-challenge": "^4.1.0",
-    "prismjs": "^1.29.0",
+    "prismjs": "^1.30.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-simple-code-editor": "^0.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "cmdk": "^1.0.4",
         "lucide-react": "^0.447.0",
         "pkce-challenge": "^4.1.0",
-        "prismjs": "^1.29.0",
+        "prismjs": "^1.30.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-simple-code-editor": "^0.14.1",
@@ -8841,9 +8841,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"


### PR DESCRIPTION
## Motivation and Context

See: 

Dependabot PR: https://github.com/modelcontextprotocol/inspector/pull/176

Original alert: https://github.com/modelcontextprotocol/inspector/security/dependabot/15

For some reason Dependabot only updated the package-lock.json and not package.json, so I'm creating this to address the original issue.

## How Has This Been Tested?
Ran inspector locally and JSON code is still being highlighted as expected with no errors.

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

