### PR TITLE
Enable Authentication header name configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For more details on ways to use the inspector, see the [Inspector section of the
 
 ### Authentication
 
-The inspector supports bearer token authentication for SSE connections. Enter your token in the UI when connecting to an MCP server, and it will be sent in the Authorization header.
+The inspector supports bearer token authentication for SSE connections. Enter your token in the UI when connecting to an MCP server, and it will be sent in the Authorization header. You can override the header name.
 
 ### Security Considerations
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For more details on ways to use the inspector, see the [Inspector section of the
 
 ### Authentication
 
-The inspector supports bearer token authentication for SSE connections. Enter your token in the UI when connecting to an MCP server, and it will be sent in the Authorization header. You can override the header name.
+The inspector supports bearer token authentication for SSE connections. Enter your token in the UI when connecting to an MCP server, and it will be sent in the Authorization header. You can override the header name using the input field in the sidebar.
 
 ### Security Considerations
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -108,13 +108,12 @@ const App = () => {
   const [bearerToken, setBearerToken] = useState<string>(() => {
     return localStorage.getItem("lastBearerToken") || "";
   });
-  
+
   const [headerName, setHeaderName] = useState<string>(() => {
     return localStorage.getItem("lastHeaderName") || "Authorization";
   });
 
   const [pendingSampleRequests, setPendingSampleRequests] = useState<
-
     Array<
       PendingRequest & {
         resolve: (result: CreateMessageResult) => void;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -174,8 +174,6 @@ const App = () => {
     env,
     bearerToken,
     headerName,
-    proxyServerUrl: getMCPProxyAddress(config),
-    requestTimeout: getMCPServerRequestTimeout(config),
     config,
     onNotification: (notification) => {
       setNotifications((prev) => [...prev, notification as ServerNotification]);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -108,8 +108,13 @@ const App = () => {
   const [bearerToken, setBearerToken] = useState<string>(() => {
     return localStorage.getItem("lastBearerToken") || "";
   });
+  
+  const [headerName, setHeaderName] = useState<string>(() => {
+    return localStorage.getItem("lastHeaderName") || "Authorization";
+  });
 
   const [pendingSampleRequests, setPendingSampleRequests] = useState<
+
     Array<
       PendingRequest & {
         resolve: (result: CreateMessageResult) => void;
@@ -161,6 +166,7 @@ const App = () => {
     sseUrl,
     env,
     bearerToken,
+    headerName,
     proxyServerUrl: getMCPProxyAddress(config),
     requestTimeout: getMCPServerRequestTimeout(config),
     onNotification: (notification) => {
@@ -200,6 +206,10 @@ const App = () => {
   useEffect(() => {
     localStorage.setItem("lastBearerToken", bearerToken);
   }, [bearerToken]);
+
+  useEffect(() => {
+    localStorage.setItem("lastHeaderName", headerName);
+  }, [headerName]);
 
   useEffect(() => {
     localStorage.setItem(CONFIG_LOCAL_STORAGE_KEY, JSON.stringify(config));
@@ -476,6 +486,8 @@ const App = () => {
         setConfig={setConfig}
         bearerToken={bearerToken}
         setBearerToken={setBearerToken}
+        headerName={headerName}
+        setHeaderName={setHeaderName}
         onConnect={connectMcpServer}
         onDisconnect={disconnectMcpServer}
         stdErrNotifications={stdErrNotifications}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -45,7 +45,7 @@ import Sidebar from "./components/Sidebar";
 import ToolsTab from "./components/ToolsTab";
 import { DEFAULT_INSPECTOR_CONFIG } from "./lib/constants";
 import { InspectorConfig } from "./lib/configurationTypes";
-import { getMCPProxyAddress } from "./utils/configUtils";
+import { getMCPProxyAddress, getMCPServerRequestTimeout } from "./utils/configUtils";
 import { useToast } from "@/hooks/use-toast";
 
 const params = new URLSearchParams(window.location.search);
@@ -118,7 +118,7 @@ const App = () => {
   });
 
   const [headerName, setHeaderName] = useState<string>(() => {
-    return localStorage.getItem("lastHeaderName") || "Authorization";
+    return localStorage.getItem("lastHeaderName") || "";
   });
 
   const [pendingSampleRequests, setPendingSampleRequests] = useState<

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -45,7 +45,7 @@ import Sidebar from "./components/Sidebar";
 import ToolsTab from "./components/ToolsTab";
 import { DEFAULT_INSPECTOR_CONFIG } from "./lib/constants";
 import { InspectorConfig } from "./lib/configurationTypes";
-import { getMCPProxyAddress, getMCPServerRequestTimeout } from "./utils/configUtils";
+import { getMCPProxyAddress } from "./utils/configUtils";
 import { useToast } from "@/hooks/use-toast";
 
 const params = new URLSearchParams(window.location.search);

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -161,6 +161,7 @@ const Sidebar = ({
                   variant="outline"
                   onClick={() => setShowBearerToken(!showBearerToken)}
                   className="flex items-center w-full"
+                  data-testid="auth-button"
                 >
                   {showBearerToken ? (
                     <ChevronDown className="w-4 h-4 mr-2" />
@@ -174,7 +175,10 @@ const Sidebar = ({
                     <label className="text-sm font-medium">Header Name</label>
                     <Input
                       placeholder="Authorization"
-                      onChange={(e) => setHeaderName && setHeaderName(e.target.value)}
+                      onChange={(e) =>
+                        setHeaderName && setHeaderName(e.target.value)
+                      }
+                      data-testid="header-input"
                       className="font-mono"
                       value={headerName}
                     />
@@ -183,6 +187,7 @@ const Sidebar = ({
                       placeholder="Bearer Token"
                       value={bearerToken}
                       onChange={(e) => setBearerToken(e.target.value)}
+                      data-testid="bearer-token-input"
                       className="font-mono"
                       type="password"
                     />

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -51,6 +51,8 @@ interface SidebarProps {
   setEnv: (env: Record<string, string>) => void;
   bearerToken: string;
   setBearerToken: (token: string) => void;
+  headerName?: string;
+  setHeaderName?: (name: string) => void;
   onConnect: () => void;
   onDisconnect: () => void;
   stdErrNotifications: StdErrNotification[];
@@ -75,6 +77,8 @@ const Sidebar = ({
   setEnv,
   bearerToken,
   setBearerToken,
+  headerName,
+  setHeaderName,
   onConnect,
   onDisconnect,
   stdErrNotifications,
@@ -167,6 +171,14 @@ const Sidebar = ({
                 </Button>
                 {showBearerToken && (
                   <div className="space-y-2">
+                    <label className="text-sm font-medium">Header Name</label>
+                    <Input
+                      placeholder="Authorization"
+                      defaultValue="Authorization"
+                      onChange={(e) => setHeaderName && setHeaderName(e.target.value)}
+                      className="font-mono"
+                      value={headerName}
+                    />
                     <label className="text-sm font-medium">Bearer Token</label>
                     <Input
                       placeholder="Bearer Token"

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -174,7 +174,6 @@ const Sidebar = ({
                     <label className="text-sm font-medium">Header Name</label>
                     <Input
                       placeholder="Authorization"
-                      defaultValue="Authorization"
                       onChange={(e) => setHeaderName && setHeaderName(e.target.value)}
                       className="font-mono"
                       value={headerName}

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -41,6 +41,7 @@ interface UseConnectionOptions {
   env: Record<string, string>;
   proxyServerUrl: string;
   bearerToken?: string;
+  headerName?: string;
   requestTimeout?: number;
   onNotification?: (notification: Notification) => void;
   onStdErrNotification?: (notification: Notification) => void;
@@ -64,6 +65,7 @@ export function useConnection({
   env,
   proxyServerUrl,
   bearerToken,
+  headerName,
   requestTimeout,
   onNotification,
   onStdErrNotification,
@@ -274,7 +276,8 @@ export function useConnection({
       // Use manually provided bearer token if available, otherwise use OAuth tokens
       const token = bearerToken || (await authProvider.tokens())?.access_token;
       if (token) {
-        headers["Authorization"] = `Bearer ${token}`;
+        const authHeaderName = headerName || "Authorization";
+        headers[authHeaderName] = `${token}`;
       }
 
       const clientTransport = new SSEClientTransport(mcpProxyServerUrl, {

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -49,7 +49,6 @@ interface UseConnectionOptions {
   env: Record<string, string>;
   bearerToken?: string;
   headerName?: string;
-  requestTimeout?: number;
   config: InspectorConfig;
   onNotification?: (notification: Notification) => void;
   onStdErrNotification?: (notification: Notification) => void;
@@ -67,7 +66,6 @@ export function useConnection({
   env,
   bearerToken,
   headerName,
-  requestTimeout,
   config,
   onNotification,
   onStdErrNotification,

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -296,7 +296,7 @@ export function useConnection({
       const token = bearerToken || (await authProvider.tokens())?.access_token;
       if (token) {
         const authHeaderName = headerName || "Authorization";
-        headers[authHeaderName] = `${token}`;
+        headers[authHeaderName] = `Bearer ${token}`;
       }
 
       const clientTransport = new SSEClientTransport(mcpProxyServerUrl, {


### PR DESCRIPTION
This change adds a Header Name field to the sidebar. It overrides the "Authorization" default name.

<img width="309" alt="image" src="https://github.com/user-attachments/assets/a8d112a4-3031-4e8e-954c-3a1f9dcac06a" />

## Motivation and Context
Some servers use a custom header name (e.g., Vercel Preview). The current feature doesn't support these servers.

## How Has This Been Tested?
I've added unit tests and tested it manually

## Breaking Changes
No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Please let me know if it requires any changes, and thanks for the great project!
