### PR TITLE
Set completion support to false by default

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -86,7 +86,7 @@ export function useConnection({
   const [requestHistory, setRequestHistory] = useState<
     { request: string; response?: string }[]
   >([]);
-  const [completionsSupported, setCompletionsSupported] = useState(true);
+  const [completionsSupported, setCompletionsSupported] = useState(false);
 
   const pushHistory = (request: object, response?: object) => {
     setRequestHistory((prev) => [
@@ -443,7 +443,7 @@ export function useConnection({
         throw error;
       }
       setServerCapabilities(capabilities ?? null);
-      setCompletionsSupported(true); // Reset completions support on new connection
+      setCompletionsSupported(capabilities?.completions !== undefined);
 
       if (onPendingRequest) {
         client.setRequestHandler(CreateMessageRequestSchema, (request) => {


### PR DESCRIPTION
Change completion support default to false and use server capabilities value to assert support for completion.
Fixes #436 

## Motivation and Context
Current implementation always tries a first completion request on resource template or prompt usage, even if the server does not advertise support for completions. The silent error fallback currently implemented then switch back the support to false for further calls.

## How Has This Been Tested?
Yes, with a server with completion, and with one without

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
