### PR TITLE
feat: highlight tool errors in red text

### DIFF
--- a/client/src/components/JsonView.tsx
+++ b/client/src/components/JsonView.tsx
@@ -36,7 +36,7 @@ const JsonView = memo(
     initialExpandDepth = 3,
     className,
     withCopyButton = true,
-    isError = false
+    isError = false,
   }: JsonViewProps) => {
     const { toast } = useToast();
     const [copied, setCopied] = useState(false);
@@ -102,7 +102,7 @@ const JsonView = memo(
             name={name}
             depth={0}
             initialExpandDepth={initialExpandDepth}
-            isError = {isError}
+            isError={isError}
           />
         </div>
       </div>
@@ -121,7 +121,13 @@ interface JsonNodeProps {
 }
 
 const JsonNode = memo(
-  ({ data, name, depth = 0, initialExpandDepth, isError = false }: JsonNodeProps) => {
+  ({
+    data,
+    name,
+    depth = 0,
+    initialExpandDepth,
+    isError = false,
+  }: JsonNodeProps) => {
     const [isExpanded, setIsExpanded] = useState(depth < initialExpandDepth);
 
     const getDataType = (value: JsonValue): string => {
@@ -241,7 +247,14 @@ const JsonNode = memo(
                 {name}:
               </span>
             )}
-            <pre className={clsx(typeStyleMap.string, "break-all whitespace-pre-wrap")}>"{value}"</pre>
+            <pre
+              className={clsx(
+                typeStyleMap.string,
+                "break-all whitespace-pre-wrap",
+              )}
+            >
+              "{value}"
+            </pre>
           </div>
         );
       }

--- a/client/src/components/JsonView.tsx
+++ b/client/src/components/JsonView.tsx
@@ -11,6 +11,7 @@ interface JsonViewProps {
   initialExpandDepth?: number;
   className?: string;
   withCopyButton?: boolean;
+  isError?: boolean;
 }
 
 function tryParseJson(str: string): { success: boolean; data: JsonValue } {
@@ -35,6 +36,7 @@ const JsonView = memo(
     initialExpandDepth = 3,
     className,
     withCopyButton = true,
+    isError = false
   }: JsonViewProps) => {
     const { toast } = useToast();
     const [copied, setCopied] = useState(false);
@@ -100,6 +102,7 @@ const JsonView = memo(
             name={name}
             depth={0}
             initialExpandDepth={initialExpandDepth}
+            isError = {isError}
           />
         </div>
       </div>
@@ -114,10 +117,11 @@ interface JsonNodeProps {
   name?: string;
   depth: number;
   initialExpandDepth: number;
+  isError?: boolean;
 }
 
 const JsonNode = memo(
-  ({ data, name, depth = 0, initialExpandDepth }: JsonNodeProps) => {
+  ({ data, name, depth = 0, initialExpandDepth, isError = false }: JsonNodeProps) => {
     const [isExpanded, setIsExpanded] = useState(depth < initialExpandDepth);
 
     const getDataType = (value: JsonValue): string => {
@@ -133,7 +137,8 @@ const JsonNode = memo(
       boolean: "text-amber-600",
       null: "text-purple-600",
       undefined: "text-gray-600",
-      string: "text-green-600 break-all whitespace-pre-wrap",
+      string: "text-green-600 group-hover:text-green-500",
+      error: "text-red-600 group-hover:text-red-500",
       default: "text-gray-700",
     };
 
@@ -236,7 +241,7 @@ const JsonNode = memo(
                 {name}:
               </span>
             )}
-            <pre className={typeStyleMap.string}>"{value}"</pre>
+            <pre className={clsx(typeStyleMap.string, "break-all whitespace-pre-wrap")}>"{value}"</pre>
           </div>
         );
       }
@@ -250,8 +255,8 @@ const JsonNode = memo(
           )}
           <pre
             className={clsx(
-              typeStyleMap.string,
-              "cursor-pointer group-hover:text-green-500",
+              isError ? typeStyleMap.error : typeStyleMap.string,
+              "cursor-pointer break-all whitespace-pre-wrap",
             )}
             onClick={() => setIsExpanded(!isExpanded)}
             title={isExpanded ? "Click to collapse" : "Click to expand"}

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -66,11 +66,11 @@ const ToolsTab = ({
       return (
         <>
           <h4 className="font-semibold mb-2">
-            Tool Result: {isError ? "Error" : "Success"}
+            Tool Result: {isError ? <span className="text-red-600 font-semibold">Error</span> : <span className="text-green-600 font-semibold">Success</span>}
           </h4>
           {structuredResult.content.map((item, index) => (
             <div key={index} className="mb-2">
-              {item.type === "text" && <JsonView data={item.text} />}
+              {item.type === "text" && <JsonView data={item.text} isError={isError}/>}
               {item.type === "image" && (
                 <img
                   src={`data:${item.mimeType};base64,${item.data}`}

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -66,11 +66,18 @@ const ToolsTab = ({
       return (
         <>
           <h4 className="font-semibold mb-2">
-            Tool Result: {isError ? <span className="text-red-600 font-semibold">Error</span> : <span className="text-green-600 font-semibold">Success</span>}
+            Tool Result:{" "}
+            {isError ? (
+              <span className="text-red-600 font-semibold">Error</span>
+            ) : (
+              <span className="text-green-600 font-semibold">Success</span>
+            )}
           </h4>
           {structuredResult.content.map((item, index) => (
             <div key={index} className="mb-2">
-              {item.type === "text" && <JsonView data={item.text} isError={isError}/>}
+              {item.type === "text" && (
+                <JsonView data={item.text} isError={isError} />
+              )}
               {item.type === "image" && (
                 <img
                   src={`data:${item.mimeType};base64,${item.data}`}


### PR DESCRIPTION
This is the PR for the issue  #252  addressing the highlight tool errors.

<img width="1727" alt="Tool error highlighted" src="https://github.com/user-attachments/assets/124ca2af-f5f8-4265-85a0-7c2d45d52dd9" />

##

<img width="1728" alt="Tool success highlighted" src="https://github.com/user-attachments/assets/76fd9f48-9f52-4655-a460-909b5b7bc4eb" />


## Motivation and Context
This enhancement aims on highlighting the tool error. It was green text that has been displayed while tool error occurs. Now added a conditional check to highlight tool `error` in `red` and tool `success` in `green`.

## How Has This Been Tested?
Tested connecting with variety of servers -` server-everything` and `my-test-local-server`
- [x] Tested the tool error ui which appears and highlighted in `red` color
- [x] Tested the tool success ui which appears and highlighted in `green` color
- [x] Tested the history  JsonView not affected by these ui changes
- [x] Tested the prompt JsonView not affected by these ui changes
- [x] Tested the history JsonView not afftected by these ui changes
- [x] Tested the sampling JsonView not affected by these ui changes

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
The `isError` prop can utilized across various tabs to change the color of the string. 
