### PR TITLE
fix: Use same protocol for proxy server URL

### DIFF
--- a/client/src/utils/configUtils.ts
+++ b/client/src/utils/configUtils.ts
@@ -6,7 +6,7 @@ export const getMCPProxyAddress = (config: InspectorConfig): string => {
   if (proxyFullAddress) {
     return proxyFullAddress;
   }
-  return `http://${window.location.hostname}:${DEFAULT_MCP_PROXY_LISTEN_PORT}`;
+  return `${window.location.protocol}//${window.location.hostname}:${DEFAULT_MCP_PROXY_LISTEN_PORT}`;
 };
 
 export const getMCPServerRequestTimeout = (config: InspectorConfig): number => {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Fixes #245 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Fixes a bug where the Client always assumes the Proxy server is running over `http`. Now the Client will use `https` when loaded over `https`.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tested locally that `http://localhost:5173/` still connects to proxy server over `http`.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
