### PR TITLE
fix: Do not reconnect on rerender

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -47,6 +47,7 @@ import ToolsTab from "./components/ToolsTab";
 import { DEFAULT_INSPECTOR_CONFIG } from "./lib/constants";
 import { InspectorConfig } from "./lib/configurationTypes";
 import { useToast } from "@/hooks/use-toast";
+
 const params = new URLSearchParams(window.location.search);
 const PROXY_PORT = params.get("proxyPort") ?? "6277";
 const PROXY_SERVER_URL = `http://${window.location.hostname}:${PROXY_PORT}`;
@@ -197,8 +198,13 @@ const App = () => {
     localStorage.setItem(CONFIG_LOCAL_STORAGE_KEY, JSON.stringify(config));
   }, [config]);
 
+  const hasProcessedRef = useRef(false);
   // Auto-connect if serverUrl is provided in URL params (e.g. after OAuth callback)
   useEffect(() => {
+    if (hasProcessedRef.current) {
+      // Only try to connect once
+      return;
+    }
     const serverUrl = params.get("serverUrl");
     if (serverUrl) {
       setSseUrl(serverUrl);
@@ -212,6 +218,7 @@ const App = () => {
         title: "Success",
         description: "Successfully authenticated with OAuth",
       });
+      hasProcessedRef.current = true;
       // Connect to the server
       connectMcpServer();
     }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Fixes a bug where the `useEffect` that wraps `connectMcpServer` runs repeatedly because `connectMcpServer` itself is not a stable callback reference. Every time the app re-renders, `connectMcpServer` is a different function, triggering the `useEffect` to run again.

I _think_ this fixes #250 - it certainly makes things much more stable for me though I have been getting a few scattered `ENOENT` errors as well.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Fixes a bug where the `useEffect` runs over and over and reconnects several times, which tends to overload the proxy and cause it to 500.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

The old clicky clicky against my [existing](http://mcp-stytch-b2b-okr-manager.maxwell-gerber42.workers.dev/) MCP servers 

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
