### PR TITLE
feat - Display section reset on clear button hit

### DIFF
--- a/client/src/components/PromptsTab.tsx
+++ b/client/src/components/PromptsTab.tsx
@@ -89,7 +89,10 @@ const PromptsTab = ({
         <ListPane
           items={prompts}
           listItems={listPrompts}
-          clearItems={clearPrompts}
+          clearItems={() => {
+            clearPrompts();
+            setSelectedPrompt(null);
+          }}
           setSelectedItem={(prompt) => {
             setSelectedPrompt(prompt);
             setPromptArgs({});

--- a/client/src/components/PromptsTab.tsx
+++ b/client/src/components/PromptsTab.tsx
@@ -43,7 +43,7 @@ const PromptsTab = ({
   clearPrompts: () => void;
   getPrompt: (name: string, args: Record<string, string>) => void;
   selectedPrompt: Prompt | null;
-  setSelectedPrompt: (prompt: Prompt) => void;
+  setSelectedPrompt: (prompt: Prompt | null) => void;
   handleCompletion: (
     ref: PromptReference | ResourceReference,
     argName: string,

--- a/client/src/components/ResourcesTab.tsx
+++ b/client/src/components/ResourcesTab.tsx
@@ -104,7 +104,6 @@ const ResourcesTab = ({
     if (selectedTemplate) {
       const uri = fillTemplate(selectedTemplate.uriTemplate, templateValues);
       readResource(uri);
-      setSelectedTemplate(null);
       // We don't have the full Resource object here, so we create a partial one
       setSelectedResource({ uri, name: uri } as Resource);
     }
@@ -116,7 +115,13 @@ const ResourcesTab = ({
         <ListPane
           items={resources}
           listItems={listResources}
-          clearItems={clearResources}
+          clearItems={() => {
+            clearResources();
+            // Condition to check if selected resource is not resource template's resource
+            if (!selectedTemplate) {
+              setSelectedResource(null);
+            }
+          }}
           setSelectedItem={(resource) => {
             setSelectedResource(resource);
             readResource(resource.uri);
@@ -139,7 +144,14 @@ const ResourcesTab = ({
         <ListPane
           items={resourceTemplates}
           listItems={listResourceTemplates}
-          clearItems={clearResourceTemplates}
+          clearItems={() => {
+            clearResourceTemplates();
+            // Condition to check if selected resource is resource template's resource
+            if (selectedTemplate) {
+              setSelectedResource(null);
+            }
+            setSelectedTemplate(null);
+          }}
           setSelectedItem={(template) => {
             setSelectedTemplate(template);
             setSelectedResource(null);


### PR DESCRIPTION
This PR closes #301 

## Motivation and Context
There is no way we can get the right sections cleared out once a selection has been made on the `Resources` and `Prompts` tabs. It takes a inspector restart to get them back to initial state.
This PR resets the display section on the right side when `Clear` button is hit.
Attaching the below video for reference of what was fixed in this PR.

https://github.com/user-attachments/assets/f1d4d50f-3468-436e-84ac-d70028e11e25

## How Has This Been Tested?
- Running test cases were successful. 
- Tested if the change has any negative impact on the respective `Resources` and `Prompts` tab and tested flows in other tabs as well. 

## Breaking Changes
There are no breaking changes in this PR

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
