### PR TITLE
feat: 🎸 Add clear button for error notifications

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -467,6 +467,10 @@ const App = () => {
     setLogLevel(level);
   };
 
+  const clearStdErrNotifications = () => {
+    setStdErrNotifications([]);
+  };
+
   if (window.location.pathname === "/oauth/callback") {
     const OAuthCallback = React.lazy(
       () => import("./components/OAuthCallback"),
@@ -502,6 +506,7 @@ const App = () => {
         logLevel={logLevel}
         sendLogLevelRequest={sendLogLevelRequest}
         loggingSupported={!!serverCapabilities?.logging || false}
+        clearStdErrNotifications={clearStdErrNotifications}
       />
       <div className="flex-1 flex flex-col overflow-hidden">
         <div className="flex-1 overflow-auto">

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -54,6 +54,7 @@ interface SidebarProps {
   onConnect: () => void;
   onDisconnect: () => void;
   stdErrNotifications: StdErrNotification[];
+  clearStdErrNotifications: () => void;
   logLevel: LoggingLevel;
   sendLogLevelRequest: (level: LoggingLevel) => void;
   loggingSupported: boolean;
@@ -78,6 +79,7 @@ const Sidebar = ({
   onConnect,
   onDisconnect,
   stdErrNotifications,
+  clearStdErrNotifications,
   logLevel,
   sendLogLevelRequest,
   loggingSupported,
@@ -470,9 +472,19 @@ const Sidebar = ({
             {stdErrNotifications.length > 0 && (
               <>
                 <div className="mt-4 border-t border-gray-200 pt-4">
-                  <h3 className="text-sm font-medium">
-                    Error output from MCP server
-                  </h3>
+                  <div className="flex justify-between items-center">
+                    <h3 className="text-sm font-medium">
+                      Error output from MCP server
+                    </h3>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={clearStdErrNotifications}
+                      className="h-8 px-2"
+                    >
+                      Clear
+                    </Button>
+                  </div>
                   <div className="mt-2 max-h-80 overflow-y-auto">
                     {stdErrNotifications.map((notification, index) => (
                       <div

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -29,6 +29,7 @@ describe("Sidebar Environment Variables", () => {
     onConnect: jest.fn(),
     onDisconnect: jest.fn(),
     stdErrNotifications: [],
+    clearStdErrNotifications: jest.fn(),
     logLevel: "info" as const,
     sendLogLevelRequest: jest.fn(),
     loggingSupported: true,


### PR DESCRIPTION
Add clear button for error notifications in MCP Inspector

## Motivation and Context
Currently, there's no way to clear error notifications in the MCP Inspector UI, which can lead to a cluttered interface especially during long debugging sessions. This feature adds a clear button that allows users to remove all error notifications when they are no longer needed, improving the overall user experience.

## How Has This Been Tested?
- Tested in local development environment with MCP Inspector
- Verified clear functionality works with both single and multiple error notifications
- Tested button UI appearance in both light and dark themes
- Verified state management properly clears all notifications

## Breaking Changes
No breaking changes. This is a purely additive UI feature that doesn't affect existing functionality.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
- Implemented through prop drilling pattern from App to Sidebar component
- State management handled through React useState hook in App component
- Button positioned next to error output title for intuitive UX