### PR TITLE
Fix: Store auth tokens with server-specific keys

### DIFF
--- a/client/src/components/OAuthCallback.tsx
+++ b/client/src/components/OAuthCallback.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { authProvider } from "../lib/auth";
+import { InspectorOAuthClientProvider } from "../lib/auth";
 import { SESSION_KEYS } from "../lib/constants";
 import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
 
@@ -25,7 +25,10 @@ const OAuthCallback = () => {
       }
 
       try {
-        const result = await auth(authProvider, {
+        // Create an auth provider with the current server URL
+        const serverAuthProvider = new InspectorOAuthClientProvider(serverUrl);
+
+        const result = await auth(serverAuthProvider, {
           serverUrl,
           authorizationCode: code,
         });

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -5,9 +5,14 @@ import {
   OAuthTokens,
   OAuthTokensSchema,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
-import { SESSION_KEYS } from "./constants";
+import { SESSION_KEYS, getServerSpecificKey } from "./constants";
 
-class InspectorOAuthClientProvider implements OAuthClientProvider {
+export class InspectorOAuthClientProvider implements OAuthClientProvider {
+  constructor(private serverUrl: string) {
+    // Save the server URL to session storage
+    sessionStorage.setItem(SESSION_KEYS.SERVER_URL, serverUrl);
+  }
+
   get redirectUrl() {
     return window.location.origin + "/oauth/callback";
   }
@@ -24,7 +29,11 @@ class InspectorOAuthClientProvider implements OAuthClientProvider {
   }
 
   async clientInformation() {
-    const value = sessionStorage.getItem(SESSION_KEYS.CLIENT_INFORMATION);
+    const key = getServerSpecificKey(
+      SESSION_KEYS.CLIENT_INFORMATION,
+      this.serverUrl,
+    );
+    const value = sessionStorage.getItem(key);
     if (!value) {
       return undefined;
     }
@@ -33,14 +42,16 @@ class InspectorOAuthClientProvider implements OAuthClientProvider {
   }
 
   saveClientInformation(clientInformation: OAuthClientInformation) {
-    sessionStorage.setItem(
+    const key = getServerSpecificKey(
       SESSION_KEYS.CLIENT_INFORMATION,
-      JSON.stringify(clientInformation),
+      this.serverUrl,
     );
+    sessionStorage.setItem(key, JSON.stringify(clientInformation));
   }
 
   async tokens() {
-    const tokens = sessionStorage.getItem(SESSION_KEYS.TOKENS);
+    const key = getServerSpecificKey(SESSION_KEYS.TOKENS, this.serverUrl);
+    const tokens = sessionStorage.getItem(key);
     if (!tokens) {
       return undefined;
     }
@@ -49,7 +60,8 @@ class InspectorOAuthClientProvider implements OAuthClientProvider {
   }
 
   saveTokens(tokens: OAuthTokens) {
-    sessionStorage.setItem(SESSION_KEYS.TOKENS, JSON.stringify(tokens));
+    const key = getServerSpecificKey(SESSION_KEYS.TOKENS, this.serverUrl);
+    sessionStorage.setItem(key, JSON.stringify(tokens));
   }
 
   redirectToAuthorization(authorizationUrl: URL) {
@@ -57,11 +69,19 @@ class InspectorOAuthClientProvider implements OAuthClientProvider {
   }
 
   saveCodeVerifier(codeVerifier: string) {
-    sessionStorage.setItem(SESSION_KEYS.CODE_VERIFIER, codeVerifier);
+    const key = getServerSpecificKey(
+      SESSION_KEYS.CODE_VERIFIER,
+      this.serverUrl,
+    );
+    sessionStorage.setItem(key, codeVerifier);
   }
 
   codeVerifier() {
-    const verifier = sessionStorage.getItem(SESSION_KEYS.CODE_VERIFIER);
+    const key = getServerSpecificKey(
+      SESSION_KEYS.CODE_VERIFIER,
+      this.serverUrl,
+    );
+    const verifier = sessionStorage.getItem(key);
     if (!verifier) {
       throw new Error("No code verifier saved for session");
     }
@@ -69,5 +89,3 @@ class InspectorOAuthClientProvider implements OAuthClientProvider {
     return verifier;
   }
 }
-
-export const authProvider = new InspectorOAuthClientProvider();

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -8,6 +8,15 @@ export const SESSION_KEYS = {
   CLIENT_INFORMATION: "mcp_client_information",
 } as const;
 
+// Generate server-specific session storage keys
+export const getServerSpecificKey = (
+  baseKey: string,
+  serverUrl?: string,
+): string => {
+  if (!serverUrl) return baseKey;
+  return `[${serverUrl}] ${baseKey}`;
+};
+
 export type ConnectionStatus =
   | "disconnected"
   | "connected"

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -45,9 +45,9 @@ jest.mock("@/hooks/use-toast", () => ({
 
 // Mock the auth provider
 jest.mock("../../auth", () => ({
-  authProvider: {
+  InspectorOAuthClientProvider: jest.fn().mockImplementation(() => ({
     tokens: jest.fn().mockResolvedValue({ access_token: "mock-token" }),
-  },
+  })),
 }));
 
 describe("useConnection", () => {


### PR DESCRIPTION
This PR adds server-specific storage for auth tokens and client information in sessionStorage.

## Problem
When changing the server URL in the sidebar, the client would try to use client information and access tokens from the previously configured server, causing auth errors.

## Fix
- Created a helper function  to prefix storage keys with server URL
- Refactored  to require a server URL as a constructor parameter
- Updated components to create provider instances with their specific server URL
- Fixed tests to work with the new implementation

This ensures that tokens and client information are properly isolated between different servers.
