### PR TITLE
Do not remove form on error in tool call tab.

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -147,17 +147,11 @@ const ToolsTab = ({
           </h3>
         </div>
         <div className="p-4">
-          {error ? (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>Error</AlertTitle>
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          ) : selectedTool ? (
+          {selectedTool ? (
             <div className="space-y-4">
-              <p className="text-sm text-gray-600">
-                {selectedTool.description}
-              </p>
+            <p className="text-sm text-gray-600">
+              {selectedTool.description}
+            </p>
               {Object.entries(selectedTool.inputSchema.properties ?? []).map(
                 ([key, value]) => {
                   const prop = value as JsonSchemaType;
@@ -252,6 +246,13 @@ const ToolsTab = ({
                 Run Tool
               </Button>
               {toolResult && renderToolResult()}
+              {error && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertTitle>Error</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
             </div>
           ) : (
             <Alert>

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -149,9 +149,9 @@ const ToolsTab = ({
         <div className="p-4">
           {selectedTool ? (
             <div className="space-y-4">
-            <p className="text-sm text-gray-600">
-              {selectedTool.description}
-            </p>
+              <p className="text-sm text-gray-600">
+                {selectedTool.description}
+              </p>
               {Object.entries(selectedTool.inputSchema.properties ?? []).map(
                 ([key, value]) => {
                   const prop = value as JsonSchemaType;

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, jest } from "@jest/globals";
+import "@testing-library/jest-dom";
 import ToolsTab from "../ToolsTab";
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { Tabs } from "@/components/ui/tabs";
@@ -68,5 +69,17 @@ describe("ToolsTab", () => {
     // Verify input is reset
     const newInput = screen.getByRole("spinbutton") as HTMLInputElement;
     expect(newInput.value).toBe("");
+  });
+
+  it("should display error message when error prop is provided", () => {
+    const errorMessage = "Test error message";
+    renderToolsTab({
+      selectedTool: mockTools[0],
+      error: errorMessage,
+    });
+
+    // Verify error message is displayed
+    expect(screen.getByText("Error")).toBeTruthy();
+    expect(screen.getByText(errorMessage)).toBeTruthy();
   });
 });


### PR DESCRIPTION
Now if you have an error in you MCP tool call, do not remove the form

Before: 

![image](https://github.com/user-attachments/assets/26cbbdff-5cef-4f88-a513-183bdfbafff0)

After:

https://github.com/user-attachments/assets/40aa3da2-df23-4892-8997-87eee4630a9a


## Motivation and Context
Before, on each error, you need to select another tool and then come back to the same one, now, you can see the error and continue testing.

## How Has This Been Tested?
Yep, I'm building my own MCP, and I made the change to continue my integration, I tested it with another MCP.

## Breaking Changes
Nope

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
Nope
