### PR TITLE
When argument to a tool is not specified it should not be default and send via MCP request as a NULL value.

### DIFF
--- a/client/src/utils/__tests__/schemaUtils.test.ts
+++ b/client/src/utils/__tests__/schemaUtils.test.ts
@@ -51,13 +51,13 @@ describe("generateDefaultValue", () => {
 
   test("generates null for non-required primitive types", () => {
     expect(generateDefaultValue({ type: "string", required: false })).toBe(
-      null,
+      undefined,
     );
     expect(generateDefaultValue({ type: "number", required: false })).toBe(
-      null,
+      undefined,
     );
     expect(generateDefaultValue({ type: "boolean", required: false })).toBe(
-      null,
+      undefined,
     );
   });
 

--- a/client/src/utils/schemaUtils.ts
+++ b/client/src/utils/schemaUtils.ts
@@ -13,7 +13,7 @@ export function generateDefaultValue(schema: JsonSchemaType): JsonValue {
   if (!schema.required) {
     if (schema.type === "array") return [];
     if (schema.type === "object") return {};
-    return null;
+    return undefined;
   }
 
   switch (schema.type) {


### PR DESCRIPTION
When argument to a tool is not specified it should not be default and send via MCP request as a NULL value.

## Motivation and Context
The tool must be defined so that a parameter is `nullable` in its JSON Schema in order to send a `null` value. If it is not marked as nullable, then `null` should **not** be sent—omit the parameter instead. This avoids schema validation errors and ensures proper behavior with strict clients like TypeScript SDKs.

## How Has This Been Tested?
The [MCP-ODBC](https://github.com/OpenLinkSoftware/mcp-odbc-server) includes tools with optional parameters. These are not nullable by default, and the TypeScript SDK rejects inspector requests when `null` is incorrectly included. This change was tested against that server to confirm that unspecified parameters are properly omitted, and requests are accepted.

## Breaking Changes
No breaking changes. This restores the correct behavior that existed before the regression which introduced `null` defaults for optional parameters.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
