### PR TITLE
Reverse env variable sourcing order 

### DIFF
--- a/cli/src/transport.ts
+++ b/cli/src/transport.ts
@@ -38,8 +38,8 @@ function createStdioTransport(options: TransportOptions): Transport {
   const defaultEnv = getDefaultEnvironment();
 
   const env: Record<string, string> = {
-    ...processEnv,
     ...defaultEnv,
+    ...processEnv,
   };
 
   const { cmd: actualCommand, args: actualArgs } = findActualExecutable(

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -59,8 +59,8 @@ const createTransport = async (req: express.Request): Promise<Transport> => {
   if (transportType === "stdio") {
     const command = query.command as string;
     const origArgs = shellParseArgs(query.args as string) as string[];
-    const queryEnv = query.env ? JSON.parse(query.env as string) : {};
-    const env = { ...process.env, ...defaultEnvironment, ...queryEnv };
+  const queryEnv = query.env ? JSON.parse(query.env as string) : {};
+  const env = { ...defaultEnvironment, ...process.env, ...queryEnv };
 
     const { cmd, args } = findActualExecutable(command, origArgs);
 


### PR DESCRIPTION
Reverses what overrides what when env variables are being applied.
Note, I am not sure this is actually what we should do, but will share more rationale below.

## Motivation and Context
As noted in [this issue](https://github.com/modelcontextprotocol/inspector/issues/375) , when the PATH is set for the Inspector process, it appears to get overridden with the defaults set by the SDK.

Looking at the order, it seems like it would make more sense to do this the other way around.

## How Has This Been Tested?
Wrote some ad-hoc scripts to test this outside of Inspector, just to verify that my custom PATH was being referenced.  I can add some dedicated testing to the repo if we would like to make sure there aren't any other side effects.

## Breaking Changes
Technically if users are expecting the existing behavior to be correct, then this could break existing usage.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

