### PR TITLE
Send HTTP DELETE on streamable transport disconnect

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -45,6 +45,7 @@ import {
 } from "@/utils/configUtils";
 import { getMCPServerRequestTimeout } from "@/utils/configUtils";
 import { InspectorConfig } from "../configurationTypes";
+import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 
 interface UseConnectionOptions {
   transportType: "stdio" | "sse" | "streamable-http";
@@ -83,6 +84,9 @@ export function useConnection({
   const [serverCapabilities, setServerCapabilities] =
     useState<ServerCapabilities | null>(null);
   const [mcpClient, setMcpClient] = useState<Client | null>(null);
+  const [clientTransport, setClientTransport] = useState<Transport | null>(
+    null,
+  );
   const [requestHistory, setRequestHistory] = useState<
     { request: string; response?: string }[]
   >([]);
@@ -377,14 +381,6 @@ export function useConnection({
         transportType,
       );
 
-      const clientTransport =
-        transportType === "streamable-http"
-          ? new StreamableHTTPClientTransport(mcpProxyServerUrl as URL, {
-              sessionId: undefined,
-              ...transportOptions,
-            })
-          : new SSEClientTransport(mcpProxyServerUrl as URL, transportOptions);
-
       if (onNotification) {
         [
           CancelledNotificationSchema,
@@ -414,7 +410,20 @@ export function useConnection({
 
       let capabilities;
       try {
-        await client.connect(clientTransport);
+        const transport =
+          transportType === "streamable-http"
+            ? new StreamableHTTPClientTransport(mcpProxyServerUrl as URL, {
+                sessionId: undefined,
+                ...transportOptions,
+              })
+            : new SSEClientTransport(
+                mcpProxyServerUrl as URL,
+                transportOptions,
+              );
+
+        await client.connect(transport as Transport);
+
+        setClientTransport(transport);
 
         capabilities = client.getServerCapabilities();
         const initializeRequest = {
@@ -468,10 +477,15 @@ export function useConnection({
   };
 
   const disconnect = async () => {
+    if (transportType === "streamable-http")
+      await (
+        clientTransport as StreamableHTTPClientTransport
+      ).terminateSession();
     await mcpClient?.close();
     const authProvider = new InspectorOAuthClientProvider(sseUrl);
     authProvider.clear();
     setMcpClient(null);
+    setClientTransport(null);
     setConnectionStatus("disconnected");
     setCompletionsSupported(false);
     setServerCapabilities(null);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -226,6 +226,33 @@ app.post("/mcp", async (req, res) => {
   }
 });
 
+app.delete("/mcp", async (req, res) => {
+  const sessionId = req.headers["mcp-session-id"] as string | undefined;
+  console.log(`Received DELETE message for sessionId ${sessionId}`);
+  let serverTransport: Transport | undefined;
+  if (sessionId) {
+    try {
+      serverTransport = serverTransports.get(
+        sessionId,
+      ) as StreamableHTTPClientTransport;
+      if (!serverTransport) {
+        res.status(404).end("Transport not found for sessionId " + sessionId);
+      } else {
+        await (
+          serverTransport as StreamableHTTPClientTransport
+        ).terminateSession();
+        webAppTransports.delete(sessionId);
+        serverTransports.delete(sessionId);
+        console.log(`Transports removed for sessionId ${sessionId}`);
+      }
+      res.status(200).end();
+    } catch (error) {
+      console.error("Error in /mcp route:", error);
+      res.status(500).json(error);
+    }
+  }
+});
+
 app.get("/stdio", async (req, res) => {
   try {
     console.log("New connection");


### PR DESCRIPTION
* In server/src/index.ts
  - add delete handler for /mcp endpoint
    - gets the server transport for the sessionId
    - calls terminateSession on it
    - removes the webapp and server transports for the sessionId from the maps
    - returns status 200 to the client.
    
* In client/src/lib/hooks/useConnection.ts
  - import Transport
  - add useState for clientTransport, type Transport or null initialized to null
  - in connect() function
    - move creation of client transport down a ways, just before calling client.connect with it
    - immendiately efter calling client.connect, call setClientTransport with the connected transport (has to happen after, so that what's saved has the abort controller, etc. otherwise it doesn't work to save it prior.
    - in disconnect() function
      - immediately call clientTransport.terminateSession if transportType is "streamable-http"
      - setClientTransport to null
     
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
For StreamableHttp transport, the spec says

<img width="717" alt="Screenshot 2025-05-29 at 7 56 06 PM" src="https://github.com/user-attachments/assets/48cdccc2-1884-47ee-bbc8-f5c8e0051b73" />

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Manually connect to the everything server, and then disconnect. 

### Browser devtools console
<img width="761" alt="Screenshot 2025-05-29 at 7 58 26 PM" src="https://github.com/user-attachments/assets/30f04847-b53e-46ef-92c6-196da794b758" />

### Inspector proxy server
<img width="609" alt="Screenshot 2025-05-29 at 8 01 26 PM" src="https://github.com/user-attachments/assets/6d2e99ad-938f-451c-a132-4efae27a6045" />

### Everything server
<img width="782" alt="Screenshot 2025-05-29 at 8 01 03 PM" src="https://github.com/user-attachments/assets/d552e8f1-de3e-4610-b3ad-e1358b1bd463" />

### NOTE
The sessionIds differ in the above reports for the Inspector proxy and the everything MCP server because there are two transports each direction. I.e., 
* Client -> Proxy sessionId = 967785de-3cb1-4c6a-987f-505ce56ae947
* Proxy -> MCP sessionId = 84cbb2d2-b853-49c4-8b4b-9c79b0172db3

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
DO NOT MERGE UNTIL https://github.com/modelcontextprotocol/inspector/pull/428 is merged, this PR is a branch off that one to separate the functionality.