### PR TITLE
fix: prop.type not accept integer

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -226,7 +226,11 @@ const ToolsTab = ({
                         </div>
                       ) : (
                         <Input
-                          type={prop.type === "number" || prop.type === "integer" ? "number" : "text"}
+                          type={
+                            prop.type === "number" || prop.type === "integer"
+                              ? "number"
+                              : "text"
+                          }
                           id={key}
                           name={key}
                           placeholder={prop.description}
@@ -235,7 +239,8 @@ const ToolsTab = ({
                             setParams({
                               ...params,
                               [key]:
-                                prop.type === "number" || prop.type === "integer"
+                                prop.type === "number" ||
+                                prop.type === "integer"
                                   ? Number(e.target.value)
                                   : e.target.value,
                             })

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -226,7 +226,7 @@ const ToolsTab = ({
                         </div>
                       ) : (
                         <Input
-                          type={prop.type === "number" ? "number" : "text"}
+                          type={prop.type === "number" || prop.type === "integer" ? "number" : "text"}
                           id={key}
                           name={key}
                           placeholder={prop.description}
@@ -235,7 +235,7 @@ const ToolsTab = ({
                             setParams({
                               ...params,
                               [key]:
-                                prop.type === "number"
+                                prop.type === "number" || prop.type === "integer"
                                   ? Number(e.target.value)
                                   : e.target.value,
                             })


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Refer to: https://github.com/modelcontextprotocol/rust-sdk/issues/73
JsonSchema has a integer type which not handle by inspector

## How Has This Been Tested?
via: https://github.com/modelcontextprotocol/rust-sdk/issues/73

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

