### PR TITLE
fix: quick oauth flow could not transition to token_request due to missing server metadata

### DIFF
--- a/client/src/components/AuthDebugger.tsx
+++ b/client/src/components/AuthDebugger.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { DebugInspectorOAuthClientProvider } from "../lib/auth";
-import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
+import { auth, discoverOAuthMetadata } from "@modelcontextprotocol/sdk/client/auth.js";
+import { OAuthMetadataSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { AlertCircle } from "lucide-react";
 import { AuthDebuggerState } from "../lib/auth-types";
 import { OAuthFlowProgress } from "./OAuthFlowProgress";
@@ -123,6 +124,14 @@ const AuthDebugger = ({
       const serverAuthProvider = new DebugInspectorOAuthClientProvider(
         serverUrl,
       );
+      // First discover OAuth metadata separately so we can save it
+      const metadata = await discoverOAuthMetadata(serverUrl);
+      if (!metadata) {
+        throw new Error("Failed to discover OAuth metadata");
+      }
+      const parsedMetadata = await OAuthMetadataSchema.parseAsync(metadata);
+      serverAuthProvider.saveServerMetadata(parsedMetadata);
+      
       await auth(serverAuthProvider, { serverUrl: serverUrl });
       updateAuthState({
         statusMessage: {

--- a/client/src/components/__tests__/AuthDebugger.test.tsx
+++ b/client/src/components/__tests__/AuthDebugger.test.tsx
@@ -48,6 +48,7 @@ import {
   registerClient,
   startAuthorization,
   exchangeAuthorization,
+  auth,
 } from "@modelcontextprotocol/sdk/client/auth.js";
 import { OAuthMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
 
@@ -64,6 +65,7 @@ const mockStartAuthorization = startAuthorization as jest.MockedFunction<
 const mockExchangeAuthorization = exchangeAuthorization as jest.MockedFunction<
   typeof exchangeAuthorization
 >;
+const mockAuth = auth as jest.MockedFunction<typeof auth>;
 
 const sessionStorageMock = {
   getItem: jest.fn(),
@@ -185,6 +187,55 @@ describe("AuthDebugger", () => {
             "Please enter a server URL in the sidebar before authenticating",
         },
       });
+    });
+
+    it("should start quick OAuth flow and properly fetch and save metadata", async () => {
+      // Setup the auth mock
+      mockAuth.mockResolvedValue("AUTHORIZED");
+      
+      const updateAuthState = jest.fn();
+      await act(async () => {
+        renderAuthDebugger({ updateAuthState });
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Quick OAuth Flow"));
+      });
+
+      // Should first discover and save OAuth metadata
+      expect(mockDiscoverOAuthMetadata).toHaveBeenCalledWith("https://example.com");
+      
+      // Then should call auth with the server provider
+      expect(mockAuth).toHaveBeenCalled();
+      
+      // Check that updateAuthState was called with the right info message
+      expect(updateAuthState).toHaveBeenCalledWith(expect.objectContaining({
+        statusMessage: {
+          type: "info",
+          message: "Starting OAuth authentication process...",
+        },
+      }));
+    });
+
+    it("should show error when quick OAuth flow fails to discover metadata", async () => {
+      mockDiscoverOAuthMetadata.mockRejectedValue(new Error("Metadata discovery failed"));
+      
+      const updateAuthState = jest.fn();
+      await act(async () => {
+        renderAuthDebugger({ updateAuthState });
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Quick OAuth Flow"));
+      });
+
+      // Check that updateAuthState was called with an error message
+      expect(updateAuthState).toHaveBeenCalledWith(expect.objectContaining({
+        statusMessage: {
+          type: "error",
+          message: expect.stringContaining("Failed to start OAuth flow"),
+        },
+      }));
     });
   });
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
I was testing the new auth debugger and noticed the Quick OAuth Flow would fail to transition due to it missing the server metadata.

Fixed by:

1. Adding explicit metadata discovery before the auth call
2. Saving the metadata to the provider
3. Adding tests for the quick OAuth flow to prevent future regressions

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
