### PR TITLE
Fix the inspector caching problem

### DIFF
--- a/client/bin/client.js
+++ b/client/bin/client.js
@@ -9,10 +9,34 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const distPath = join(__dirname, "../dist");
 
 const server = http.createServer((request, response) => {
-  return handler(request, response, {
+  const handlerOptions = {
     public: distPath,
     rewrites: [{ source: "/**", destination: "/index.html" }],
-  });
+    headers: [
+      {
+        // Ensure index.html is never cached
+        source: "index.html",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-cache, no-store, max-age=0",
+          },
+        ],
+      },
+      {
+        // Allow long-term caching for hashed assets
+        source: "assets/**",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+    ],
+  };
+
+  return handler(request, response, handlerOptions);
 });
 
 const port = process.env.PORT || 6274;


### PR DESCRIPTION
* In `client/bin/client.js` 
  - in the request handler passed to `createServer`, expand the handler options to include "Cache-Control" header for
    - index.html - "no-cache, no-store, max-age=0"
    - assets/** - "public, max-age=31536000, immutable"

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
I've noticed that on a new version of the inspector, I have to go to the browser's devtools panel and clear site data then reload the page.
* The assets are hashed and immutable, so caching should always be allowed for them
* The index.html file is the problem, because if cached, it will point to old assets, and therefore needs to have caching turned off
* This PR adds appropriate headers to the index.html and assets that are served.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Ran server locally and observed headers sent to the client:
### No caching of index.html
<img width="675" alt="Screenshot 2025-04-30 at 5 20 51 PM" src="https://github.com/user-attachments/assets/91d49a38-e9e8-46ad-8c84-375bb5a1b80e" />

### Allowed caching of hashed .js files
<img width="730" alt="Screenshot 2025-04-30 at 5 20 58 PM" src="https://github.com/user-attachments/assets/af6a0272-cd73-4b5c-be88-a9ab8e7606f2" />

### Allowed caching of hashed .css files
<img width="744" alt="Screenshot 2025-04-30 at 5 38 35 PM" src="https://github.com/user-attachments/assets/4b3f0d56-65fb-4932-9356-08eaa9249cf0" />

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
