### PR TITLE
fix: console warning in sidebar

### DIFF
--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -522,7 +522,9 @@ const Sidebar = ({
                   </SelectTrigger>
                   <SelectContent>
                     {Object.values(LoggingLevelSchema.enum).map((level) => (
-                      <SelectItem key={level} value={level}>{level}</SelectItem>
+                      <SelectItem key={level} value={level}>
+                        {level}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -522,7 +522,7 @@ const Sidebar = ({
                   </SelectTrigger>
                   <SelectContent>
                     {Object.values(LoggingLevelSchema.enum).map((level) => (
-                      <SelectItem value={level}>{level}</SelectItem>
+                      <SelectItem key={level} value={level}>{level}</SelectItem>
                     ))}
                   </SelectContent>
                 </Select>


### PR DESCRIPTION
This PR fixes the **console warning** in sidebar in logging level select element. Added key attribute in the select element to fix this

<img width="1728" alt="Screenshot 2025-04-14 at 11 41 46 PM" src="https://github.com/user-attachments/assets/024f85a4-3575-4414-80d9-b7c773fc4916" />


## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This solves the console warning associated with the sidebar  logging level select element.

## How Has This Been Tested?
Tested in the browser console

![Screenshot 2025-04-16 at 12 00 32 PM](https://github.com/user-attachments/assets/0798fa13-a56e-4089-898f-a14a2f4080ff)


## Breaking Changes
There are no breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
