### PR TITLE
feat: Progress Support for Long Running Tool Calls ⏳

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,16 @@ The MCP Inspector includes a proxy server that can run and communicate with loca
 
 ### Configuration
 
-The MCP Inspector supports the following configuration settings. To change them click on the `Configuration` button in the MCP Inspector UI :
+The MCP Inspector supports the following configuration settings. To change them, click on the `Configuration` button in the MCP Inspector UI:
 
-| Name                       | Purpose                                                                                   | Default Value |
-| -------------------------- | ----------------------------------------------------------------------------------------- | ------------- |
-| MCP_SERVER_REQUEST_TIMEOUT | Maximum time in milliseconds to wait for a response from the MCP server before timing out | 10000         |
-| MCP_PROXY_FULL_ADDRESS     | The full URL of the MCP Inspector proxy server (e.g. `http://10.2.1.14:2277`)             | `null`        |
+| Setting                                 | Description                                                                                                  | Default |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------- |
+| `MCP_SERVER_REQUEST_TIMEOUT`            | Timeout for requests to the MCP server (ms)                                                                  | 10000   |
+| `MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS` | Reset timeout on progress notifications                                                                      | true    |
+| `MCP_REQUEST_MAX_TOTAL_TIMEOUT`         | Maximum total timeout for requests sent to the MCP server (ms) (Use with progress notifications)             | 60000   |
+| `MCP_PROXY_FULL_ADDRESS`                | Set this if you are running the MCP Inspector Proxy on a non-default address. Example: http://10.1.1.22:5577 | ""      |
+
+These settings can be adjusted in real-time through the UI and will persist across sessions.
 
 ### From this repository
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -105,8 +105,7 @@ const App = () => {
       Object.entries(mergedConfig).forEach(([key, value]) => {
         mergedConfig[key as keyof InspectorConfig] = {
           ...value,
-          description:
-            DEFAULT_INSPECTOR_CONFIG[key as keyof InspectorConfig].description,
+          label: DEFAULT_INSPECTOR_CONFIG[key as keyof InspectorConfig].label,
         };
       });
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -95,10 +95,22 @@ const App = () => {
   const [config, setConfig] = useState<InspectorConfig>(() => {
     const savedConfig = localStorage.getItem(CONFIG_LOCAL_STORAGE_KEY);
     if (savedConfig) {
-      return {
+      // merge default config with saved config
+      const mergedConfig = {
         ...DEFAULT_INSPECTOR_CONFIG,
         ...JSON.parse(savedConfig),
       } as InspectorConfig;
+
+      // update description of keys to match the new description (in case of any updates to the default config description)
+      Object.entries(mergedConfig).forEach(([key, value]) => {
+        mergedConfig[key as keyof InspectorConfig] = {
+          ...value,
+          description:
+            DEFAULT_INSPECTOR_CONFIG[key as keyof InspectorConfig].description,
+        };
+      });
+
+      return mergedConfig;
     }
     return DEFAULT_INSPECTOR_CONFIG;
   });

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -275,7 +275,7 @@ const App = () => {
     setErrors((prev) => ({ ...prev, [tabKey]: null }));
   };
 
-  const makeConnectionRequest = async <T extends z.ZodType>(
+  const sendMCPRequest = async <T extends z.ZodType>(
     request: ClientRequest,
     schema: T,
     tabKey?: keyof typeof errors,
@@ -299,7 +299,7 @@ const App = () => {
   };
 
   const listResources = async () => {
-    const response = await makeConnectionRequest(
+    const response = await sendMCPRequest(
       {
         method: "resources/list" as const,
         params: nextResourceCursor ? { cursor: nextResourceCursor } : {},
@@ -312,7 +312,7 @@ const App = () => {
   };
 
   const listResourceTemplates = async () => {
-    const response = await makeConnectionRequest(
+    const response = await sendMCPRequest(
       {
         method: "resources/templates/list" as const,
         params: nextResourceTemplateCursor
@@ -329,7 +329,7 @@ const App = () => {
   };
 
   const readResource = async (uri: string) => {
-    const response = await makeConnectionRequest(
+    const response = await sendMCPRequest(
       {
         method: "resources/read" as const,
         params: { uri },
@@ -342,7 +342,7 @@ const App = () => {
 
   const subscribeToResource = async (uri: string) => {
     if (!resourceSubscriptions.has(uri)) {
-      await makeConnectionRequest(
+      await sendMCPRequest(
         {
           method: "resources/subscribe" as const,
           params: { uri },
@@ -358,7 +358,7 @@ const App = () => {
 
   const unsubscribeFromResource = async (uri: string) => {
     if (resourceSubscriptions.has(uri)) {
-      await makeConnectionRequest(
+      await sendMCPRequest(
         {
           method: "resources/unsubscribe" as const,
           params: { uri },
@@ -373,7 +373,7 @@ const App = () => {
   };
 
   const listPrompts = async () => {
-    const response = await makeConnectionRequest(
+    const response = await sendMCPRequest(
       {
         method: "prompts/list" as const,
         params: nextPromptCursor ? { cursor: nextPromptCursor } : {},
@@ -386,7 +386,7 @@ const App = () => {
   };
 
   const getPrompt = async (name: string, args: Record<string, string> = {}) => {
-    const response = await makeConnectionRequest(
+    const response = await sendMCPRequest(
       {
         method: "prompts/get" as const,
         params: { name, arguments: args },
@@ -398,7 +398,7 @@ const App = () => {
   };
 
   const listTools = async () => {
-    const response = await makeConnectionRequest(
+    const response = await sendMCPRequest(
       {
         method: "tools/list" as const,
         params: nextToolCursor ? { cursor: nextToolCursor } : {},
@@ -412,7 +412,7 @@ const App = () => {
 
   const callTool = async (name: string, params: Record<string, unknown>) => {
     try {
-      const response = await makeConnectionRequest(
+      const response = await sendMCPRequest(
         {
           method: "tools/call" as const,
           params: {
@@ -446,7 +446,7 @@ const App = () => {
   };
 
   const sendLogLevelRequest = async (level: LoggingLevel) => {
-    await makeConnectionRequest(
+    await sendMCPRequest(
       {
         method: "logging/setLevel" as const,
         params: { level },
@@ -664,7 +664,7 @@ const App = () => {
                     <ConsoleTab />
                     <PingTab
                       onPingClick={() => {
-                        void makeConnectionRequest(
+                        void sendMCPRequest(
                           {
                             method: "ping" as const,
                           },

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -326,7 +326,7 @@ const Sidebar = ({
                     <div key={key} className="space-y-2">
                       <div className="flex items-center gap-1">
                         <label className="text-sm font-medium text-green-600 break-all">
-                          {configItem.description}
+                          {configItem.label}
                         </label>
                         <Tooltip>
                           <TooltipTrigger asChild>

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -325,7 +325,7 @@ const Sidebar = ({
                   return (
                     <div key={key} className="space-y-2">
                       <div className="flex items-center gap-1">
-                        <label className="text-sm font-medium text-green-600">
+                        <label className="text-sm font-medium text-green-600 break-all">
                           {configKey}
                         </label>
                         <Tooltip>

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -326,7 +326,7 @@ const Sidebar = ({
                     <div key={key} className="space-y-2">
                       <div className="flex items-center gap-1">
                         <label className="text-sm font-medium text-green-600 break-all">
-                          {configKey}
+                          {configItem.description}
                         </label>
                         <Tooltip>
                           <TooltipTrigger asChild>

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -13,7 +13,7 @@ import {
   ListToolsResult,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
-import { Send } from "lucide-react";
+import { Loader2, Send } from "lucide-react";
 import { useEffect, useState } from "react";
 import ListPane from "./ListPane";
 import JsonView from "./JsonView";
@@ -31,7 +31,7 @@ const ToolsTab = ({
   tools: Tool[];
   listTools: () => void;
   clearTools: () => void;
-  callTool: (name: string, params: Record<string, unknown>) => void;
+  callTool: (name: string, params: Record<string, unknown>) => Promise<void>;
   selectedTool: Tool | null;
   setSelectedTool: (tool: Tool | null) => void;
   toolResult: CompatibilityCallToolResult | null;
@@ -39,6 +39,8 @@ const ToolsTab = ({
   error: string | null;
 }) => {
   const [params, setParams] = useState<Record<string, unknown>>({});
+  const [isToolRunning, setIsToolRunning] = useState(false);
+
   useEffect(() => {
     setParams({});
   }, [selectedTool]);
@@ -234,9 +236,28 @@ const ToolsTab = ({
                   );
                 },
               )}
-              <Button onClick={() => callTool(selectedTool.name, params)}>
-                <Send className="w-4 h-4 mr-2" />
-                Run Tool
+              <Button
+                onClick={async () => {
+                  try {
+                    setIsToolRunning(true);
+                    await callTool(selectedTool.name, params);
+                  } finally {
+                    setIsToolRunning(false);
+                  }
+                }}
+                disabled={isToolRunning}
+              >
+                {isToolRunning ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    Running...
+                  </>
+                ) : (
+                  <>
+                    <Send className="w-4 h-4 mr-2" />
+                    Run Tool
+                  </>
+                )}
               </Button>
               {toolResult && renderToolResult()}
             </div>

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -343,7 +343,8 @@ describe("Sidebar Environment Variables", () => {
       expect(setConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           MCP_SERVER_REQUEST_TIMEOUT: {
-            description: "Request Timeout",
+            label: "Request Timeout",
+            description: "Timeout for requests to the MCP server (ms)",
             value: 5000,
           },
         }),
@@ -366,7 +367,9 @@ describe("Sidebar Environment Variables", () => {
       expect(setConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           MCP_PROXY_FULL_ADDRESS: {
-            description: "Inspector Proxy Address",
+            label: "Inspector Proxy Address",
+            description:
+              "Set this if you are running the MCP Inspector Proxy on a non-default address. Example: http://10.1.1.22:5577",
             value: "http://localhost:8080",
           },
         }),
@@ -389,7 +392,9 @@ describe("Sidebar Environment Variables", () => {
       expect(setConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           MCP_REQUEST_MAX_TOTAL_TIMEOUT: {
-            description: "Maximum Total Timeout",
+            label: "Maximum Total Timeout",
+            description:
+              "Maximum total timeout for requests sent to the MCP server (ms) (Use with progress notifications)",
             value: 10000,
           },
         }),
@@ -410,7 +415,8 @@ describe("Sidebar Environment Variables", () => {
       expect(setConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           MCP_SERVER_REQUEST_TIMEOUT: {
-            description: "Request Timeout",
+            label: "Request Timeout",
+            description: "Timeout for requests to the MCP server (ms)",
             value: 0,
           },
         }),
@@ -455,7 +461,8 @@ describe("Sidebar Environment Variables", () => {
       expect(setConfig).toHaveBeenLastCalledWith(
         expect.objectContaining({
           MCP_SERVER_REQUEST_TIMEOUT: {
-            description: "Request Timeout",
+            label: "Request Timeout",
+            description: "Timeout for requests to the MCP server (ms)",
             value: 3000,
           },
         }),

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -350,6 +350,54 @@ describe("Sidebar Environment Variables", () => {
       );
     });
 
+    it("should update MCP server proxy address", () => {
+      const setConfig = jest.fn();
+      renderSidebar({ config: DEFAULT_INSPECTOR_CONFIG, setConfig });
+
+      openConfigSection();
+
+      const proxyAddressInput = screen.getByTestId(
+        "MCP_PROXY_FULL_ADDRESS-input",
+      );
+      fireEvent.change(proxyAddressInput, {
+        target: { value: "http://localhost:8080" },
+      });
+
+      expect(setConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          MCP_PROXY_FULL_ADDRESS: {
+            description:
+              "Set this if you are running the MCP Inspector Proxy on a non-default address. Example: http://10.1.1.22:5577",
+            value: "http://localhost:8080",
+          },
+        }),
+      );
+    });
+
+    it("should update max total timeout", () => {
+      const setConfig = jest.fn();
+      renderSidebar({ config: DEFAULT_INSPECTOR_CONFIG, setConfig });
+
+      openConfigSection();
+
+      const maxTotalTimeoutInput = screen.getByTestId(
+        "MCP_REQUEST_MAX_TOTAL_TIMEOUT-input",
+      );
+      fireEvent.change(maxTotalTimeoutInput, {
+        target: { value: "10000" },
+      });
+
+      expect(setConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          MCP_REQUEST_MAX_TOTAL_TIMEOUT: {
+            description:
+              "Maximum total timeout for requests sent to the MCP server (ms) (Use with progress notifications)",
+            value: 10000,
+          },
+        }),
+      );
+    });
+
     it("should handle invalid timeout values entered by user", () => {
       const setConfig = jest.fn();
       renderSidebar({ config: DEFAULT_INSPECTOR_CONFIG, setConfig });

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -343,7 +343,7 @@ describe("Sidebar Environment Variables", () => {
       expect(setConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           MCP_SERVER_REQUEST_TIMEOUT: {
-            description: "Timeout for requests to the MCP server (ms)",
+            description: "Request Timeout",
             value: 5000,
           },
         }),
@@ -366,8 +366,7 @@ describe("Sidebar Environment Variables", () => {
       expect(setConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           MCP_PROXY_FULL_ADDRESS: {
-            description:
-              "Set this if you are running the MCP Inspector Proxy on a non-default address. Example: http://10.1.1.22:5577",
+            description: "Inspector Proxy Address",
             value: "http://localhost:8080",
           },
         }),
@@ -390,8 +389,7 @@ describe("Sidebar Environment Variables", () => {
       expect(setConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           MCP_REQUEST_MAX_TOTAL_TIMEOUT: {
-            description:
-              "Maximum total timeout for requests sent to the MCP server (ms) (Use with progress notifications)",
+            description: "Maximum Total Timeout",
             value: 10000,
           },
         }),
@@ -412,7 +410,7 @@ describe("Sidebar Environment Variables", () => {
       expect(setConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           MCP_SERVER_REQUEST_TIMEOUT: {
-            description: "Timeout for requests to the MCP server (ms)",
+            description: "Request Timeout",
             value: 0,
           },
         }),
@@ -457,7 +455,7 @@ describe("Sidebar Environment Variables", () => {
       expect(setConfig).toHaveBeenLastCalledWith(
         expect.objectContaining({
           MCP_SERVER_REQUEST_TIMEOUT: {
-            description: "Timeout for requests to the MCP server (ms)",
+            description: "Request Timeout",
             value: 3000,
           },
         }),

--- a/client/src/lib/configurationTypes.ts
+++ b/client/src/lib/configurationTypes.ts
@@ -1,4 +1,5 @@
 export type ConfigItem = {
+  label: string;
   description: string;
   value: string | number | boolean;
 };

--- a/client/src/lib/configurationTypes.ts
+++ b/client/src/lib/configurationTypes.ts
@@ -20,13 +20,13 @@ export type InspectorConfig = {
    * Whether to reset the timeout on progress notifications. Useful for long-running operations that send periodic progress updates.
    * Refer: https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/utilities/progress/#progress-flow
    */
-  MCP_SERVER_REQUEST_TIMEOUT_RESET_ON_PROGRESS: ConfigItem;
+  MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS: ConfigItem;
 
   /**
    * Maximum total time in milliseconds to wait for a response from the MCP server before timing out. Used in conjunction with MCP_SERVER_REQUEST_TIMEOUT_RESET_ON_PROGRESS.
    * Refer: https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/utilities/progress/#progress-flow
    */
-  MCP_SERVER_REQUEST_TIMEOUT_MAX_TOTAL_TIMEOUT: ConfigItem;
+  MCP_REQUEST_MAX_TOTAL_TIMEOUT: ConfigItem;
 
   /**
    * The full address of the MCP Proxy Server, in case it is running on a non-default address. Example: http://10.1.1.22:5577

--- a/client/src/lib/configurationTypes.ts
+++ b/client/src/lib/configurationTypes.ts
@@ -15,5 +15,21 @@ export type InspectorConfig = {
    * Maximum time in milliseconds to wait for a response from the MCP server before timing out.
    */
   MCP_SERVER_REQUEST_TIMEOUT: ConfigItem;
+
+  /**
+   * Whether to reset the timeout on progress notifications. Useful for long-running operations that send periodic progress updates.
+   * Refer: https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/utilities/progress/#progress-flow
+   */
+  MCP_SERVER_REQUEST_TIMEOUT_RESET_ON_PROGRESS: ConfigItem;
+
+  /**
+   * Maximum total time in milliseconds to wait for a response from the MCP server before timing out. Used in conjunction with MCP_SERVER_REQUEST_TIMEOUT_RESET_ON_PROGRESS.
+   * Refer: https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/utilities/progress/#progress-flow
+   */
+  MCP_SERVER_REQUEST_TIMEOUT_MAX_TOTAL_TIMEOUT: ConfigItem;
+
+  /**
+   * The full address of the MCP Proxy Server, in case it is running on a non-default address. Example: http://10.1.1.22:5577
+   */
   MCP_PROXY_FULL_ADDRESS: ConfigItem;
 };

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -25,6 +25,14 @@ export const DEFAULT_INSPECTOR_CONFIG: InspectorConfig = {
     description: "Timeout for requests to the MCP server (ms)",
     value: 10000,
   },
+  MCP_SERVER_REQUEST_TIMEOUT_RESET_ON_PROGRESS: {
+    description: "Reset timeout on progress notifications",
+    value: true,
+  },
+  MCP_SERVER_REQUEST_TIMEOUT_MAX_TOTAL_TIMEOUT: {
+    description: "Maximum total timeout for requests sent to the MCP server (ms)",
+    value: 60000,
+  },
   MCP_PROXY_FULL_ADDRESS: {
     description:
       "Set this if you are running the MCP Inspector Proxy on a non-default address. Example: http://10.1.1.22:5577",

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -22,21 +22,19 @@ export const DEFAULT_MCP_PROXY_LISTEN_PORT = "6277";
  **/
 export const DEFAULT_INSPECTOR_CONFIG: InspectorConfig = {
   MCP_SERVER_REQUEST_TIMEOUT: {
-    description: "Timeout for requests to the MCP server (ms)",
+    description: "Request Timeout",
     value: 10000,
   },
   MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS: {
-    description: "Reset timeout on progress notifications",
+    description: "Reset Timeout on Progress",
     value: true,
   },
   MCP_REQUEST_MAX_TOTAL_TIMEOUT: {
-    description:
-      "Maximum total timeout for requests sent to the MCP server (ms) (Use with progress notifications)",
+    description: "Maximum Total Timeout",
     value: 60000,
   },
   MCP_PROXY_FULL_ADDRESS: {
-    description:
-      "Set this if you are running the MCP Inspector Proxy on a non-default address. Example: http://10.1.1.22:5577",
+    description: "Inspector Proxy Address",
     value: "",
   },
 } as const;

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -25,12 +25,13 @@ export const DEFAULT_INSPECTOR_CONFIG: InspectorConfig = {
     description: "Timeout for requests to the MCP server (ms)",
     value: 10000,
   },
-  MCP_SERVER_REQUEST_TIMEOUT_RESET_ON_PROGRESS: {
+  MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS: {
     description: "Reset timeout on progress notifications",
     value: true,
   },
-  MCP_SERVER_REQUEST_TIMEOUT_MAX_TOTAL_TIMEOUT: {
-    description: "Maximum total timeout for requests sent to the MCP server (ms)",
+  MCP_REQUEST_MAX_TOTAL_TIMEOUT: {
+    description:
+      "Maximum total timeout for requests sent to the MCP server (ms) (Use with progress notifications)",
     value: 60000,
   },
   MCP_PROXY_FULL_ADDRESS: {

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -22,19 +22,25 @@ export const DEFAULT_MCP_PROXY_LISTEN_PORT = "6277";
  **/
 export const DEFAULT_INSPECTOR_CONFIG: InspectorConfig = {
   MCP_SERVER_REQUEST_TIMEOUT: {
-    description: "Request Timeout",
+    label: "Request Timeout",
+    description: "Timeout for requests to the MCP server (ms)",
     value: 10000,
   },
   MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS: {
-    description: "Reset Timeout on Progress",
+    label: "Reset Timeout on Progress",
+    description: "Reset timeout on progress notifications",
     value: true,
   },
   MCP_REQUEST_MAX_TOTAL_TIMEOUT: {
-    description: "Maximum Total Timeout",
+    label: "Maximum Total Timeout",
+    description:
+      "Maximum total timeout for requests sent to the MCP server (ms) (Use with progress notifications)",
     value: 60000,
   },
   MCP_PROXY_FULL_ADDRESS: {
-    description: "Inspector Proxy Address",
+    label: "Inspector Proxy Address",
+    description:
+      "Set this if you are running the MCP Inspector Proxy on a non-default address. Example: http://10.1.1.22:5577",
     value: "",
   },
 } as const;

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -1,0 +1,165 @@
+import { renderHook, act } from "@testing-library/react";
+import { useConnection } from "../useConnection";
+import { z } from "zod";
+import { ClientRequest } from "@modelcontextprotocol/sdk/types.js";
+import { DEFAULT_INSPECTOR_CONFIG } from "../../constants";
+
+// Mock fetch
+global.fetch = jest.fn().mockResolvedValue({
+  json: () => Promise.resolve({ status: "ok" }),
+});
+
+// Mock the SDK dependencies
+const mockRequest = jest.fn().mockResolvedValue({ test: "response" });
+const mockClient = {
+  request: mockRequest,
+  notification: jest.fn(),
+  connect: jest.fn().mockResolvedValue(undefined),
+  close: jest.fn(),
+  getServerCapabilities: jest.fn(),
+  setNotificationHandler: jest.fn(),
+  setRequestHandler: jest.fn(),
+};
+
+jest.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: jest.fn().mockImplementation(() => mockClient),
+}));
+
+jest.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: jest.fn(),
+  SseError: jest.fn(),
+}));
+
+jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
+  auth: jest.fn().mockResolvedValue("AUTHORIZED"),
+}));
+
+// Mock the toast hook
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}));
+
+// Mock the auth provider
+jest.mock("../../auth", () => ({
+  authProvider: {
+    tokens: jest.fn().mockResolvedValue({ access_token: "mock-token" }),
+  },
+}));
+
+describe("useConnection", () => {
+  const defaultProps = {
+    transportType: "sse" as const,
+    command: "",
+    args: "",
+    sseUrl: "http://localhost:8080",
+    env: {},
+    config: DEFAULT_INSPECTOR_CONFIG,
+  };
+
+  describe("Request Configuration", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test("uses the default config values in makeRequest", async () => {
+      const { result } = renderHook(() => useConnection(defaultProps));
+
+      // Connect the client
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Wait for state update
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      const mockRequest: ClientRequest = {
+        method: "ping",
+        params: {},
+      };
+
+      const mockSchema = z.object({
+        test: z.string(),
+      });
+
+      await act(async () => {
+        await result.current.makeRequest(mockRequest, mockSchema);
+      });
+
+      expect(mockClient.request).toHaveBeenCalledWith(
+        mockRequest,
+        mockSchema,
+        expect.objectContaining({
+          timeout: DEFAULT_INSPECTOR_CONFIG.MCP_SERVER_REQUEST_TIMEOUT.value,
+          maxTotalTimeout:
+            DEFAULT_INSPECTOR_CONFIG
+              .MCP_SERVER_REQUEST_TIMEOUT_MAX_TOTAL_TIMEOUT.value,
+          resetTimeoutOnProgress:
+            DEFAULT_INSPECTOR_CONFIG
+              .MCP_SERVER_REQUEST_TIMEOUT_RESET_ON_PROGRESS.value,
+        }),
+      );
+    });
+
+    test("overrides the default config values when passed in options in makeRequest", async () => {
+      const { result } = renderHook(() => useConnection(defaultProps));
+
+      // Connect the client
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Wait for state update
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      const mockRequest: ClientRequest = {
+        method: "ping",
+        params: {},
+      };
+
+      const mockSchema = z.object({
+        test: z.string(),
+      });
+
+      await act(async () => {
+        await result.current.makeRequest(mockRequest, mockSchema, {
+          timeout: 1000,
+          maxTotalTimeout: 2000,
+          resetTimeoutOnProgress: false,
+        });
+      });
+
+      expect(mockClient.request).toHaveBeenCalledWith(
+        mockRequest,
+        mockSchema,
+        expect.objectContaining({
+          timeout: 1000,
+          maxTotalTimeout: 2000,
+          resetTimeoutOnProgress: false,
+        }),
+      );
+    });
+  });
+
+  test("throws error when mcpClient is not connected", async () => {
+    const { result } = renderHook(() => useConnection(defaultProps));
+
+    const mockRequest: ClientRequest = {
+      method: "ping",
+      params: {},
+    };
+
+    const mockSchema = z.object({
+      test: z.string(),
+    });
+
+    await expect(
+      result.current.makeRequest(mockRequest, mockSchema),
+    ).rejects.toThrow("MCP client not connected");
+  });
+});

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -95,11 +95,10 @@ describe("useConnection", () => {
         expect.objectContaining({
           timeout: DEFAULT_INSPECTOR_CONFIG.MCP_SERVER_REQUEST_TIMEOUT.value,
           maxTotalTimeout:
-            DEFAULT_INSPECTOR_CONFIG
-              .MCP_SERVER_REQUEST_TIMEOUT_MAX_TOTAL_TIMEOUT.value,
+            DEFAULT_INSPECTOR_CONFIG.MCP_REQUEST_MAX_TOTAL_TIMEOUT.value,
           resetTimeoutOnProgress:
-            DEFAULT_INSPECTOR_CONFIG
-              .MCP_SERVER_REQUEST_TIMEOUT_RESET_ON_PROGRESS.value,
+            DEFAULT_INSPECTOR_CONFIG.MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS
+              .value,
         }),
       );
     });

--- a/client/src/utils/configUtils.ts
+++ b/client/src/utils/configUtils.ts
@@ -12,3 +12,15 @@ export const getMCPProxyAddress = (config: InspectorConfig): string => {
 export const getMCPServerRequestTimeout = (config: InspectorConfig): number => {
   return config.MCP_SERVER_REQUEST_TIMEOUT.value as number;
 };
+
+export const resetRequestTimeoutOnProgress = (
+  config: InspectorConfig,
+): boolean => {
+  return config.MCP_SERVER_REQUEST_TIMEOUT_RESET_ON_PROGRESS.value as boolean;
+};
+
+export const getMCPServerRequestMaxTotalTimeout = (
+  config: InspectorConfig,
+): number => {
+  return config.MCP_SERVER_REQUEST_TIMEOUT_MAX_TOTAL_TIMEOUT.value as number;
+};

--- a/client/src/utils/configUtils.ts
+++ b/client/src/utils/configUtils.ts
@@ -16,11 +16,11 @@ export const getMCPServerRequestTimeout = (config: InspectorConfig): number => {
 export const resetRequestTimeoutOnProgress = (
   config: InspectorConfig,
 ): boolean => {
-  return config.MCP_SERVER_REQUEST_TIMEOUT_RESET_ON_PROGRESS.value as boolean;
+  return config.MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS.value as boolean;
 };
 
 export const getMCPServerRequestMaxTotalTimeout = (
   config: InspectorConfig,
 ): number => {
-  return config.MCP_SERVER_REQUEST_TIMEOUT_MAX_TOTAL_TIMEOUT.value as number;
+  return config.MCP_REQUEST_MAX_TOTAL_TIMEOUT.value as number;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/inspector",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "workspaces": [
         "client",
         "server"
       ],
       "dependencies": {
-        "@modelcontextprotocol/inspector-client": "^0.8.0",
-        "@modelcontextprotocol/inspector-server": "^0.8.0",
+        "@modelcontextprotocol/inspector-client": "^0.8.1",
+        "@modelcontextprotocol/inspector-server": "^0.8.1",
         "concurrently": "^9.0.1",
         "shell-quote": "^1.8.2",
         "spawn-rx": "^5.1.2",
@@ -32,10 +32,10 @@
     },
     "client": {
       "name": "@modelcontextprotocol/inspector-client",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.6.1",
+        "@modelcontextprotocol/sdk": "^1.8.0",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.3",
         "@radix-ui/react-icons": "^1.3.0",
@@ -1329,11 +1329,13 @@
       "link": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.6.1",
-      "license": "MIT",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.8.0.tgz",
+      "integrity": "sha512-e06W7SwrontJDHwCawNO5SGxG+nU9AAx+jpHHZqGl/WrDBdWOpvirC+s58VpJTB5QemI4jTRcjWT4Pt3Q1NPQQ==",
       "dependencies": {
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
+        "cross-spawn": "^7.0.3",
         "eventsource": "^3.0.2",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
@@ -9483,10 +9485,10 @@
     },
     "server": {
       "name": "@modelcontextprotocol/inspector-server",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.6.1",
+        "@modelcontextprotocol/sdk": "^1.8.0",
         "cors": "^2.8.5",
         "express": "^4.21.0",
         "ws": "^8.18.0",


### PR DESCRIPTION
## Progress Support for Long Running Tool Calls

https://github.com/user-attachments/assets/504b33e3-8c24-4bb9-8bf5-b01fd4799980

The MCP Inspector now fully supports the [Model Context Protocol Progress Flow](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/utilities/progress/#progress-flow) specification, which enables:
- Optional progress tracking for long-running operations
- Added new configuration settings to the MCP Inspector for supporting this:
   - `MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS`: Controls whether timeouts reset on progress notifications. Default: `true`
   - `MCP_REQUEST_MAX_TOTAL_TIMEOUT`: Sets maximum total timeout for requests with progress notifications. Default: `60000` ms

## Other Changes
1. `Run tool` button now shows as a spinner while the tool is running (and becomes disabled).
2. Improves error handling for `callTool` exceptions.
3. Some minor code-refactoring, to improve readability.
4. Progress notifications are now handled little differently than other notifications, check `.onprogress` hook in `useConnection`  

### Testing
* Used the [everything](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) MCP Server's `longRunningOperation` tool.
* To enable progress notifications set `MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS` to `true` (default).
  *  if tool response `duration` is less than  `MCP_REQUEST_MAX_TOTAL_TIMEOUT` then tool call will succeed.
  * otherwise, it will fail with `MCP error -32001: Maximum total timeout exceeded`
![Screenshot 2025-04-05 at 1 17 51 AM](https://github.com/user-attachments/assets/8bc39ff1-3288-4fa2-9dc5-c3dc4afecc32)
* Increased  `MCP_REQUEST_MAX_TOTAL_TIMEOUT` to 200000 (200 seconds) and verified if duration is set to 150 seconds,  the tool execution completes fine.
<img width="558" alt="Screenshot 2025-04-05 at 1 48 54 PM" src="https://github.com/user-attachments/assets/00308948-9a26-48a6-95bf-e700e997a3c2" />

* Disabled `MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS` and verified that tool correctly times out.

## Related Issues
- Fixes https://github.com/modelcontextprotocol/inspector/issues/223