### PR TITLE
Fix to the Authorization header bug for Streamable-HTTP

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -335,6 +335,7 @@ export function useConnection({
         transportType === "streamable-http"
           ? new StreamableHTTPClientTransport(mcpProxyServerUrl as URL, {
               sessionId: undefined,
+              ...transportOptions,
             })
           : new SSEClientTransport(mcpProxyServerUrl as URL, transportOptions);
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fixed the Streamable HTTP transport to properly propagate authorization headers by including transport options in the StreamableHTTPClientTransport initialization.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Bug referenced in [369](https://github.com/modelcontextprotocol/inspector/issues/369)

The Streamable HTTP transport was not properly passing authorization headers to the server, resulting in 401 Unauthorized errors. This was happening because the transport options containing the authorization headers were not being passed to the StreamableHTTPClientTransport constructor. This fix ensures that authentication headers are properly propagated through the Streamable HTTP transport, maintaining consistent authentication behavior across all transport types.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
* Tested with a Streamable HTTP connection using bearer token authentication
* Verified that authorization headers are properly passed through to the server
* Confirmed that 401 Unauthorized errors are no longer occurring when valid authentication is provided
* Tested with both default "Authorization" header name and custom header names

Successfully connected after screenshot

<img width="319" alt="Screenshot 2025-04-30 at 10 30 53 PM" src="https://github.com/user-attachments/assets/5a3db62c-ff7d-4b97-8c07-4bfca397f111" />

Logs (after fix)

```
[1] 2025-05-01T05:30:34.803Z router dispatching OPTIONS /mcp?url=https%3A%2F%2Fdevelopment.gateway.cloudmcp.dev%2Fmcp-gateway-test%2Fmcp&transportType=streamable-http
[1] 2025-05-01T05:30:34.803Z router corsMiddleware  : /mcp?url=https%3A%2F%2Fdevelopment.gateway.cloudmcp.dev%2Fmcp-gateway-test%2Fmcp&transportType=streamable-http
[1] 2025-05-01T05:30:34.804Z router dispatching POST /mcp?url=https%3A%2F%2Fdevelopment.gateway.cloudmcp.dev%2Fmcp-gateway-test%2Fmcp&transportType=streamable-http
[1] 2025-05-01T05:30:34.804Z router corsMiddleware  : /mcp?url=https%3A%2F%2Fdevelopment.gateway.cloudmcp.dev%2Fmcp-gateway-test%2Fmcp&transportType=streamable-http
[1] 2025-05-01T05:30:34.804Z router <anonymous>  : /mcp?url=https%3A%2F%2Fdevelopment.gateway.cloudmcp.dev%2Fmcp-gateway-test%2Fmcp&transportType=streamable-http
[1] Received POST message for sessionId f91063e9-35b4-43af-bc32-37c590dfc7a3
[1] 2025-05-01T05:30:34.806Z router dispatching GET /mcp?url=https%3A%2F%2Fdevelopment.gateway.cloudmcp.dev%2Fmcp-gateway-test%2Fmcp&transportType=streamable-http
[1] 2025-05-01T05:30:34.807Z router corsMiddleware  : /mcp?url=https%3A%2F%2Fdevelopment.gateway.cloudmcp.dev%2Fmcp-gateway-test%2Fmcp&transportType=streamable-http
[1] 2025-05-01T05:30:34.807Z router <anonymous>  : /mcp?url=https%3A%2F%2Fdevelopment.gateway.cloudmcp.dev%2Fmcp-gateway-test%2Fmcp&transportType=streamable-http
[1] Received GET message for sessionId f91063e9-35b4-43af-bc32-37c590dfc7a3
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes. This is a bug fix that maintains backward compatibility while fixing the authorization header propagation issue.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed