### PR TITLE
Fix type issue in Tools Tab that is breaking the build.

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -83,7 +83,7 @@ const ToolsTab = ({
               <span className="text-green-600 font-semibold">Success</span>
             )}
           </h4>
-          {structuredResult.content.map((item, index) => (
+          {structuredResult?.content?.map((item, index) => (
             <div key={index} className="mb-2">
               {item.type === "text" && (
                 <JsonView data={item.text} isError={isError} />

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -10,6 +10,7 @@ import type { JsonValue, JsonSchemaType } from "@/utils/jsonUtils";
 import { generateDefaultValue } from "@/utils/schemaUtils";
 import {
   CallToolResultSchema,
+  CallToolResult,
   CompatibilityCallToolResult,
   ListToolsResult,
   Tool,
@@ -69,7 +70,7 @@ const ToolsTab = ({
           </>
         );
       }
-      const structuredResult = parsedResult.data;
+      const structuredResult = parsedResult.data as CallToolResult;
       const isError = structuredResult.isError ?? false;
 
       return (


### PR DESCRIPTION
In ToolsTab.tsx
- cast `structuredResult` to `CallToolResult`
- add `?` optional property operators to `structuredResult?.content?.map`

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
* Somehow a change has made it in that causes the build to break with the following:

<img width="1145" alt="Screenshot 2025-05-20 at 2 35 02 PM" src="https://github.com/user-attachments/assets/05303cba-7cd2-4af0-b36b-e67a67be82d7" />

* Interestingly, the line that is breaking the build was added six months ago, and it does not break my build locally. 

<img width="1115" alt="Screenshot 2025-05-19 at 1 20 31 PM" src="https://github.com/user-attachments/assets/e0d1c380-55cd-48d7-aa6c-cac63e718edb" />

* At that time, structuredResult was cast as `CallToolResult`  and therefore, it worked, because `content` is a required property of [CallToolUnstructuredResultSchema](https://github.com/modelcontextprotocol/typescript-sdk/blob/3975c1ac793b9a393ff9ebadaf7a3ec4587d3563/src/types.ts#L895) which is a member of the [`CallToolResult`](https://github.com/modelcontextprotocol/typescript-sdk/blob/3975c1ac793b9a393ff9ebadaf7a3ec4587d3563/src/types.ts#L944) union.

<img width="867" alt="Screenshot 2025-05-19 at 1 27 56 PM" src="https://github.com/user-attachments/assets/a4e2fe2b-b234-4cb1-9aff-f14bb9fe4cda" />

* However, since that time, the following commit changed how that constant is created. Now instead of being a `CallToolResult`, it is just parsed JSON, so of course the `content` property could be undefined.

<img width="1230" alt="Screenshot 2025-05-19 at 1 25 03 PM" src="https://github.com/user-attachments/assets/50807119-0172-4dc2-be28-dad55f31b539" />

* This seems an absolutely necessary fix, but it doesn't break my build locally and I wonder how it could have been in the codebase for 3 months without this coming up. Makes me wonder if there are CI changes that somehow cause it to act differently

### The actual problem
* UPDATE: This PR's casting did not fix the problem, instead I had to add optional property operators to the expression.
* I was able to duplicate the problem locally by running `npm install --no-package-lock` so the `package-lock.json` we have seems to have something in it that caused this to happen only in CI. 
* 5 days ago, [this commit](https://github.com/modelcontextprotocol/typescript-sdk/commit/882e0b7d05c95af3ad3736612743dcdfe3e4745b) to the Typescript SDK split `CallToolResult` into structured and unstructured variants, one of which does not have the required content property. 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Local build, test, lint, and manual connection to server and invoking tools and observing results.
<img width="1913" alt="Screenshot 2025-05-20 at 2 53 46 PM" src="https://github.com/user-attachments/assets/086da01b-54c1-4182-bd9b-a1e1935a0111" />

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
