### PR TITLE
[OAuth] Request all supported scopes when not using the OAuth debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ You can paste the Server Entry into your existing `mcp.json` file under your cho
 
 The inspector supports bearer token authentication for SSE connections. Enter your token in the UI when connecting to an MCP server, and it will be sent in the Authorization header. You can override the header name using the input field in the sidebar.
 
+It also follows [the MCP specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization#2-authorization-flow) for OAuth for remote transports. It uses all the scopes specified in the provider's `scopes_supported` field to help with debugging.
+
 ### Security Considerations
 
 The MCP Inspector includes a proxy server that can run and communicate with local MCP processes. The proxy server should not be exposed to untrusted networks as it has permissions to spawn local processes and can connect to any specified MCP server.

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -34,6 +34,15 @@ jest.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
 
 jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
   auth: jest.fn().mockResolvedValue("AUTHORIZED"),
+  discoverOAuthMetadata: jest.fn().mockResolvedValue({
+    issuer: "https://oauth.example.com",
+    authorization_endpoint: "https://oauth.example.com/authorize", 
+    token_endpoint: "https://oauth.example.com/token",
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    scopes_supported: ["read", "write"],
+  }),
 }));
 
 // Mock the toast hook

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -30,12 +30,13 @@ import {
   Progress,
 } from "@modelcontextprotocol/sdk/types.js";
 import { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import { OAuthMetadataSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { useState } from "react";
 import { useToast } from "@/lib/hooks/useToast";
 import { z } from "zod";
 import { ConnectionStatus } from "../constants";
 import { Notification, StdErrNotificationSchema } from "../notificationTypes";
-import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
+import { auth, discoverOAuthMetadata } from "@modelcontextprotocol/sdk/client/auth.js";
 import { InspectorOAuthClientProvider } from "../auth";
 import packageJson from "../../../package.json";
 import {
@@ -261,7 +262,14 @@ export function useConnection({
     if (is401Error(error)) {
       const serverAuthProvider = new InspectorOAuthClientProvider(sseUrl);
 
-      const result = await auth(serverAuthProvider, { serverUrl: sseUrl });
+      // Use all supported scopes if available
+      const metadata = await discoverOAuthMetadata(sseUrl);
+      if (!metadata) {
+        throw new Error("Failed to discover OAuth metadata");
+      }
+      const parsedMetadata = await OAuthMetadataSchema.parseAsync(metadata);
+      const scope = parsedMetadata.scopes_supported?.join(" ");
+      const result = await auth(serverAuthProvider, { serverUrl: sseUrl, scope });
       return result === "AUTHORIZED";
     }
 


### PR DESCRIPTION
Adds a "scope" section to the Authorization URL in the OAuth flow, matching the OAuth debugger behaviour.

## Motivation and Context
When using the OAuth debugger, it adds the scope search parameter with the ones provided in the `scopes_supported` key.

However, the main "connect" button does not pass them to the MCP SDK and they are missing from the call. Some OAuth providers and setups will require you to have them and the OAuth flow fails in these cases. This change fixes that.

## How Has This Been Tested?
Local tests for a streamable HTTP MCP server were successful when using the OAuth debugger. The URL generated then was:

```

```

but the "Connect" button currently returns:

```

```

This PR makes it so scopes are passed if the `scopes_supported` key is present in the authorization server metadata.

## Breaking Changes
MCP servers that rely on *implicitly* using default scopes will now have them *explicitly* set, and those scopes might differ.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed