### PR TITLE
Fix connection issue for servers with auth

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -234,7 +234,6 @@ const App = () => {
   const onOAuthConnect = useCallback(
     (serverUrl: string) => {
       setSseUrl(serverUrl);
-      setTransportType("sse");
       setIsAuthDebuggerVisible(false);
       void connectMcpServer();
     },

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -428,19 +428,18 @@ export function useConnection({
           error,
         );
 
-        // Check for auth-related errors
+        const shouldRetry = await handleAuthError(error);
+        if (shouldRetry) {
+          return connect(undefined, retryCount + 1);
+        }
         const is401Error =
           (error instanceof SseError && error.code === 401) ||
           (error instanceof Error && error.message.includes('401')) ||
           (error instanceof Error && error.message.includes('Unauthorized'));
 
         if (is401Error) {
-          console.log("Detected 401 error, attempting OAuth flow");
-          const shouldRetry = await handleAuthError(error);
-          if (shouldRetry) {
-            return connect(undefined, retryCount + 1);
-          }
           // Don't set error state if we're about to redirect for auth
+
           return;
         }
         throw error;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8407,15 +8407,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",

--- a/server/src/mcpProxy.ts
+++ b/server/src/mcpProxy.ts
@@ -1,4 +1,5 @@
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { isJSONRPCRequest } from "@modelcontextprotocol/sdk/types.js";
 
 function onClientError(error: Error) {
   console.error("Error from inspector client:", error);
@@ -19,7 +20,21 @@ export default function mcpProxy({
   let transportToServerClosed = false;
 
   transportToClient.onmessage = (message) => {
-    transportToServer.send(message).catch(onServerError);
+    transportToServer.send(message).catch((error) => {
+      // Send error response back to client if it was a request (has id) and connection is still open
+      if (isJSONRPCRequest(message) && !transportToClientClosed) {
+        const errorResponse = {
+          jsonrpc: "2.0" as const,
+          id: message.id,
+          error: {
+            code: -32001,
+            message: error.message,
+            data: error
+          }
+        };
+        transportToClient.send(errorResponse).catch(onClientError);
+      }
+    });
   };
 
   transportToServer.onmessage = (message) => {


### PR DESCRIPTION
There are multiple reports on bot being able to connect to SSE and Streamable Http with Auth:

https://github.com/modelcontextprotocol/python-sdk/issues/731
https://github.com/modelcontextprotocol/inspector/issues/390
https://github.com/modelcontextprotocol/python-sdk/issues/679

SSE: due to auth provider - described [here](https://github.com/modelcontextprotocol/inspector/issues/390
)

Streamable Http - Auth flow was working fine, but when just clicking on connect, the request was hanging and then just timing out, instead of caching Auth error and re-triggering auth. The issue was that proxy was just masking errors and not returning them back to the client  to be correctly handled during initialization. Unlike SSE, streamable Http does the first request on Initialization phase.


------
```
cd python-sdk/examples/servers/simple-auth 

uv run mcp-simple-auth --transport streamable-http

 uv run mcp-simple-auth --transport sse    
```
Testing: 
Streamable Http Test:
<img width="347" alt="image" src="https://github.com/user-attachments/assets/49a95d69-3390-4ab8-b809-d263dd2ad2de" />
SSE
<img width="160" alt="image" src="https://github.com/user-attachments/assets/79de0d6b-09d2-4817-a423-32df66b48ebb" />

