### PR TITLE
[auth debugger] Make the quick flow use the same state machine as the step-by-step flow

### DIFF
--- a/client/src/components/AuthDebugger.tsx
+++ b/client/src/components/AuthDebugger.tsx
@@ -120,7 +120,6 @@ const AuthDebugger = ({
     updateAuthState({ isInitiatingAuth: true, statusMessage: null });
     try {
       // Step through the OAuth flow using the state machine instead of the auth() function
-      // Start with a fresh state and provider
       let currentState: AuthDebuggerState = {
         ...authState,
         oauthStep: "metadata_discovery",
@@ -137,8 +136,6 @@ const AuthDebugger = ({
       // Manually step through each stage of the OAuth flow
       while (currentState.oauthStep !== "complete") {
         await oauthMachine.executeStep(currentState);
-
-        // If we reach the authorization code step, we need to wait for user input
         // In quick mode, we'll just redirect to the authorization URL
         if (
           currentState.oauthStep === "authorization_code" &&
@@ -146,7 +143,7 @@ const AuthDebugger = ({
         ) {
           // Open the authorization URL automatically
           window.location.href = currentState.authorizationUrl;
-          break; // Exit the flow - we'll need user input
+          break;
         }
       }
 

--- a/client/src/components/AuthDebugger.tsx
+++ b/client/src/components/AuthDebugger.tsx
@@ -1,11 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { DebugInspectorOAuthClientProvider } from "../lib/auth";
-import {
-  auth,
-  discoverOAuthMetadata,
-} from "@modelcontextprotocol/sdk/client/auth.js";
-import { OAuthMetadataSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { AlertCircle } from "lucide-react";
 import { AuthDebuggerState } from "../lib/auth-types";
 import { OAuthFlowProgress } from "./OAuthFlowProgress";
@@ -124,22 +119,46 @@ const AuthDebugger = ({
 
     updateAuthState({ isInitiatingAuth: true, statusMessage: null });
     try {
-      const serverAuthProvider = new DebugInspectorOAuthClientProvider(
-        serverUrl,
-      );
-      // First discover OAuth metadata separately so we can save it
-      const metadata = await discoverOAuthMetadata(serverUrl);
-      if (!metadata) {
-        throw new Error("Failed to discover OAuth metadata");
-      }
-      const parsedMetadata = await OAuthMetadataSchema.parseAsync(metadata);
-      serverAuthProvider.saveServerMetadata(parsedMetadata);
+      // Step through the OAuth flow using the state machine instead of the auth() function
+      // Start with a fresh state and provider
+      let currentState: AuthDebuggerState = {
+        ...authState,
+        oauthStep: "metadata_discovery",
+        authorizationUrl: null,
+        latestError: null,
+      };
 
-      await auth(serverAuthProvider, { serverUrl: serverUrl });
+      const oauthMachine = new OAuthStateMachine(serverUrl, (updates) => {
+        // Update our temporary state during the process
+        currentState = { ...currentState, ...updates };
+        // But don't call updateAuthState yet
+      });
+
+      // Manually step through each stage of the OAuth flow
+      while (currentState.oauthStep !== "complete") {
+        await oauthMachine.executeStep(currentState);
+
+        // If we reach the authorization code step, we need to wait for user input
+        // In quick mode, we'll just redirect to the authorization URL
+        if (
+          currentState.oauthStep === "authorization_code" &&
+          currentState.authorizationUrl
+        ) {
+          // Open the authorization URL automatically
+          window.location.href = currentState.authorizationUrl;
+          break; // Exit the flow - we'll need user input
+        }
+      }
+
+      // After the flow completes or reaches a user-input step, update the app state
       updateAuthState({
+        ...currentState,
         statusMessage: {
           type: "info",
-          message: "Starting OAuth authentication process...",
+          message:
+            currentState.oauthStep === "complete"
+              ? "Authentication completed successfully"
+              : "Please complete authentication in the opened window and enter the code",
         },
       });
     } catch (error) {
@@ -153,7 +172,7 @@ const AuthDebugger = ({
     } finally {
       updateAuthState({ isInitiatingAuth: false });
     }
-  }, [serverUrl, updateAuthState]);
+  }, [serverUrl, updateAuthState, authState]);
 
   const handleClearOAuth = useCallback(() => {
     if (serverUrl) {

--- a/client/src/components/__tests__/AuthDebugger.test.tsx
+++ b/client/src/components/__tests__/AuthDebugger.test.tsx
@@ -207,16 +207,10 @@ describe("AuthDebugger", () => {
         "https://example.com",
       );
 
-      // Then should call auth with the server provider
-      expect(mockAuth).toHaveBeenCalled();
-
       // Check that updateAuthState was called with the right info message
       expect(updateAuthState).toHaveBeenCalledWith(
         expect.objectContaining({
-          statusMessage: {
-            type: "info",
-            message: "Starting OAuth authentication process...",
-          },
+          oauthStep: "authorization_code",
         }),
       );
     });


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Previously, the quick flow called `auth` directly, but that prevented us from storing some metadata and displaying it.

This change adjusts the quick flow to use the state machine, so both step by step and quick will use the same code paths.  It also changes the source of the registration metadata in order to be able to display it post-redirect.  We lose react state, but we keep SessionStorage, so this switches to reading from session storage.

There's something else that would be nice which is to have the quick flow continue on after finishing the redirect rather than pausing, but I didn't get to it in this change.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I tested this against the typescript example server

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
