### PR TITLE
fix: update remaining version references to 0.14.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-cli",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "CLI for the Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-client",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Client-side application for the Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
         "cli"
       ],
       "dependencies": {
-        "@modelcontextprotocol/inspector-cli": "^0.14.0",
-        "@modelcontextprotocol/inspector-client": "^0.14.0",
-        "@modelcontextprotocol/inspector-server": "^0.14.0",
+        "@modelcontextprotocol/inspector-cli": "^0.14.1",
+        "@modelcontextprotocol/inspector-client": "^0.14.1",
+        "@modelcontextprotocol/inspector-server": "^0.14.1",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "concurrently": "^9.0.1",
         "open": "^10.1.0",
@@ -40,7 +40,7 @@
     },
     "cli": {
       "name": "@modelcontextprotocol/inspector-cli",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -63,7 +63,7 @@
     },
     "client": {
       "name": "@modelcontextprotocol/inspector-client",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -10920,7 +10920,7 @@
     },
     "server": {
       "name": "@modelcontextprotocol/inspector-server",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "publish-all": "npm publish --workspaces --access public && npm publish --access public"
   },
   "dependencies": {
-    "@modelcontextprotocol/inspector-cli": "^0.14.0",
-    "@modelcontextprotocol/inspector-client": "^0.14.0",
-    "@modelcontextprotocol/inspector-server": "^0.14.0",
+    "@modelcontextprotocol/inspector-cli": "^0.14.1",
+    "@modelcontextprotocol/inspector-client": "^0.14.1",
+    "@modelcontextprotocol/inspector-server": "^0.14.1",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "concurrently": "^9.0.1",
     "open": "^10.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-server",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Server-side application for the Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",


### PR DESCRIPTION
## Summary
- Updated version numbers from 0.14.0 to 0.14.1 in package.json files across all workspaces
- Updated dependency versions in root package.json and package-lock.json to match

## Test plan
- [ ] Run `npm install` to verify package-lock.json is consistent
- [ ] Run `npm run build` to verify all packages build successfully
- [ ] Verify version numbers are consistent across all packages

🤖 Generated with [Claude Code](https://claude.ai/code)