### PR TITLE
feat(client): add search param configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:8787
 http://localhost:6274/?transport=stdio&serverCommand=npx&serverArgs=arg1%20arg2
 ```
 
+You can also set initial config settings via query params, for example:
+
+```
+http://localhost:6274/?MCP_SERVER_REQUEST_TIMEOUT=10000&MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS=false&MCP_PROXY_FULL_ADDRESS=http://10.1.1.22:5577
+```
+
 Note that if both the query param and the corresponding localStorage item are set, the query param will take precedence.
 
 ### From this repository

--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ Example server configuration file:
 }
 ```
 
+You can also set the initial `transport` type, `serverUrl`, `serverCommand`, and `serverArgs` via query params, for example:
+
+```
+http://localhost:6274/?transport=sse&serverUrl=http://localhost:8787/sse
+http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:8787/mcp
+http://localhost:6274/?transport=stdio&serverCommand=npx&serverArgs=arg1%20arg2
+```
+
+Note that if both the query param and the corresponding localStorage item are set, the query param will take precedence.
+
 ### From this repository
 
 If you're working on the inspector itself:

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -49,7 +49,6 @@ import RootsTab from "./components/RootsTab";
 import SamplingTab, { PendingRequest } from "./components/SamplingTab";
 import Sidebar from "./components/Sidebar";
 import ToolsTab from "./components/ToolsTab";
-import { DEFAULT_INSPECTOR_CONFIG } from "./lib/constants";
 import { InspectorConfig } from "./lib/configurationTypes";
 import {
   getMCPProxyAddress,
@@ -57,6 +56,7 @@ import {
   getInitialTransportType,
   getInitialCommand,
   getInitialArgs,
+  initializeInspectorConfig,
 } from "./utils/configUtils";
 
 const CONFIG_LOCAL_STORAGE_KEY = "inspectorConfig_v1";
@@ -92,27 +92,9 @@ const App = () => {
   const [roots, setRoots] = useState<Root[]>([]);
   const [env, setEnv] = useState<Record<string, string>>({});
 
-  const [config, setConfig] = useState<InspectorConfig>(() => {
-    const savedConfig = localStorage.getItem(CONFIG_LOCAL_STORAGE_KEY);
-    if (savedConfig) {
-      // merge default config with saved config
-      const mergedConfig = {
-        ...DEFAULT_INSPECTOR_CONFIG,
-        ...JSON.parse(savedConfig),
-      } as InspectorConfig;
-
-      // update description of keys to match the new description (in case of any updates to the default config description)
-      Object.entries(mergedConfig).forEach(([key, value]) => {
-        mergedConfig[key as keyof InspectorConfig] = {
-          ...value,
-          label: DEFAULT_INSPECTOR_CONFIG[key as keyof InspectorConfig].label,
-        };
-      });
-
-      return mergedConfig;
-    }
-    return DEFAULT_INSPECTOR_CONFIG;
-  });
+  const [config, setConfig] = useState<InspectorConfig>(() =>
+    initializeInspectorConfig(CONFIG_LOCAL_STORAGE_KEY),
+  );
   const [bearerToken, setBearerToken] = useState<string>(() => {
     return localStorage.getItem("lastBearerToken") || "";
   });

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -51,7 +51,13 @@ import Sidebar from "./components/Sidebar";
 import ToolsTab from "./components/ToolsTab";
 import { DEFAULT_INSPECTOR_CONFIG } from "./lib/constants";
 import { InspectorConfig } from "./lib/configurationTypes";
-import { getMCPProxyAddress } from "./utils/configUtils";
+import {
+  getMCPProxyAddress,
+  getInitialSseUrl,
+  getInitialTransportType,
+  getInitialCommand,
+  getInitialArgs,
+} from "./utils/configUtils";
 
 const CONFIG_LOCAL_STORAGE_KEY = "inspectorConfig_v1";
 
@@ -71,26 +77,13 @@ const App = () => {
     prompts: null,
     tools: null,
   });
-  const [command, setCommand] = useState<string>(() => {
-    return localStorage.getItem("lastCommand") || "mcp-server-everything";
-  });
-  const [args, setArgs] = useState<string>(() => {
-    return localStorage.getItem("lastArgs") || "";
-  });
+  const [command, setCommand] = useState<string>(getInitialCommand);
+  const [args, setArgs] = useState<string>(getInitialArgs);
 
-  const [sseUrl, setSseUrl] = useState<string>(() => {
-    return localStorage.getItem("lastSseUrl") || "http://localhost:3001/sse";
-  });
+  const [sseUrl, setSseUrl] = useState<string>(getInitialSseUrl);
   const [transportType, setTransportType] = useState<
     "stdio" | "sse" | "streamable-http"
-  >(() => {
-    return (
-      (localStorage.getItem("lastTransportType") as
-        | "stdio"
-        | "sse"
-        | "streamable-http") || "stdio"
-    );
-  });
+  >(getInitialTransportType);
   const [logLevel, setLogLevel] = useState<LoggingLevel>("debug");
   const [notifications, setNotifications] = useState<ServerNotification[]>([]);
   const [stdErrNotifications, setStdErrNotifications] = useState<

--- a/client/src/utils/configUtils.ts
+++ b/client/src/utils/configUtils.ts
@@ -1,5 +1,8 @@
 import { InspectorConfig } from "@/lib/configurationTypes";
-import { DEFAULT_MCP_PROXY_LISTEN_PORT } from "@/lib/constants";
+import {
+  DEFAULT_MCP_PROXY_LISTEN_PORT,
+  DEFAULT_INSPECTOR_CONFIG,
+} from "@/lib/constants";
 
 export const getMCPProxyAddress = (config: InspectorConfig): string => {
   const proxyFullAddress = config.MCP_PROXY_FULL_ADDRESS.value as string;
@@ -66,4 +69,58 @@ export const getInitialArgs = (): string => {
   const param = getSearchParam("serverArgs");
   if (param) return param;
   return localStorage.getItem("lastArgs") || "";
+};
+
+// Returns a map of config key -> value from query params if present
+export const getConfigOverridesFromQueryParams = (
+  defaultConfig: InspectorConfig,
+): Partial<InspectorConfig> => {
+  const url = new URL(window.location.href);
+  const overrides: Partial<InspectorConfig> = {};
+  for (const key of Object.keys(defaultConfig)) {
+    const param = url.searchParams.get(key);
+    if (param !== null) {
+      // Try to coerce to correct type based on default value
+      const defaultValue = defaultConfig[key as keyof InspectorConfig].value;
+      let value: string | number | boolean = param;
+      if (typeof defaultValue === "number") {
+        value = Number(param);
+      } else if (typeof defaultValue === "boolean") {
+        value = param === "true";
+      }
+      overrides[key as keyof InspectorConfig] = {
+        ...defaultConfig[key as keyof InspectorConfig],
+        value,
+      };
+    }
+  }
+  return overrides;
+};
+
+export const initializeInspectorConfig = (
+  localStorageKey: string,
+): InspectorConfig => {
+  const savedConfig = localStorage.getItem(localStorageKey);
+  let baseConfig: InspectorConfig;
+  if (savedConfig) {
+    // merge default config with saved config
+    const mergedConfig = {
+      ...DEFAULT_INSPECTOR_CONFIG,
+      ...JSON.parse(savedConfig),
+    } as InspectorConfig;
+
+    // update description of keys to match the new description (in case of any updates to the default config description)
+    for (const [key, value] of Object.entries(mergedConfig)) {
+      mergedConfig[key as keyof InspectorConfig] = {
+        ...value,
+        label: DEFAULT_INSPECTOR_CONFIG[key as keyof InspectorConfig].label,
+      };
+    }
+    baseConfig = mergedConfig;
+  } else {
+    baseConfig = DEFAULT_INSPECTOR_CONFIG;
+  }
+  // Apply query param overrides
+  const overrides = getConfigOverridesFromQueryParams(DEFAULT_INSPECTOR_CONFIG);
+  return { ...baseConfig, ...overrides };
 };

--- a/client/src/utils/configUtils.ts
+++ b/client/src/utils/configUtils.ts
@@ -24,3 +24,46 @@ export const getMCPServerRequestMaxTotalTimeout = (
 ): number => {
   return config.MCP_REQUEST_MAX_TOTAL_TIMEOUT.value as number;
 };
+
+const getSearchParam = (key: string): string | null => {
+  try {
+    const url = new URL(window.location.href);
+    return url.searchParams.get(key);
+  } catch {
+    return null;
+  }
+};
+
+export const getInitialTransportType = ():
+  | "stdio"
+  | "sse"
+  | "streamable-http" => {
+  const param = getSearchParam("transport");
+  if (param === "stdio" || param === "sse" || param === "streamable-http") {
+    return param;
+  }
+  return (
+    (localStorage.getItem("lastTransportType") as
+      | "stdio"
+      | "sse"
+      | "streamable-http") || "stdio"
+  );
+};
+
+export const getInitialSseUrl = (): string => {
+  const param = getSearchParam("serverUrl");
+  if (param) return param;
+  return localStorage.getItem("lastSseUrl") || "http://localhost:3001/sse";
+};
+
+export const getInitialCommand = (): string => {
+  const param = getSearchParam("serverCommand");
+  if (param) return param;
+  return localStorage.getItem("lastCommand") || "mcp-server-everything";
+};
+
+export const getInitialArgs = (): string => {
+  const param = getSearchParam("serverArgs");
+  if (param) return param;
+  return localStorage.getItem("lastArgs") || "";
+};


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

I plan to use this in my workshops about MCPs and in my workshop environment I want to have an iframe of the inspector. Each exercise has a different URL for the MCP server for that exercise so having the URL of the config coming from the URL can be quite helpful.

## How Has This Been Tested?

✅ Yes

https://github.com/user-attachments/assets/7e8acbf3-13e7-4934-900c-73665c17fd49

## Breaking Changes

✅ No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally (probably, I did this in the github editor and tested it by manually modifying the code in node_modules 😅)
- [x] I have added appropriate error handling (I handle errors just as well as the existing code does 😅)
- [x] I have added or updated documentation as needed

## Additional context

My current WIP workshop repo can be found here: https://github.com/epicweb-dev/mcp-fundamentals