### PR TITLE
Add WebSocket Transport

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -82,11 +82,17 @@ const App = () => {
   const [sseUrl, setSseUrl] = useState<string>(() => {
     return localStorage.getItem("lastSseUrl") || "http://localhost:3001/sse";
   });
-  const [transportType, setTransportType] = useState<"stdio" | "sse">(() => {
-    return (
-      (localStorage.getItem("lastTransportType") as "stdio" | "sse") || "stdio"
-    );
+  const [wsUrl, setWsUrl] = useState<string>(() => {
+    return localStorage.getItem("lastWsUrl") || "ws://localhost:3002/ws";
   });
+  const [transportType, setTransportType] = useState<"stdio" | "sse" | "ws">(
+    () => {
+      return (
+        (localStorage.getItem("lastTransportType") as "stdio" | "sse" | "ws") ||
+        "stdio"
+      );
+    },
+  );
   const [logLevel, setLogLevel] = useState<LoggingLevel>("debug");
   const [notifications, setNotifications] = useState<ServerNotification[]>([]);
   const [stdErrNotifications, setStdErrNotifications] = useState<
@@ -159,6 +165,7 @@ const App = () => {
     command,
     args,
     sseUrl,
+    wsUrl,
     env,
     bearerToken,
     proxyServerUrl: getMCPProxyAddress(config),
@@ -470,6 +477,8 @@ const App = () => {
         setArgs={setArgs}
         sseUrl={sseUrl}
         setSseUrl={setSseUrl}
+        wsUrl={wsUrl}
+        setWsUrl={setWsUrl}
         env={env}
         setEnv={setEnv}
         config={config}

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -39,14 +39,16 @@ import {
 
 interface SidebarProps {
   connectionStatus: ConnectionStatus;
-  transportType: "stdio" | "sse";
-  setTransportType: (type: "stdio" | "sse") => void;
+  transportType: "stdio" | "sse" | "ws";
+  setTransportType: (type: "stdio" | "sse" | "ws") => void;
   command: string;
   setCommand: (command: string) => void;
   args: string;
   setArgs: (args: string) => void;
   sseUrl: string;
   setSseUrl: (url: string) => void;
+  wsUrl: string;
+  setWsUrl: (url: string) => void;
   env: Record<string, string>;
   setEnv: (env: Record<string, string>) => void;
   bearerToken: string;
@@ -71,6 +73,8 @@ const Sidebar = ({
   setArgs,
   sseUrl,
   setSseUrl,
+  wsUrl,
+  setWsUrl,
   env,
   setEnv,
   bearerToken,
@@ -106,7 +110,7 @@ const Sidebar = ({
             <label className="text-sm font-medium">Transport Type</label>
             <Select
               value={transportType}
-              onValueChange={(value: "stdio" | "sse") =>
+              onValueChange={(value: "stdio" | "sse" | "ws") =>
                 setTransportType(value)
               }
             >
@@ -116,6 +120,7 @@ const Sidebar = ({
               <SelectContent>
                 <SelectItem value="stdio">STDIO</SelectItem>
                 <SelectItem value="sse">SSE</SelectItem>
+                <SelectItem value="ws">WebSocket</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -141,7 +146,7 @@ const Sidebar = ({
                 />
               </div>
             </>
-          ) : (
+          ) : transportType === "sse" ? (
             <>
               <div className="space-y-2">
                 <label className="text-sm font-medium">URL</label>
@@ -179,7 +184,19 @@ const Sidebar = ({
                 )}
               </div>
             </>
-          )}
+          ) : transportType === "ws" ? (
+            <>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">URL</label>
+                <Input
+                  placeholder="URL"
+                  value={wsUrl}
+                  onChange={(e) => setWsUrl(e.target.value)}
+                  className="font-mono"
+                />
+              </div>
+            </>
+          ) : null}
           {transportType === "stdio" && (
             <div className="space-y-2">
               <Button

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -22,6 +22,8 @@ describe("Sidebar Environment Variables", () => {
     setArgs: jest.fn(),
     sseUrl: "",
     setSseUrl: jest.fn(),
+    wsUrl: "",
+    setWsUrl: jest.fn(),
     env: {},
     setEnv: jest.fn(),
     bearerToken: "",

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -34,10 +34,11 @@ import { authProvider } from "../auth";
 import packageJson from "../../../package.json";
 
 interface UseConnectionOptions {
-  transportType: "stdio" | "sse";
+  transportType: "stdio" | "sse" | "ws";
   command: string;
   args: string;
   sseUrl: string;
+  wsUrl: string;
   env: Record<string, string>;
   proxyServerUrl: string;
   bearerToken?: string;
@@ -61,6 +62,7 @@ export function useConnection({
   command,
   args,
   sseUrl,
+  wsUrl,
   env,
   proxyServerUrl,
   bearerToken,
@@ -262,8 +264,12 @@ export function useConnection({
       mcpProxyServerUrl.searchParams.append("command", command);
       mcpProxyServerUrl.searchParams.append("args", args);
       mcpProxyServerUrl.searchParams.append("env", JSON.stringify(env));
-    } else {
+    } else if (transportType === "sse") {
       mcpProxyServerUrl.searchParams.append("url", sseUrl);
+    } else if (transportType === "ws") {
+      mcpProxyServerUrl.searchParams.append("url", wsUrl);
+    } else {
+      throw new Error(`Unsupported transport type: ${transportType}`);
     }
 
     try {
@@ -316,6 +322,7 @@ export function useConnection({
 
       try {
         await client.connect(clientTransport);
+        console.log("Connected to MCP Server via the MCP Inspector Proxy");
       } catch (error) {
         console.error(
           `Failed to connect to MCP Server via the MCP Inspector Proxy: ${mcpProxyServerUrl}:`,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { WebSocketClientTransport } from "@modelcontextprotocol/sdk/client/websocket.js";
 import express from "express";
 import { findActualExecutable } from "spawn-rx";
 import mcpProxy from "./mcpProxy.js";
@@ -37,6 +38,10 @@ const app = express();
 app.use(cors());
 
 let webAppTransports: SSEServerTransport[] = [];
+
+const getSessionIds = () => {
+  return webAppTransports.map((t) => t.sessionId);
+};
 
 const createTransport = async (req: express.Request): Promise<Transport> => {
   const query = req.query;
@@ -93,6 +98,13 @@ const createTransport = async (req: express.Request): Promise<Transport> => {
     await transport.start();
 
     console.log("Connected to SSE transport");
+    return transport;
+  } else if (transportType === "ws") {
+    const url = query.url as string;
+    const transport = new WebSocketClientTransport(new URL(url));
+    await transport.start();
+
+    console.log("Connected to WS transport");
     return transport;
   } else {
     console.error(`Invalid transport type: ${transportType}`);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Adds the WebSocket transport type as a supported option to connect to an MCP Server.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Per [this discussion](https://github.com/modelcontextprotocol/specification/discussions/220) on MCP Hosting there are a number of groups currently using WebSockets for their hosted platform and thus adding support would be helpful for debugging connections to running instances.  Simply adds the existing client transport implementation from the SDK to the Sidebar and the MCP Proxy.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tested against our existing MCP servers with our own WebSocketServerTransport implementation for ListTools and Tool execution.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
