### PR TITLE
fix - Reset Prompt results

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -647,6 +647,7 @@ const App = () => {
                       setSelectedPrompt={(prompt) => {
                         clearError("prompts");
                         setSelectedPrompt(prompt);
+                        setPromptContent("");
                       }}
                       handleCompletion={handleCompletion}
                       completionsSupported={completionsSupported}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This PR is to fix a `reset error` in `prompts tab` where prompt results weren't reset when switching between prompts. 
With this fix, the results will be reset and rightly populated every time on selecting a new prompt.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Prompt results were not reset when switching between prompts. 
This results in confusion since the previously selected prompt's result always stays and never gets reset unless user hits refresh.
The below is the reset error observed in the `Prompts` tab.

https://github.com/user-attachments/assets/e88387a5-3617-4553-82b6-b2fc1a92ee65


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Tested by switching between prompts, hitting clear button and observed the previous results to be reset and current results to be rightly populated. 
- Ran local test cases successfully

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
This PR doesn't include any breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

