### PR TITLE
Allow multiple instances of the Inspector to connect to the same MCP server

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -48,7 +48,8 @@ app.use((req, res, next) => {
   next();
 });
 
-const webAppTransports: Map<string, Transport> = new Map<string, Transport>(); // Transports by sessionId
+const webAppTransports: Map<string, Transport> = new Map<string, Transport>(); // Web app transports by web app sessionId
+const serverTransports: Map<string, Transport> = new Map<string, Transport>(); // Server Transports by web app sessionId
 
 const createTransport = async (req: express.Request): Promise<Transport> => {
   const query = req.query;
@@ -137,8 +138,6 @@ const createTransport = async (req: express.Request): Promise<Transport> => {
   }
 };
 
-let backingServerTransport: Transport | undefined;
-
 app.get("/mcp", async (req, res) => {
   const sessionId = req.headers["mcp-session-id"] as string;
   console.log(`Received GET message for sessionId ${sessionId}`);
@@ -161,12 +160,12 @@ app.get("/mcp", async (req, res) => {
 app.post("/mcp", async (req, res) => {
   const sessionId = req.headers["mcp-session-id"] as string | undefined;
   console.log(`Received POST message for sessionId ${sessionId}`);
+  let serverTransport: Transport | undefined;
   if (!sessionId) {
     try {
       console.log("New streamable-http connection");
       try {
-        await backingServerTransport?.close();
-        backingServerTransport = await createTransport(req);
+        serverTransport = await createTransport(req);
       } catch (error) {
         if (error instanceof SseError && error.code === 401) {
           console.error(
@@ -180,12 +179,13 @@ app.post("/mcp", async (req, res) => {
         throw error;
       }
 
-      console.log("Connected MCP client to backing server transport");
+      console.log("Connected MCP client to server transport");
 
       const webAppTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: randomUUID,
         onsessioninitialized: (sessionId) => {
           webAppTransports.set(sessionId, webAppTransport);
+          serverTransports.set(sessionId, serverTransport!);
           console.log("Created streamable web app transport " + sessionId);
         },
       });
@@ -194,7 +194,7 @@ app.post("/mcp", async (req, res) => {
 
       mcpProxy({
         transportToClient: webAppTransport,
-        transportToServer: backingServerTransport,
+        transportToServer: serverTransport,
       });
 
       await (webAppTransport as StreamableHTTPServerTransport).handleRequest(
@@ -229,10 +229,9 @@ app.post("/mcp", async (req, res) => {
 app.get("/stdio", async (req, res) => {
   try {
     console.log("New connection");
-
+    let serverTransport: Transport | undefined;
     try {
-      await backingServerTransport?.close();
-      backingServerTransport = await createTransport(req);
+      serverTransport = await createTransport(req);
     } catch (error) {
       if (error instanceof SseError && error.code === 401) {
         console.error(
@@ -250,26 +249,24 @@ app.get("/stdio", async (req, res) => {
 
     const webAppTransport = new SSEServerTransport("/message", res);
     webAppTransports.set(webAppTransport.sessionId, webAppTransport);
-
-    console.log("Created web app transport");
+    serverTransports.set(webAppTransport.sessionId, serverTransport);
+    console.log("Created client/server transports");
 
     await webAppTransport.start();
-    (backingServerTransport as StdioClientTransport).stderr!.on(
-      "data",
-      (chunk) => {
-        webAppTransport.send({
-          jsonrpc: "2.0",
-          method: "notifications/stderr",
-          params: {
-            content: chunk.toString(),
-          },
-        });
-      },
-    );
+
+    (serverTransport as StdioClientTransport).stderr!.on("data", (chunk) => {
+      webAppTransport.send({
+        jsonrpc: "2.0",
+        method: "notifications/stderr",
+        params: {
+          content: chunk.toString(),
+        },
+      });
+    });
 
     mcpProxy({
       transportToClient: webAppTransport,
-      transportToServer: backingServerTransport,
+      transportToServer: serverTransport,
     });
 
     console.log("Set up MCP proxy");
@@ -284,10 +281,9 @@ app.get("/sse", async (req, res) => {
     console.log(
       "New SSE connection. NOTE: The sse transport is deprecated and has been replaced by streamable-http",
     );
-
+    let serverTransport: SSEServerTransport | undefined;
     try {
-      await backingServerTransport?.close();
-      backingServerTransport = await createTransport(req);
+      serverTransport = (await createTransport(req)) as SSEServerTransport;
     } catch (error) {
       if (error instanceof SseError && error.code === 401) {
         console.error(
@@ -305,13 +301,14 @@ app.get("/sse", async (req, res) => {
 
     const webAppTransport = new SSEServerTransport("/message", res);
     webAppTransports.set(webAppTransport.sessionId, webAppTransport);
-    console.log("Created web app transport");
+    serverTransports.set(webAppTransport.sessionId, serverTransport);
+    console.log("Created client/server transports");
 
     await webAppTransport.start();
 
     mcpProxy({
       transportToClient: webAppTransport,
-      transportToServer: backingServerTransport,
+      transportToServer: serverTransport,
     });
 
     console.log("Set up MCP proxy");


### PR DESCRIPTION
* In server/src/index.ts
  - add serverTransports map

  - remove backingServerTransport var

  - in /mcp POST handler, when a new connection is being made
    - create a server transport
    - map the server transport using the session id from the web app connection
    - pass serverTransport to the mcpProxy instead of backingServerTransport

  - in /stdio GET handler, when a new connection is being made
    - create a server transport
    - map the server transport using the session id from the web app connection
    - pass serverTransport to the mcpProxy instead of backingServerTransport

  - in /sse GET handler, when a new connection is being made
    - create a server transport
    - map the server transport using the session id from the web app connection
    - pass serverTransport to the mcpProxy instead of backingServerTransport

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Some servers are meant to share resources among multiple clients.  The current version of the Inspector cannot manage this.

While it does require an appropriate implementation on the server itself, the proxy server for the Inspector also requires a few changes to support this properly. Currently, a single server transport is bound to every client transport, and that causes problems when new connections are made ore broken. Instead, each client transport needs to be paired with its own server transport. 


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
[This video](https://www.loom.com/share/bf3ef46e66b44793aa48553ede6f8066) shows me first connecting to a properly implemented server with multiple instances of the current Inspector to demonstrate the problem, then with the changes in this PR to show how it should work. 

In the video, I show connections using SSE, but I've also fixed the StreamableHttp handling as well. 

Note that I have another PR inbound for server-everything, which allows multiple connections, so that this capability is testable entirely with in-project assets.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
