### PR TITLE
feat: Show initialize request/response in History panel (#269)

### DIFF
--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -17,6 +17,8 @@ const mockClient = {
   connect: jest.fn().mockResolvedValue(undefined),
   close: jest.fn(),
   getServerCapabilities: jest.fn(),
+  getServerVersion: jest.fn(),
+  getInstructions: jest.fn(),
   setNotificationHandler: jest.fn(),
   setRequestHandler: jest.fn(),
 };

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -335,8 +335,19 @@ export function useConnection({
         );
       }
 
+      let capabilities;
       try {
         await client.connect(clientTransport);
+
+        capabilities = client.getServerCapabilities();
+        const initializeRequest = {
+          method: "initialize",
+        };
+        pushHistory(initializeRequest, {
+          capabilities,
+          serverInfo: client.getServerVersion(),
+          instructions: client.getInstructions(),
+        });
       } catch (error) {
         console.error(
           `Failed to connect to MCP Server via the MCP Inspector Proxy: ${mcpProxyServerUrl}:`,
@@ -353,8 +364,6 @@ export function useConnection({
         }
         throw error;
       }
-
-      const capabilities = client.getServerCapabilities();
       setServerCapabilities(capabilities ?? null);
       setCompletionsSupported(true); // Reset completions support on new connection
 


### PR DESCRIPTION
This is a candidate PR for issue #269.

Fixes #269

This PR adds a representation of initialize request and response to the History panel.

<img width="638" alt="Screenshot 2025-04-04 at 6 20 03 PM" src="https://github.com/user-attachments/assets/50da9521-245e-4865-8d09-1e1d479dec17" />


## Motivation and Context
The information in server's `initialize` response is very helpful - notably `instructions` and `serverCapabilities`. It would be great to see it in the inspector.

## How Has This Been Tested?
Tested connecting with variety of servers - `server-everything`, `linear-mcp-server`

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional Context

I am using the existing `pushHistory` method to push the request / response for `initialize` RPC messages.

There's a rub: the actual RPC request is abstracted in `Client.connect` (including `notification/initialized`).
This means that the payload pushed to history can potentially diverge from the one in the API client. I took the conservative approach, by representing the request with `method` only - I think the key information is the server response.