### PR TITLE
Revert "Bump version to 0.11.0"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,8 @@ jobs:
       # - run: npm ci
       - run: npm install --no-package-lock
 
+      - run: npm run build
+
       # TODO: Add --provenance once the repo is public
       - run: npm run publish-all
         env:

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-cli",
-  "version": "0.11.0",
+  "version": "0.10.2",
   "description": "CLI for the Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",
@@ -21,7 +21,7 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.2",
+    "@modelcontextprotocol/sdk": "^1.10.0",
     "commander": "^13.1.0",
     "spawn-rx": "^5.1.2"
   }

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-client",
-  "version": "0.11.0",
+  "version": "0.10.2",
   "description": "Client-side application for the Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",
@@ -23,7 +23,7 @@
     "test:watch": "jest --config jest.config.cjs --watch"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.2",
+    "@modelcontextprotocol/sdk": "^1.10.0",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-dialog": "^1.1.3",
     "@radix-ui/react-icons": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "0.11.0",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/inspector",
-      "version": "0.11.0",
+      "version": "0.10.2",
       "license": "MIT",
       "workspaces": [
         "client",
@@ -14,9 +14,9 @@
         "cli"
       ],
       "dependencies": {
-        "@modelcontextprotocol/inspector-cli": "^0.11.0",
-        "@modelcontextprotocol/inspector-client": "^0.11.0",
-        "@modelcontextprotocol/inspector-server": "^0.11.0",
+        "@modelcontextprotocol/inspector-cli": "^0.10.2",
+        "@modelcontextprotocol/inspector-client": "^0.10.2",
+        "@modelcontextprotocol/inspector-server": "^0.10.2",
         "@modelcontextprotocol/sdk": "^1.10.2",
         "concurrently": "^9.0.1",
         "shell-quote": "^1.8.2",
@@ -38,10 +38,10 @@
     },
     "cli": {
       "name": "@modelcontextprotocol/inspector-cli",
-      "version": "0.11.0",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.10.2",
+        "@modelcontextprotocol/sdk": "^1.10.0",
         "commander": "^13.1.0",
         "spawn-rx": "^5.1.2"
       },
@@ -59,10 +59,10 @@
     },
     "client": {
       "name": "@modelcontextprotocol/inspector-client",
-      "version": "0.11.0",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.10.2",
+        "@modelcontextprotocol/sdk": "^1.10.0",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.3",
         "@radix-ui/react-icons": "^1.3.0",
@@ -8564,10 +8564,10 @@
     },
     "server": {
       "name": "@modelcontextprotocol/inspector-server",
-      "version": "0.11.0",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.10.2",
+        "@modelcontextprotocol/sdk": "^1.10.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "ws": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "0.11.0",
+  "version": "0.10.2",
   "description": "Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",
@@ -38,9 +38,9 @@
     "publish-all": "npm publish --workspaces --access public && npm publish --access public"
   },
   "dependencies": {
-    "@modelcontextprotocol/inspector-cli": "^0.11.0",
-    "@modelcontextprotocol/inspector-client": "^0.11.0",
-    "@modelcontextprotocol/inspector-server": "^0.11.0",
+    "@modelcontextprotocol/inspector-cli": "^0.10.2",
+    "@modelcontextprotocol/inspector-client": "^0.10.2",
+    "@modelcontextprotocol/inspector-server": "^0.10.2",
     "@modelcontextprotocol/sdk": "^1.10.2",
     "concurrently": "^9.0.1",
     "shell-quote": "^1.8.2",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-server",
-  "version": "0.11.0",
+  "version": "0.10.2",
   "description": "Server-side application for the Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",
@@ -27,7 +27,7 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.2",
+    "@modelcontextprotocol/sdk": "^1.10.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "ws": "^8.18.0",


### PR DESCRIPTION
Reverts modelcontextprotocol/inspector#350. Need to add prepare script. Thought it was there, but it apparently wasn't