### PR TITLE
Add preliminary UI tests

### DIFF
--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -11,7 +11,6 @@ module.exports = {
     "^.+\\.tsx?$": [
       "ts-jest",
       {
-        useESM: true,
         jsx: "react-jsx",
         tsconfig: "tsconfig.jest.json"
       }

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,9 +1,6 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
-  setupFilesAfterEnv: [
-    '<rootDir>/src/setupTests.ts'
-  ],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1"
   },

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -3,16 +3,16 @@ module.exports = {
   testEnvironment: "jsdom",
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
-    "\\.css$": "<rootDir>/src/__mocks__/styleMock.js"
+    "\\.css$": "<rootDir>/src/__mocks__/styleMock.js",
   },
   transform: {
     "^.+\\.tsx?$": [
       "ts-jest",
       {
         jsx: "react-jsx",
-        tsconfig: "tsconfig.jest.json"
-      }
-    ]
+        tsconfig: "tsconfig.jest.json",
+      },
+    ],
   },
   extensionsToTreatAsEsm: [".ts", ".tsx"],
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
@@ -21,13 +21,13 @@ module.exports = {
     "/node_modules/",
     "/dist/",
     "/bin/",
-    "\\.config\\.(js|ts|cjs|mjs)$"
+    "\\.config\\.(js|ts|cjs|mjs)$",
   ],
   // Exclude the same patterns from coverage reports
   coveragePathIgnorePatterns: [
     "/node_modules/",
     "/dist/",
     "/bin/",
-    "\\.config\\.(js|ts|cjs|mjs)$"
-  ]
+    "\\.config\\.(js|ts|cjs|mjs)$",
+  ],
 };

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,12 +1,11 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
+  setupFilesAfterEnv: [
+    '<rootDir>/src/setupTests.ts'
+  ],
   moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/src/$1",
-    "^../components/DynamicJsonForm$":
-      "<rootDir>/src/utils/__mocks__/DynamicJsonForm.ts",
-    "^../../components/DynamicJsonForm$":
-      "<rootDir>/src/utils/__mocks__/DynamicJsonForm.ts",
+    "^@/(.*)$": "<rootDir>/src/$1"
   },
   transform: {
     "^.+\\.tsx?$": [
@@ -14,9 +13,9 @@ module.exports = {
       {
         useESM: true,
         jsx: "react-jsx",
-        tsconfig: "tsconfig.jest.json",
-      },
-    ],
+        tsconfig: "tsconfig.jest.json"
+      }
+    ]
   },
   extensionsToTreatAsEsm: [".ts", ".tsx"],
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
@@ -25,13 +24,13 @@ module.exports = {
     "/node_modules/",
     "/dist/",
     "/bin/",
-    "\\.config\\.(js|ts|cjs|mjs)$",
+    "\\.config\\.(js|ts|cjs|mjs)$"
   ],
   // Exclude the same patterns from coverage reports
   coveragePathIgnorePatterns: [
     "/node_modules/",
     "/dist/",
     "/bin/",
-    "\\.config\\.(js|ts|cjs|mjs)$",
-  ],
+    "\\.config\\.(js|ts|cjs|mjs)$"
+  ]
 };

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -2,7 +2,8 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
   moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/src/$1"
+    "^@/(.*)$": "<rootDir>/src/$1",
+    "\\.css$": "<rootDir>/src/__mocks__/styleMock.js"
   },
   transform: {
     "^.+\\.tsx?$": [

--- a/client/package.json
+++ b/client/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
-    "@radix-ui/react-dialog": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.4",
+    "@radix-ui/react-dialog": "^1.1.3",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.3",
@@ -50,6 +50,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.7.5",
     "@types/react": "^18.3.10",

--- a/client/src/__mocks__/styleMock.js
+++ b/client/src/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/client/src/components/__tests__/DynamicJsonForm.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.test.tsx
@@ -1,94 +1,94 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, jest } from '@jest/globals';
-import DynamicJsonForm from '../DynamicJsonForm';
-import type { JsonSchemaType } from '../DynamicJsonForm';
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, jest } from "@jest/globals";
+import DynamicJsonForm from "../DynamicJsonForm";
+import type { JsonSchemaType } from "../DynamicJsonForm";
 
-describe('DynamicJsonForm String Fields', () => {
+describe("DynamicJsonForm String Fields", () => {
   const renderForm = (props = {}) => {
     const defaultProps = {
       schema: {
         type: "string" as const,
-        description: "Test string field"
+        description: "Test string field",
       } satisfies JsonSchemaType,
       value: undefined,
-      onChange: jest.fn()
+      onChange: jest.fn(),
     };
     return render(<DynamicJsonForm {...defaultProps} {...props} />);
   };
 
-  describe('Type Validation', () => {
-    it('should handle numeric input as string type', () => {
+  describe("Type Validation", () => {
+    it("should handle numeric input as string type", () => {
       const onChange = jest.fn();
       renderForm({ onChange });
-      
-      const input = screen.getByRole('textbox');
-      fireEvent.change(input, { target: { value: '123321' } });
-      
-      expect(onChange).toHaveBeenCalledWith('123321');
+
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "123321" } });
+
+      expect(onChange).toHaveBeenCalledWith("123321");
       // Verify the value is a string, not a number
-      expect(typeof onChange.mock.calls[0][0]).toBe('string');
+      expect(typeof onChange.mock.calls[0][0]).toBe("string");
     });
 
-    it('should render as text input, not number input', () => {
+    it("should render as text input, not number input", () => {
       renderForm();
-      const input = screen.getByRole('textbox');
-      expect(input).toHaveProperty('type', 'text');
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveProperty("type", "text");
     });
   });
 });
 
-describe('DynamicJsonForm Integer Fields', () => {
+describe("DynamicJsonForm Integer Fields", () => {
   const renderForm = (props = {}) => {
     const defaultProps = {
       schema: {
         type: "integer" as const,
-        description: "Test integer field"
+        description: "Test integer field",
       } satisfies JsonSchemaType,
       value: undefined,
-      onChange: jest.fn()
+      onChange: jest.fn(),
     };
     return render(<DynamicJsonForm {...defaultProps} {...props} />);
   };
 
-  describe('Basic Operations', () => {
-    it('should render number input with step=1', () => {
+  describe("Basic Operations", () => {
+    it("should render number input with step=1", () => {
       renderForm();
-      const input = screen.getByRole('spinbutton');
-      expect(input).toHaveProperty('type', 'number');
-      expect(input).toHaveProperty('step', '1');
+      const input = screen.getByRole("spinbutton");
+      expect(input).toHaveProperty("type", "number");
+      expect(input).toHaveProperty("step", "1");
     });
 
-    it('should pass integer values to onChange', () => {
+    it("should pass integer values to onChange", () => {
       const onChange = jest.fn();
       renderForm({ onChange });
-      
-      const input = screen.getByRole('spinbutton');
-      fireEvent.change(input, { target: { value: '42' } });
-      
+
+      const input = screen.getByRole("spinbutton");
+      fireEvent.change(input, { target: { value: "42" } });
+
       expect(onChange).toHaveBeenCalledWith(42);
       // Verify the value is a number, not a string
-      expect(typeof onChange.mock.calls[0][0]).toBe('number');
+      expect(typeof onChange.mock.calls[0][0]).toBe("number");
     });
 
-    it('should not pass string values to onChange', () => {
+    it("should not pass string values to onChange", () => {
       const onChange = jest.fn();
       renderForm({ onChange });
-      
-      const input = screen.getByRole('spinbutton');
-      fireEvent.change(input, { target: { value: 'abc' } });
-      
+
+      const input = screen.getByRole("spinbutton");
+      fireEvent.change(input, { target: { value: "abc" } });
+
       expect(onChange).not.toHaveBeenCalled();
     });
   });
 
-  describe('Edge Cases', () => {
-    it('should handle non-numeric input by not calling onChange', () => {
+  describe("Edge Cases", () => {
+    it("should handle non-numeric input by not calling onChange", () => {
       const onChange = jest.fn();
       renderForm({ onChange });
-      
-      const input = screen.getByRole('spinbutton');
-      fireEvent.change(input, { target: { value: 'abc' } });
-      
+
+      const input = screen.getByRole("spinbutton");
+      fireEvent.change(input, { target: { value: "abc" } });
+
       expect(onChange).not.toHaveBeenCalled();
     });
   });

--- a/client/src/components/__tests__/DynamicJsonForm.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.test.tsx
@@ -3,6 +3,40 @@ import { describe, it, expect, jest } from '@jest/globals';
 import DynamicJsonForm from '../DynamicJsonForm';
 import type { JsonSchemaType } from '../DynamicJsonForm';
 
+describe('DynamicJsonForm String Fields', () => {
+  const renderForm = (props = {}) => {
+    const defaultProps = {
+      schema: {
+        type: "string" as const,
+        description: "Test string field"
+      } satisfies JsonSchemaType,
+      value: undefined,
+      onChange: jest.fn()
+    };
+    return render(<DynamicJsonForm {...defaultProps} {...props} />);
+  };
+
+  describe('Type Validation', () => {
+    it('should handle numeric input as string type', () => {
+      const onChange = jest.fn();
+      renderForm({ onChange });
+      
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: '123321' } });
+      
+      expect(onChange).toHaveBeenCalledWith('123321');
+      // Verify the value is a string, not a number
+      expect(typeof onChange.mock.calls[0][0]).toBe('string');
+    });
+
+    it('should render as text input, not number input', () => {
+      renderForm();
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveProperty('type', 'text');
+    });
+  });
+});
+
 describe('DynamicJsonForm Integer Fields', () => {
   const renderForm = (props = {}) => {
     const defaultProps = {

--- a/client/src/components/__tests__/DynamicJsonForm.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, jest } from '@jest/globals';
+import DynamicJsonForm from '../DynamicJsonForm';
+import type { JsonSchemaType } from '../DynamicJsonForm';
+
+describe('DynamicJsonForm Integer Fields', () => {
+  const renderForm = (props = {}) => {
+    const defaultProps = {
+      schema: {
+        type: "integer" as const,
+        description: "Test integer field"
+      } satisfies JsonSchemaType,
+      value: undefined,
+      onChange: jest.fn()
+    };
+    return render(<DynamicJsonForm {...defaultProps} {...props} />);
+  };
+
+  describe('Basic Operations', () => {
+    it('should render number input with step=1', () => {
+      renderForm();
+      const input = screen.getByRole('spinbutton');
+      expect(input).toHaveProperty('type', 'number');
+      expect(input).toHaveProperty('step', '1');
+    });
+
+    it('should pass integer values to onChange', () => {
+      const onChange = jest.fn();
+      renderForm({ onChange });
+      
+      const input = screen.getByRole('spinbutton');
+      fireEvent.change(input, { target: { value: '42' } });
+      
+      expect(onChange).toHaveBeenCalledWith(42);
+      // Verify the value is a number, not a string
+      expect(typeof onChange.mock.calls[0][0]).toBe('number');
+    });
+
+    it('should not pass string values to onChange', () => {
+      const onChange = jest.fn();
+      renderForm({ onChange });
+      
+      const input = screen.getByRole('spinbutton');
+      fireEvent.change(input, { target: { value: 'abc' } });
+      
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle non-numeric input by not calling onChange', () => {
+      const onChange = jest.fn();
+      renderForm({ onChange });
+      
+      const input = screen.getByRole('spinbutton');
+      fireEvent.change(input, { target: { value: 'abc' } });
+      
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -1,0 +1,278 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, beforeEach, jest } from '@jest/globals';
+import Sidebar from '../Sidebar';
+
+// Mock theme hook
+jest.mock('../../lib/useTheme', () => ({
+  __esModule: true,
+  default: () => ['light', jest.fn()],
+}));
+
+describe('Sidebar Environment Variables', () => {
+  const defaultProps = {
+    connectionStatus: 'disconnected' as const,
+    transportType: 'stdio' as const,
+    setTransportType: jest.fn(),
+    command: '',
+    setCommand: jest.fn(),
+    args: '',
+    setArgs: jest.fn(),
+    sseUrl: '',
+    setSseUrl: jest.fn(),
+    env: {},
+    setEnv: jest.fn(),
+    bearerToken: '',
+    setBearerToken: jest.fn(),
+    onConnect: jest.fn(),
+    stdErrNotifications: [],
+    logLevel: 'info' as const,
+    sendLogLevelRequest: jest.fn(),
+    loggingSupported: true,
+  };
+
+  const renderSidebar = (props = {}) => {
+    return render(<Sidebar {...defaultProps} {...props} />);
+  };
+
+  const openEnvVarsSection = () => {
+    const button = screen.getByText('Environment Variables');
+    fireEvent.click(button);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Basic Operations', () => {
+    it('should add a new environment variable', () => {
+      const setEnv = jest.fn();
+      renderSidebar({ env: {}, setEnv });
+      
+      openEnvVarsSection();
+      
+      const addButton = screen.getByText('Add Environment Variable');
+      fireEvent.click(addButton);
+      
+      expect(setEnv).toHaveBeenCalledWith({ '': '' });
+    });
+
+    it('should remove an environment variable', () => {
+      const setEnv = jest.fn();
+      const initialEnv = { TEST_KEY: 'test_value' };
+      renderSidebar({ env: initialEnv, setEnv });
+      
+      openEnvVarsSection();
+      
+      const removeButton = screen.getByRole('button', { name: '×' });
+      fireEvent.click(removeButton);
+      
+      expect(setEnv).toHaveBeenCalledWith({});
+    });
+
+    it('should update environment variable value', () => {
+      const setEnv = jest.fn();
+      const initialEnv = { TEST_KEY: 'test_value' };
+      renderSidebar({ env: initialEnv, setEnv });
+      
+      openEnvVarsSection();
+      
+      const valueInput = screen.getByDisplayValue('test_value');
+      fireEvent.change(valueInput, { target: { value: 'new_value' } });
+      
+      expect(setEnv).toHaveBeenCalledWith({ TEST_KEY: 'new_value' });
+    });
+
+    it('should toggle value visibility', () => {
+      const initialEnv = { TEST_KEY: 'test_value' };
+      renderSidebar({ env: initialEnv });
+      
+      openEnvVarsSection();
+      
+      const valueInput = screen.getByDisplayValue('test_value');
+      expect(valueInput).toHaveProperty('type', 'password');
+      
+      const toggleButton = screen.getByRole('button', { name: /show value/i });
+      fireEvent.click(toggleButton);
+      
+      expect(valueInput).toHaveProperty('type', 'text');
+    });
+  });
+
+  describe('Key Editing', () => {
+    it('should maintain order when editing first key', () => {
+      const setEnv = jest.fn();
+      const initialEnv = {
+        FIRST_KEY: 'first_value',
+        SECOND_KEY: 'second_value',
+        THIRD_KEY: 'third_value',
+      };
+      renderSidebar({ env: initialEnv, setEnv });
+      
+      openEnvVarsSection();
+      
+      const firstKeyInput = screen.getByDisplayValue('FIRST_KEY');
+      fireEvent.change(firstKeyInput, { target: { value: 'NEW_FIRST_KEY' } });
+      
+      expect(setEnv).toHaveBeenCalledWith({
+        NEW_FIRST_KEY: 'first_value',
+        SECOND_KEY: 'second_value',
+        THIRD_KEY: 'third_value',
+      });
+    });
+
+    it('should maintain order when editing middle key', () => {
+      const setEnv = jest.fn();
+      const initialEnv = {
+        FIRST_KEY: 'first_value',
+        SECOND_KEY: 'second_value',
+        THIRD_KEY: 'third_value',
+      };
+      renderSidebar({ env: initialEnv, setEnv });
+      
+      openEnvVarsSection();
+      
+      const middleKeyInput = screen.getByDisplayValue('SECOND_KEY');
+      fireEvent.change(middleKeyInput, { target: { value: 'NEW_SECOND_KEY' } });
+      
+      expect(setEnv).toHaveBeenCalledWith({
+        FIRST_KEY: 'first_value',
+        NEW_SECOND_KEY: 'second_value',
+        THIRD_KEY: 'third_value',
+      });
+    });
+
+    it('should maintain order when editing last key', () => {
+      const setEnv = jest.fn();
+      const initialEnv = {
+        FIRST_KEY: 'first_value',
+        SECOND_KEY: 'second_value',
+        THIRD_KEY: 'third_value',
+      };
+      renderSidebar({ env: initialEnv, setEnv });
+      
+      openEnvVarsSection();
+      
+      const lastKeyInput = screen.getByDisplayValue('THIRD_KEY');
+      fireEvent.change(lastKeyInput, { target: { value: 'NEW_THIRD_KEY' } });
+      
+      expect(setEnv).toHaveBeenCalledWith({
+        FIRST_KEY: 'first_value',
+        SECOND_KEY: 'second_value',
+        NEW_THIRD_KEY: 'third_value',
+      });
+    });
+  });
+
+  describe('Multiple Operations', () => {
+    it('should maintain state after multiple key edits', () => {
+      const setEnv = jest.fn();
+      const initialEnv = {
+        FIRST_KEY: 'first_value',
+        SECOND_KEY: 'second_value',
+      };
+      const { rerender } = renderSidebar({ env: initialEnv, setEnv });
+      
+      openEnvVarsSection();
+      
+      // First key edit
+      const firstKeyInput = screen.getByDisplayValue('FIRST_KEY');
+      fireEvent.change(firstKeyInput, { target: { value: 'NEW_FIRST_KEY' } });
+      
+      // Get the updated env from the first setEnv call
+      const updatedEnv = (setEnv.mock.calls[0][0] as Record<string, string>);
+      
+      // Rerender with the updated env
+      rerender(<Sidebar {...defaultProps} env={updatedEnv} setEnv={setEnv} />);
+      
+      // Second key edit
+      const secondKeyInput = screen.getByDisplayValue('SECOND_KEY');
+      fireEvent.change(secondKeyInput, { target: { value: 'NEW_SECOND_KEY' } });
+      
+      // Verify the final state matches what we expect
+      expect(setEnv).toHaveBeenLastCalledWith({
+        NEW_FIRST_KEY: 'first_value',
+        NEW_SECOND_KEY: 'second_value',
+      });
+    });
+
+    it('should maintain visibility state after key edit', () => {
+      const initialEnv = { TEST_KEY: 'test_value' };
+      const { rerender } = renderSidebar({ env: initialEnv });
+      
+      openEnvVarsSection();
+      
+      // Show the value
+      const toggleButton = screen.getByRole('button', { name: /show value/i });
+      fireEvent.click(toggleButton);
+      
+      const valueInput = screen.getByDisplayValue('test_value');
+      expect(valueInput).toHaveProperty('type', 'text');
+      
+      // Edit the key
+      const keyInput = screen.getByDisplayValue('TEST_KEY');
+      fireEvent.change(keyInput, { target: { value: 'NEW_KEY' } });
+      
+      // Rerender with updated env
+      rerender(<Sidebar {...defaultProps} env={{ NEW_KEY: 'test_value' }} />);
+      
+      // Value should still be visible
+      const updatedValueInput = screen.getByDisplayValue('test_value');
+      expect(updatedValueInput).toHaveProperty('type', 'text');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty key', () => {
+      const setEnv = jest.fn();
+      const initialEnv = { TEST_KEY: 'test_value' };
+      renderSidebar({ env: initialEnv, setEnv });
+      
+      openEnvVarsSection();
+      
+      const keyInput = screen.getByDisplayValue('TEST_KEY');
+      fireEvent.change(keyInput, { target: { value: '' } });
+      
+      expect(setEnv).toHaveBeenCalledWith({ '': 'test_value' });
+    });
+
+    it('should handle special characters in key', () => {
+      const setEnv = jest.fn();
+      const initialEnv = { TEST_KEY: 'test_value' };
+      renderSidebar({ env: initialEnv, setEnv });
+      
+      openEnvVarsSection();
+      
+      const keyInput = screen.getByDisplayValue('TEST_KEY');
+      fireEvent.change(keyInput, { target: { value: 'TEST-KEY@123' } });
+      
+      expect(setEnv).toHaveBeenCalledWith({ 'TEST-KEY@123': 'test_value' });
+    });
+
+    it('should handle unicode characters', () => {
+      const setEnv = jest.fn();
+      const initialEnv = { TEST_KEY: 'test_value' };
+      renderSidebar({ env: initialEnv, setEnv });
+      
+      openEnvVarsSection();
+      
+      const keyInput = screen.getByDisplayValue('TEST_KEY');
+      fireEvent.change(keyInput, { target: { value: 'TEST_🔑' } });
+      
+      expect(setEnv).toHaveBeenCalledWith({ 'TEST_🔑': 'test_value' });
+    });
+
+    it('should handle very long key names', () => {
+      const setEnv = jest.fn();
+      const initialEnv = { TEST_KEY: 'test_value' };
+      renderSidebar({ env: initialEnv, setEnv });
+      
+      openEnvVarsSection();
+      
+      const keyInput = screen.getByDisplayValue('TEST_KEY');
+      const longKey = 'A'.repeat(100);
+      fireEvent.change(keyInput, { target: { value: longKey } });
+      
+      expect(setEnv).toHaveBeenCalledWith({ [longKey]: 'test_value' });
+    });
+  });
+});

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -166,7 +166,7 @@ describe("Sidebar Environment Variables", () => {
       const setEnv = jest.fn();
       const initialEnv = {
         KEY1: "value1",
-        KEY2: "value2"
+        KEY2: "value2",
       };
       renderSidebar({ env: initialEnv, setEnv });
 
@@ -175,13 +175,17 @@ describe("Sidebar Environment Variables", () => {
       // Type "NEW_" one character at a time
       const key1Input = screen.getByDisplayValue("KEY1");
       "NEW_".split("").forEach((char) => {
-        fireEvent.change(key1Input, { target: { value: char + "KEY1".slice(1) } });
+        fireEvent.change(key1Input, {
+          target: { value: char + "KEY1".slice(1) },
+        });
       });
 
       // Verify the last setEnv call maintains the order
-      const lastCall = setEnv.mock.calls[setEnv.mock.calls.length - 1][0] as Record<string, string>;
+      const lastCall = setEnv.mock.calls[
+        setEnv.mock.calls.length - 1
+      ][0] as Record<string, string>;
       const entries = Object.entries(lastCall);
-      
+
       // The values should stay with their original keys
       expect(entries[0][1]).toBe("value1"); // First entry should still have value1
       expect(entries[1][1]).toBe("value2"); // Second entry should still have value2

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -161,6 +161,31 @@ describe("Sidebar Environment Variables", () => {
         NEW_THIRD_KEY: "third_value",
       });
     });
+
+    it("should maintain order during key editing", () => {
+      const setEnv = jest.fn();
+      const initialEnv = {
+        KEY1: "value1",
+        KEY2: "value2"
+      };
+      renderSidebar({ env: initialEnv, setEnv });
+
+      openEnvVarsSection();
+
+      // Type "NEW_" one character at a time
+      const key1Input = screen.getByDisplayValue("KEY1");
+      "NEW_".split("").forEach((char) => {
+        fireEvent.change(key1Input, { target: { value: char + "KEY1".slice(1) } });
+      });
+
+      // Verify the last setEnv call maintains the order
+      const lastCall = setEnv.mock.calls[setEnv.mock.calls.length - 1][0] as Record<string, string>;
+      const entries = Object.entries(lastCall);
+      
+      // The values should stay with their original keys
+      expect(entries[0][1]).toBe("value1"); // First entry should still have value1
+      expect(entries[1][1]).toBe("value2"); // Second entry should still have value2
+    });
   });
 
   describe("Multiple Operations", () => {

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -1,31 +1,31 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, beforeEach, jest } from '@jest/globals';
-import Sidebar from '../Sidebar';
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, beforeEach, jest } from "@jest/globals";
+import Sidebar from "../Sidebar";
 
 // Mock theme hook
-jest.mock('../../lib/useTheme', () => ({
+jest.mock("../../lib/useTheme", () => ({
   __esModule: true,
-  default: () => ['light', jest.fn()],
+  default: () => ["light", jest.fn()],
 }));
 
-describe('Sidebar Environment Variables', () => {
+describe("Sidebar Environment Variables", () => {
   const defaultProps = {
-    connectionStatus: 'disconnected' as const,
-    transportType: 'stdio' as const,
+    connectionStatus: "disconnected" as const,
+    transportType: "stdio" as const,
     setTransportType: jest.fn(),
-    command: '',
+    command: "",
     setCommand: jest.fn(),
-    args: '',
+    args: "",
     setArgs: jest.fn(),
-    sseUrl: '',
+    sseUrl: "",
     setSseUrl: jest.fn(),
     env: {},
     setEnv: jest.fn(),
-    bearerToken: '',
+    bearerToken: "",
     setBearerToken: jest.fn(),
     onConnect: jest.fn(),
     stdErrNotifications: [],
-    logLevel: 'info' as const,
+    logLevel: "info" as const,
     sendLogLevelRequest: jest.fn(),
     loggingSupported: true,
   };
@@ -35,7 +35,7 @@ describe('Sidebar Environment Variables', () => {
   };
 
   const openEnvVarsSection = () => {
-    const button = screen.getByText('Environment Variables');
+    const button = screen.getByText("Environment Variables");
     fireEvent.click(button);
   };
 
@@ -43,236 +43,236 @@ describe('Sidebar Environment Variables', () => {
     jest.clearAllMocks();
   });
 
-  describe('Basic Operations', () => {
-    it('should add a new environment variable', () => {
+  describe("Basic Operations", () => {
+    it("should add a new environment variable", () => {
       const setEnv = jest.fn();
       renderSidebar({ env: {}, setEnv });
-      
+
       openEnvVarsSection();
-      
-      const addButton = screen.getByText('Add Environment Variable');
+
+      const addButton = screen.getByText("Add Environment Variable");
       fireEvent.click(addButton);
-      
-      expect(setEnv).toHaveBeenCalledWith({ '': '' });
+
+      expect(setEnv).toHaveBeenCalledWith({ "": "" });
     });
 
-    it('should remove an environment variable', () => {
+    it("should remove an environment variable", () => {
       const setEnv = jest.fn();
-      const initialEnv = { TEST_KEY: 'test_value' };
+      const initialEnv = { TEST_KEY: "test_value" };
       renderSidebar({ env: initialEnv, setEnv });
-      
+
       openEnvVarsSection();
-      
-      const removeButton = screen.getByRole('button', { name: '×' });
+
+      const removeButton = screen.getByRole("button", { name: "×" });
       fireEvent.click(removeButton);
-      
+
       expect(setEnv).toHaveBeenCalledWith({});
     });
 
-    it('should update environment variable value', () => {
+    it("should update environment variable value", () => {
       const setEnv = jest.fn();
-      const initialEnv = { TEST_KEY: 'test_value' };
+      const initialEnv = { TEST_KEY: "test_value" };
       renderSidebar({ env: initialEnv, setEnv });
-      
+
       openEnvVarsSection();
-      
-      const valueInput = screen.getByDisplayValue('test_value');
-      fireEvent.change(valueInput, { target: { value: 'new_value' } });
-      
-      expect(setEnv).toHaveBeenCalledWith({ TEST_KEY: 'new_value' });
+
+      const valueInput = screen.getByDisplayValue("test_value");
+      fireEvent.change(valueInput, { target: { value: "new_value" } });
+
+      expect(setEnv).toHaveBeenCalledWith({ TEST_KEY: "new_value" });
     });
 
-    it('should toggle value visibility', () => {
-      const initialEnv = { TEST_KEY: 'test_value' };
+    it("should toggle value visibility", () => {
+      const initialEnv = { TEST_KEY: "test_value" };
       renderSidebar({ env: initialEnv });
-      
+
       openEnvVarsSection();
-      
-      const valueInput = screen.getByDisplayValue('test_value');
-      expect(valueInput).toHaveProperty('type', 'password');
-      
-      const toggleButton = screen.getByRole('button', { name: /show value/i });
+
+      const valueInput = screen.getByDisplayValue("test_value");
+      expect(valueInput).toHaveProperty("type", "password");
+
+      const toggleButton = screen.getByRole("button", { name: /show value/i });
       fireEvent.click(toggleButton);
-      
-      expect(valueInput).toHaveProperty('type', 'text');
+
+      expect(valueInput).toHaveProperty("type", "text");
     });
   });
 
-  describe('Key Editing', () => {
-    it('should maintain order when editing first key', () => {
+  describe("Key Editing", () => {
+    it("should maintain order when editing first key", () => {
       const setEnv = jest.fn();
       const initialEnv = {
-        FIRST_KEY: 'first_value',
-        SECOND_KEY: 'second_value',
-        THIRD_KEY: 'third_value',
+        FIRST_KEY: "first_value",
+        SECOND_KEY: "second_value",
+        THIRD_KEY: "third_value",
       };
       renderSidebar({ env: initialEnv, setEnv });
-      
+
       openEnvVarsSection();
-      
-      const firstKeyInput = screen.getByDisplayValue('FIRST_KEY');
-      fireEvent.change(firstKeyInput, { target: { value: 'NEW_FIRST_KEY' } });
-      
+
+      const firstKeyInput = screen.getByDisplayValue("FIRST_KEY");
+      fireEvent.change(firstKeyInput, { target: { value: "NEW_FIRST_KEY" } });
+
       expect(setEnv).toHaveBeenCalledWith({
-        NEW_FIRST_KEY: 'first_value',
-        SECOND_KEY: 'second_value',
-        THIRD_KEY: 'third_value',
+        NEW_FIRST_KEY: "first_value",
+        SECOND_KEY: "second_value",
+        THIRD_KEY: "third_value",
       });
     });
 
-    it('should maintain order when editing middle key', () => {
+    it("should maintain order when editing middle key", () => {
       const setEnv = jest.fn();
       const initialEnv = {
-        FIRST_KEY: 'first_value',
-        SECOND_KEY: 'second_value',
-        THIRD_KEY: 'third_value',
+        FIRST_KEY: "first_value",
+        SECOND_KEY: "second_value",
+        THIRD_KEY: "third_value",
       };
       renderSidebar({ env: initialEnv, setEnv });
-      
+
       openEnvVarsSection();
-      
-      const middleKeyInput = screen.getByDisplayValue('SECOND_KEY');
-      fireEvent.change(middleKeyInput, { target: { value: 'NEW_SECOND_KEY' } });
-      
+
+      const middleKeyInput = screen.getByDisplayValue("SECOND_KEY");
+      fireEvent.change(middleKeyInput, { target: { value: "NEW_SECOND_KEY" } });
+
       expect(setEnv).toHaveBeenCalledWith({
-        FIRST_KEY: 'first_value',
-        NEW_SECOND_KEY: 'second_value',
-        THIRD_KEY: 'third_value',
+        FIRST_KEY: "first_value",
+        NEW_SECOND_KEY: "second_value",
+        THIRD_KEY: "third_value",
       });
     });
 
-    it('should maintain order when editing last key', () => {
+    it("should maintain order when editing last key", () => {
       const setEnv = jest.fn();
       const initialEnv = {
-        FIRST_KEY: 'first_value',
-        SECOND_KEY: 'second_value',
-        THIRD_KEY: 'third_value',
+        FIRST_KEY: "first_value",
+        SECOND_KEY: "second_value",
+        THIRD_KEY: "third_value",
       };
       renderSidebar({ env: initialEnv, setEnv });
-      
+
       openEnvVarsSection();
-      
-      const lastKeyInput = screen.getByDisplayValue('THIRD_KEY');
-      fireEvent.change(lastKeyInput, { target: { value: 'NEW_THIRD_KEY' } });
-      
+
+      const lastKeyInput = screen.getByDisplayValue("THIRD_KEY");
+      fireEvent.change(lastKeyInput, { target: { value: "NEW_THIRD_KEY" } });
+
       expect(setEnv).toHaveBeenCalledWith({
-        FIRST_KEY: 'first_value',
-        SECOND_KEY: 'second_value',
-        NEW_THIRD_KEY: 'third_value',
+        FIRST_KEY: "first_value",
+        SECOND_KEY: "second_value",
+        NEW_THIRD_KEY: "third_value",
       });
     });
   });
 
-  describe('Multiple Operations', () => {
-    it('should maintain state after multiple key edits', () => {
+  describe("Multiple Operations", () => {
+    it("should maintain state after multiple key edits", () => {
       const setEnv = jest.fn();
       const initialEnv = {
-        FIRST_KEY: 'first_value',
-        SECOND_KEY: 'second_value',
+        FIRST_KEY: "first_value",
+        SECOND_KEY: "second_value",
       };
       const { rerender } = renderSidebar({ env: initialEnv, setEnv });
-      
+
       openEnvVarsSection();
-      
+
       // First key edit
-      const firstKeyInput = screen.getByDisplayValue('FIRST_KEY');
-      fireEvent.change(firstKeyInput, { target: { value: 'NEW_FIRST_KEY' } });
-      
+      const firstKeyInput = screen.getByDisplayValue("FIRST_KEY");
+      fireEvent.change(firstKeyInput, { target: { value: "NEW_FIRST_KEY" } });
+
       // Get the updated env from the first setEnv call
-      const updatedEnv = (setEnv.mock.calls[0][0] as Record<string, string>);
-      
+      const updatedEnv = setEnv.mock.calls[0][0] as Record<string, string>;
+
       // Rerender with the updated env
       rerender(<Sidebar {...defaultProps} env={updatedEnv} setEnv={setEnv} />);
-      
+
       // Second key edit
-      const secondKeyInput = screen.getByDisplayValue('SECOND_KEY');
-      fireEvent.change(secondKeyInput, { target: { value: 'NEW_SECOND_KEY' } });
-      
+      const secondKeyInput = screen.getByDisplayValue("SECOND_KEY");
+      fireEvent.change(secondKeyInput, { target: { value: "NEW_SECOND_KEY" } });
+
       // Verify the final state matches what we expect
       expect(setEnv).toHaveBeenLastCalledWith({
-        NEW_FIRST_KEY: 'first_value',
-        NEW_SECOND_KEY: 'second_value',
+        NEW_FIRST_KEY: "first_value",
+        NEW_SECOND_KEY: "second_value",
       });
     });
 
-    it('should maintain visibility state after key edit', () => {
-      const initialEnv = { TEST_KEY: 'test_value' };
+    it("should maintain visibility state after key edit", () => {
+      const initialEnv = { TEST_KEY: "test_value" };
       const { rerender } = renderSidebar({ env: initialEnv });
-      
+
       openEnvVarsSection();
-      
+
       // Show the value
-      const toggleButton = screen.getByRole('button', { name: /show value/i });
+      const toggleButton = screen.getByRole("button", { name: /show value/i });
       fireEvent.click(toggleButton);
-      
-      const valueInput = screen.getByDisplayValue('test_value');
-      expect(valueInput).toHaveProperty('type', 'text');
-      
+
+      const valueInput = screen.getByDisplayValue("test_value");
+      expect(valueInput).toHaveProperty("type", "text");
+
       // Edit the key
-      const keyInput = screen.getByDisplayValue('TEST_KEY');
-      fireEvent.change(keyInput, { target: { value: 'NEW_KEY' } });
-      
+      const keyInput = screen.getByDisplayValue("TEST_KEY");
+      fireEvent.change(keyInput, { target: { value: "NEW_KEY" } });
+
       // Rerender with updated env
-      rerender(<Sidebar {...defaultProps} env={{ NEW_KEY: 'test_value' }} />);
-      
+      rerender(<Sidebar {...defaultProps} env={{ NEW_KEY: "test_value" }} />);
+
       // Value should still be visible
-      const updatedValueInput = screen.getByDisplayValue('test_value');
-      expect(updatedValueInput).toHaveProperty('type', 'text');
+      const updatedValueInput = screen.getByDisplayValue("test_value");
+      expect(updatedValueInput).toHaveProperty("type", "text");
     });
   });
 
-  describe('Edge Cases', () => {
-    it('should handle empty key', () => {
+  describe("Edge Cases", () => {
+    it("should handle empty key", () => {
       const setEnv = jest.fn();
-      const initialEnv = { TEST_KEY: 'test_value' };
+      const initialEnv = { TEST_KEY: "test_value" };
       renderSidebar({ env: initialEnv, setEnv });
-      
+
       openEnvVarsSection();
-      
-      const keyInput = screen.getByDisplayValue('TEST_KEY');
-      fireEvent.change(keyInput, { target: { value: '' } });
-      
-      expect(setEnv).toHaveBeenCalledWith({ '': 'test_value' });
+
+      const keyInput = screen.getByDisplayValue("TEST_KEY");
+      fireEvent.change(keyInput, { target: { value: "" } });
+
+      expect(setEnv).toHaveBeenCalledWith({ "": "test_value" });
     });
 
-    it('should handle special characters in key', () => {
+    it("should handle special characters in key", () => {
       const setEnv = jest.fn();
-      const initialEnv = { TEST_KEY: 'test_value' };
+      const initialEnv = { TEST_KEY: "test_value" };
       renderSidebar({ env: initialEnv, setEnv });
-      
+
       openEnvVarsSection();
-      
-      const keyInput = screen.getByDisplayValue('TEST_KEY');
-      fireEvent.change(keyInput, { target: { value: 'TEST-KEY@123' } });
-      
-      expect(setEnv).toHaveBeenCalledWith({ 'TEST-KEY@123': 'test_value' });
+
+      const keyInput = screen.getByDisplayValue("TEST_KEY");
+      fireEvent.change(keyInput, { target: { value: "TEST-KEY@123" } });
+
+      expect(setEnv).toHaveBeenCalledWith({ "TEST-KEY@123": "test_value" });
     });
 
-    it('should handle unicode characters', () => {
+    it("should handle unicode characters", () => {
       const setEnv = jest.fn();
-      const initialEnv = { TEST_KEY: 'test_value' };
+      const initialEnv = { TEST_KEY: "test_value" };
       renderSidebar({ env: initialEnv, setEnv });
-      
+
       openEnvVarsSection();
-      
-      const keyInput = screen.getByDisplayValue('TEST_KEY');
-      fireEvent.change(keyInput, { target: { value: 'TEST_🔑' } });
-      
-      expect(setEnv).toHaveBeenCalledWith({ 'TEST_🔑': 'test_value' });
+
+      const keyInput = screen.getByDisplayValue("TEST_KEY");
+      fireEvent.change(keyInput, { target: { value: "TEST_🔑" } });
+
+      expect(setEnv).toHaveBeenCalledWith({ "TEST_🔑": "test_value" });
     });
 
-    it('should handle very long key names', () => {
+    it("should handle very long key names", () => {
       const setEnv = jest.fn();
-      const initialEnv = { TEST_KEY: 'test_value' };
+      const initialEnv = { TEST_KEY: "test_value" };
       renderSidebar({ env: initialEnv, setEnv });
-      
+
       openEnvVarsSection();
-      
-      const keyInput = screen.getByDisplayValue('TEST_KEY');
-      const longKey = 'A'.repeat(100);
+
+      const keyInput = screen.getByDisplayValue("TEST_KEY");
+      const longKey = "A".repeat(100);
       fireEvent.change(keyInput, { target: { value: longKey } });
-      
-      expect(setEnv).toHaveBeenCalledWith({ [longKey]: 'test_value' });
+
+      expect(setEnv).toHaveBeenCalledWith({ [longKey]: "test_value" });
     });
   });
 });

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, jest } from "@jest/globals";
+import ToolsTab from "../ToolsTab";
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { Tabs } from "@/components/ui/tabs";
+
+describe("ToolsTab", () => {
+  const mockTools: Tool[] = [
+    {
+      name: "tool1",
+      description: "First tool",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          num: { type: "number" as const }
+        }
+      }
+    },
+    {
+      name: "tool2",
+      description: "Second tool",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          num: { type: "number" as const }
+        }
+      }
+    }
+  ];
+
+  const defaultProps = {
+    tools: mockTools,
+    listTools: jest.fn(),
+    clearTools: jest.fn(),
+    callTool: jest.fn(),
+    selectedTool: null,
+    setSelectedTool: jest.fn(),
+    toolResult: null,
+    nextCursor: "",
+    error: null
+  };
+
+  const renderToolsTab = (props = {}) => {
+    return render(
+      <Tabs defaultValue="tools">
+        <ToolsTab {...defaultProps} {...props} />
+      </Tabs>
+    );
+  };
+
+  it("should reset input values when switching tools", () => {
+    const { rerender } = renderToolsTab({
+      selectedTool: mockTools[0]
+    });
+
+    // Enter a value in the first tool's input
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "42" } });
+    expect(input.value).toBe("42");
+
+    // Switch to second tool
+    rerender(
+      <Tabs defaultValue="tools">
+        <ToolsTab {...defaultProps} selectedTool={mockTools[1]} />
+      </Tabs>
+    );
+
+    // Verify input is reset
+    const newInput = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(newInput.value).toBe("");
+  });
+});

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -12,9 +12,9 @@ describe("ToolsTab", () => {
       inputSchema: {
         type: "object" as const,
         properties: {
-          num: { type: "number" as const }
-        }
-      }
+          num: { type: "number" as const },
+        },
+      },
     },
     {
       name: "tool2",
@@ -22,10 +22,10 @@ describe("ToolsTab", () => {
       inputSchema: {
         type: "object" as const,
         properties: {
-          num: { type: "number" as const }
-        }
-      }
-    }
+          num: { type: "number" as const },
+        },
+      },
+    },
   ];
 
   const defaultProps = {
@@ -37,20 +37,20 @@ describe("ToolsTab", () => {
     setSelectedTool: jest.fn(),
     toolResult: null,
     nextCursor: "",
-    error: null
+    error: null,
   };
 
   const renderToolsTab = (props = {}) => {
     return render(
       <Tabs defaultValue="tools">
         <ToolsTab {...defaultProps} {...props} />
-      </Tabs>
+      </Tabs>,
     );
   };
 
   it("should reset input values when switching tools", () => {
     const { rerender } = renderToolsTab({
-      selectedTool: mockTools[0]
+      selectedTool: mockTools[0],
     });
 
     // Enter a value in the first tool's input
@@ -62,7 +62,7 @@ describe("ToolsTab", () => {
     rerender(
       <Tabs defaultValue="tools">
         <ToolsTab {...defaultProps} selectedTool={mockTools[1]} />
-      </Tabs>
+      </Tabs>,
     );
 
     // Verify input is reset

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -24,7 +24,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["jest", "@testing-library/jest-dom", "node"]
   },
   "include": ["src"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.2.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.7.5",
         "@types/react": "^18.3.10",
@@ -86,6 +88,13 @@
         "typescript-eslint": "^8.7.0",
         "vite": "^5.4.8"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.2.tgz",
+      "integrity": "sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -574,6 +583,19 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3786,6 +3808,148 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-2cSskAvA1QNtKc8Y9VJQRv0tm3hLVgxRGDB+KYhIaPQJ1I+RHbhIXcM+zClKXzMes/wshsMVzf4B9vS4IZpqDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -3819,6 +3983,14 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4585,6 +4757,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -5331,6 +5513,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5467,6 +5656,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -5523,6 +5722,14 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -6796,6 +7003,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7984,6 +8201,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -8135,6 +8363,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -9151,6 +9389,27 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9835,6 +10094,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {


### PR DESCRIPTION
This PR adds configuration for adding UI tests as well as a few preliminary tests related to recent issues in this repo.

## Motivation and Context
Manually testing UI inputs isn't really feasible for reproducing issues and avoiding new bugs, especially related to UI components that have many dynamic input fields.

## How Has This Been Tested?
Tests are run automatically in the GitHub actions.

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
