### PR TITLE
fix: missing condition for lengthy strings

### DIFF
--- a/client/src/components/JsonView.tsx
+++ b/client/src/components/JsonView.tsx
@@ -227,7 +227,7 @@ const JsonNode = memo(
             )}
             <pre
               className={clsx(
-                typeStyleMap.string,
+                isError ? typeStyleMap.error : typeStyleMap.string,
                 "break-all whitespace-pre-wrap",
               )}
             >


### PR DESCRIPTION
Tool error not highlighted for lengthy strings. This PR fixes #299 

## Motivation and Context
When I was testing the sample LLM tool found that the tool error not being highlighted due to the missing condition in the lengthy strings.

<img width="1708" alt="Screenshot 2025-04-12 at 5 52 15 PM" src="https://github.com/user-attachments/assets/85e57ef2-a6f6-41fa-88b3-66c7d1d5a896" />


## How Has This Been Tested?
- Tested the sample LLM tool call and made sure the error is highlighted 
- Tested the normal tool calls flow with server-everything

## Breaking Changes
There are no breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
This is bug is related to the enhancement #275 
