### PR TITLE
Allow WWW-Authenticate header to be accessed by client

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -44,7 +44,7 @@ const { values } = parseArgs({
 const app = express();
 app.use(cors());
 app.use((req, res, next) => {
-  res.header("Access-Control-Expose-Headers", "mcp-session-id");
+  res.header("Access-Control-Expose-Headers", ["mcp-session-id", "www-authenticate"]);
   next();
 });
 


### PR DESCRIPTION
* In server/src/index.ts
  * Add www-authenticate to Access-Control-Expose-Headers list for responses. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
When a `401 Unauthorized` error is returned from a server, the [`WWW-Authenticate`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/WWW-Authenticate) header should be included in the response, advertising the [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Authentication) methods (or [challenges](https://developer.mozilla.org/en-US/docs/Glossary/Challenge)) that might be used to gain access.

By adding this header name to the [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Expose-Headers) header in the server response, it should tell the browser to expose that header to scripts, so that the client can extract the authentication method or challenge and react appropriately.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Not yet. Looking for an MCP server that returns WWW-Authenticate header on 401. 

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
* This fixes #168
