### PR TITLE
Fix support for streamable-http connections

### DIFF
--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   preset: "ts-jest",
-  testEnvironment: "jsdom",
+  testEnvironment: "jest-fixed-jsdom",
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
     "\\.css$": "<rootDir>/src/__mocks__/styleMock.js",

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -278,15 +278,26 @@ export function useConnection({
       setConnectionStatus("error-connecting-to-proxy");
       return;
     }
-    const mcpProxyServerUrl = new URL(`${getMCPProxyAddress(config)}/sse`);
-    mcpProxyServerUrl.searchParams.append("transportType", transportType);
-    if (transportType === "stdio") {
-      mcpProxyServerUrl.searchParams.append("command", command);
-      mcpProxyServerUrl.searchParams.append("args", args);
-      mcpProxyServerUrl.searchParams.append("env", JSON.stringify(env));
-    } else {
-      mcpProxyServerUrl.searchParams.append("url", sseUrl);
+    let mcpProxyServerUrl;
+    switch (transportType) {
+      case "stdio":
+        mcpProxyServerUrl = new URL(`${getMCPProxyAddress(config)}/stdio`);
+        mcpProxyServerUrl.searchParams.append("command", command);
+        mcpProxyServerUrl.searchParams.append("args", args);
+        mcpProxyServerUrl.searchParams.append("env", JSON.stringify(env));
+        break;
+      case "sse":
+        mcpProxyServerUrl = new URL(`${getMCPProxyAddress(config)}/sse`);
+        mcpProxyServerUrl.searchParams.append("url", sseUrl);
+        break;
+
+      case "streamable-http":
+        mcpProxyServerUrl = new URL(`${getMCPProxyAddress(config)}/mcp`);
+        mcpProxyServerUrl.searchParams.append("url", sseUrl);
+        break;
     }
+    (mcpProxyServerUrl as URL).searchParams.append("transportType", transportType);
+
 
     try {
       // Inject auth manually instead of using SSEClientTransport, because we're
@@ -304,7 +315,7 @@ export function useConnection({
         headers[authHeaderName] = `Bearer ${token}`;
       }
 
-      const clientTransport = new SSEClientTransport(mcpProxyServerUrl, {
+      const clientTransport = new SSEClientTransport(mcpProxyServerUrl as URL, {
         eventSourceInit: {
           fetch: (url, init) => fetch(url, { ...init, headers }),
         },

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -296,8 +296,10 @@ export function useConnection({
         mcpProxyServerUrl.searchParams.append("url", sseUrl);
         break;
     }
-    (mcpProxyServerUrl as URL).searchParams.append("transportType", transportType);
-
+    (mcpProxyServerUrl as URL).searchParams.append(
+      "transportType",
+      transportType,
+    );
 
     try {
       // Inject auth manually instead of using SSEClientTransport, because we're

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^22.7.5",
         "@types/shell-quote": "^1.7.5",
+        "jest-fixed-jsdom": "^0.0.9",
         "prettier": "3.3.3",
         "typescript": "^5.4.2"
       }
@@ -5356,6 +5357,19 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-fixed-jsdom": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/jest-fixed-jsdom/-/jest-fixed-jsdom-0.0.9.tgz",
+      "integrity": "sha512-KPfqh2+sn5q2B+7LZktwDcwhCpOpUSue8a1I+BcixWLOQoEVyAjAGfH+IYZGoxZsziNojoHGRTC8xRbB1wDD4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "jest-environment-jsdom": ">=28.0.0"
       }
     },
     "node_modules/jest-get-type": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@modelcontextprotocol/inspector-cli": "^0.10.2",
         "@modelcontextprotocol/inspector-client": "^0.10.2",
         "@modelcontextprotocol/inspector-server": "^0.10.2",
-        "@modelcontextprotocol/sdk": "^1.10.0",
+        "@modelcontextprotocol/sdk": "^1.10.2",
         "concurrently": "^9.0.1",
         "shell-quote": "^1.8.2",
         "spawn-rx": "^5.1.2",
@@ -37,7 +37,7 @@
     },
     "cli": {
       "name": "@modelcontextprotocol/inspector-cli",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",
@@ -58,7 +58,7 @@
     },
     "client": {
       "name": "@modelcontextprotocol/inspector-client",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",
@@ -1399,9 +1399,9 @@
       "link": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.0.tgz",
-      "integrity": "sha512-wijOavYZfSOADbVM0LA7mrQ17N4IKNdFcfezknCCsZ1Y1KstVWlkDZ5ebcxuQJmqTTxsNjBHLc7it1SV0TBiPg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.2.tgz",
+      "integrity": "sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -8550,7 +8550,7 @@
     },
     "server": {
       "name": "@modelcontextprotocol/inspector-server",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.7.5",
     "@types/shell-quote": "^1.7.5",
+    "jest-fixed-jsdom": "^0.0.9",
     "prettier": "3.3.3",
     "typescript": "^5.4.2"
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@modelcontextprotocol/inspector-cli": "^0.10.2",
     "@modelcontextprotocol/inspector-client": "^0.10.2",
     "@modelcontextprotocol/inspector-server": "^0.10.2",
-    "@modelcontextprotocol/sdk": "^1.10.0",
+    "@modelcontextprotocol/sdk": "^1.10.2",
     "concurrently": "^9.0.1",
     "shell-quote": "^1.8.2",
     "spawn-rx": "^5.1.2",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -98,7 +98,7 @@ const createTransport = async (req: express.Request): Promise<Transport> => {
     return transport;
   } else if (transportType === "streamable-http") {
     const headers: HeadersInit = {
-      Accept: "text/event-stream, application/json"
+      Accept: "text/event-stream, application/json",
     };
 
     for (const key of STREAMABLE_HTTP_HEADERS_PASSTHROUGH) {
@@ -128,7 +128,6 @@ const createTransport = async (req: express.Request): Promise<Transport> => {
 };
 
 let backingServerTransport: Transport | undefined;
-
 
 app.get("/mcp", async (req, res) => {
   try {
@@ -227,7 +226,9 @@ app.get("/stdio", async (req, res) => {
     console.log("Created web app transport");
 
     await webAppTransport.start();
-    (backingServerTransport as StdioClientTransport).stderr!.on("data", (chunk) => {
+    (backingServerTransport as StdioClientTransport).stderr!.on(
+      "data",
+      (chunk) => {
         webAppTransport.send({
           jsonrpc: "2.0",
           method: "notifications/stderr",
@@ -235,7 +236,8 @@ app.get("/stdio", async (req, res) => {
             content: chunk.toString(),
           },
         });
-      });
+      },
+    );
 
     mcpProxy({
       transportToClient: webAppTransport,
@@ -251,7 +253,9 @@ app.get("/stdio", async (req, res) => {
 
 app.get("/sse", async (req, res) => {
   try {
-    console.log("New SSE connection. NOTE: The sse transport is deprecated and has been replaced by streamable-http");
+    console.log(
+      "New SSE connection. NOTE: The sse transport is deprecated and has been replaced by streamable-http",
+    );
 
     try {
       await backingServerTransport?.close();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,7 +22,7 @@ import mcpProxy from "./mcpProxy.js";
 import { randomUUID } from "node:crypto";
 
 const SSE_HEADERS_PASSTHROUGH = ["authorization"];
-const STREAMABLE_HTTP_HEADERS_PASSTHROUGH = ["authorization", "mcp-session-id"];
+const STREAMABLE_HTTP_HEADERS_PASSTHROUGH = ["authorization", "mcp-session-id", "last-event-id"];
 
 const defaultEnvironment = {
   ...getDefaultEnvironment(),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,7 +22,11 @@ import mcpProxy from "./mcpProxy.js";
 import { randomUUID } from "node:crypto";
 
 const SSE_HEADERS_PASSTHROUGH = ["authorization"];
-const STREAMABLE_HTTP_HEADERS_PASSTHROUGH = ["authorization", "mcp-session-id", "last-event-id"];
+const STREAMABLE_HTTP_HEADERS_PASSTHROUGH = [
+  "authorization",
+  "mcp-session-id",
+  "last-event-id",
+];
 
 const defaultEnvironment = {
   ...getDefaultEnvironment(),


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
## Description
* In server/index.js
  - add get/post handlers for /mcp
  - amend console log on SSE connect, with deprecation message
  - add /stdio GET handler and refactored /sse GET handler to not also do stdio. Each transport has its own handler now
  - add required headers to streamable-http request
  - add `mcp-session-id` and `last-event-id` to `STREAMABLE_HTTP_HEADERS_PASSTHROUGH`

* In /client/src/lib/hooks/useConnection.ts
  - in connect function
    - create server url properly based on new transport type.
    
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The [PR that added support for streamable-http servers](https://github.com/modelcontextprotocol/inspector/pull/294) was incomplete, but it actually seemed to work because the proxy server had `/sse` and `/message` endpoints. 

This adds `/mcp` GET/POST endpoint support to the MCP proxy server, and slightly refactors the creation of the transport in the UI.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Locally against stdio, sse, and streamble-http servers

### Streamable HTTP (/mcp)
<img width="1899" alt="mcp-endpooint" src="https://github.com/user-attachments/assets/f35e6315-56b3-4fb0-b21b-a7c183d585b2" />

### Stdio (/stdio + /message)
<img width="1918" alt="Screenshot 2025-04-21 at 11 43 41 AM" src="https://github.com/user-attachments/assets/dd6af08c-5e0a-4e1f-8876-5d4e5a43418f" />

### SSE (/sse + /message)
<img width="1920" alt="Screenshot 2025-04-21 at 11 45 48 AM" src="https://github.com/user-attachments/assets/1dd420e6-9709-41a5-872b-f036dac67455" />


## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Testing streamable-http with [this PR](https://github.com/modelcontextprotocol/servers/pull/1496) on the `everything` server.