### PR TITLE
fix: Prevent unnecessary reconnection attempts in OAuth callback by removing connectMcpServer from dependency array

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -222,7 +222,7 @@ const App = () => {
       // Connect to the server
       connectMcpServer();
     }
-  }, [connectMcpServer, toast]);
+  }, [toast]);
 
   useEffect(() => {
     fetch(`${getMCPProxyAddress(config)}/config`)


### PR DESCRIPTION
## Motivation and Context
See: https://github.com/modelcontextprotocol/inspector/pull/253#issuecomment-2775878435

Related to issue: https://github.com/modelcontextprotocol/inspector/issues/250

## How Has This Been Tested?

1. Built Alex's repro example: https://github.com/alexhancock/snippets/tree/main/inspector-sse-connection-failed-example
2. Ran the Inspector app from this branch in dev mode and configured server to use command `node` and arguments as path to ^^
3. Listed tools, ran tool, and observed the results below:

![image](https://github.com/user-attachments/assets/25e86fe0-6eef-47b4-8f53-581372106f06)


## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Longer term solution ideas mentioned here: https://github.com/modelcontextprotocol/inspector/pull/253#issuecomment-2776312734
