### PR TITLE
fix: use X-MCP-Proxy-Auth header for proxy authentication

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -347,9 +347,10 @@ const App = () => {
 
   useEffect(() => {
     const headers: HeadersInit = {};
-    const proxyAuthToken = getMCPProxyAuthToken(config);
+    const { token: proxyAuthToken, header: proxyAuthTokenHeader } =
+      getMCPProxyAuthToken(config);
     if (proxyAuthToken) {
-      headers["Authorization"] = `Bearer ${proxyAuthToken}`;
+      headers[proxyAuthTokenHeader] = `Bearer ${proxyAuthToken}`;
     }
 
     fetch(`${getMCPProxyAddress(config)}/config`, { headers })

--- a/client/src/__tests__/App.config.test.tsx
+++ b/client/src/__tests__/App.config.test.tsx
@@ -1,0 +1,240 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import App from "../App";
+import { DEFAULT_INSPECTOR_CONFIG } from "../lib/constants";
+
+// Mock auth dependencies first
+jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("../lib/oauth-state-machine", () => ({
+  OAuthStateMachine: jest.fn(),
+}));
+
+jest.mock("../lib/auth", () => ({
+  InspectorOAuthClientProvider: jest.fn().mockImplementation(() => ({
+    tokens: jest.fn().mockResolvedValue(null),
+    clear: jest.fn(),
+  })),
+  DebugInspectorOAuthClientProvider: jest.fn(),
+}));
+
+// Mock the config utils
+jest.mock("../utils/configUtils", () => ({
+  ...jest.requireActual("../utils/configUtils"),
+  getMCPProxyAddress: jest.fn(() => "http://localhost:6277"),
+  getMCPProxyAuthToken: jest.fn((config) => ({
+    token: config.MCP_PROXY_AUTH_TOKEN.value,
+    header: "X-MCP-Proxy-Auth",
+  })),
+  getInitialTransportType: jest.fn(() => "stdio"),
+  getInitialSseUrl: jest.fn(() => "http://localhost:3001/sse"),
+  getInitialCommand: jest.fn(() => "mcp-server-everything"),
+  getInitialArgs: jest.fn(() => ""),
+  initializeInspectorConfig: jest.fn(() => DEFAULT_INSPECTOR_CONFIG),
+  saveInspectorConfig: jest.fn(),
+}));
+
+// Mock other dependencies
+jest.mock("../lib/hooks/useConnection", () => ({
+  useConnection: () => ({
+    connectionStatus: "disconnected",
+    serverCapabilities: null,
+    mcpClient: null,
+    requestHistory: [],
+    makeRequest: jest.fn(),
+    sendNotification: jest.fn(),
+    handleCompletion: jest.fn(),
+    completionsSupported: false,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  }),
+}));
+
+jest.mock("../lib/hooks/useDraggablePane", () => ({
+  useDraggablePane: () => ({
+    height: 300,
+    handleDragStart: jest.fn(),
+  }),
+  useDraggableSidebar: () => ({
+    width: 320,
+    isDragging: false,
+    handleDragStart: jest.fn(),
+  }),
+}));
+
+jest.mock("../components/Sidebar", () => ({
+  __esModule: true,
+  default: () => <div>Sidebar</div>,
+}));
+
+// Mock fetch
+global.fetch = jest.fn();
+
+describe("App - Config Endpoint", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          defaultEnvironment: { TEST_ENV: "test" },
+          defaultCommand: "test-command",
+          defaultArgs: "test-args",
+        }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    
+    // Reset getMCPProxyAuthToken to default behavior
+    const { getMCPProxyAuthToken } = require("../utils/configUtils");
+    getMCPProxyAuthToken.mockImplementation((config) => ({
+      token: config.MCP_PROXY_AUTH_TOKEN.value,
+      header: "X-MCP-Proxy-Auth",
+    }));
+  });
+
+  test("sends X-MCP-Proxy-Auth header when fetching config with proxy auth token", async () => {
+    const mockConfig = {
+      ...DEFAULT_INSPECTOR_CONFIG,
+      MCP_PROXY_AUTH_TOKEN: {
+        ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+        value: "test-proxy-token",
+      },
+    };
+
+    // Mock initializeInspectorConfig to return our test config
+    const { initializeInspectorConfig } = require("../utils/configUtils");
+    initializeInspectorConfig.mockReturnValue(mockConfig);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:6277/config",
+        {
+          headers: {
+            "X-MCP-Proxy-Auth": "Bearer test-proxy-token",
+          },
+        }
+      );
+    });
+  });
+
+  test("does not send auth header when proxy auth token is empty", async () => {
+    const mockConfig = {
+      ...DEFAULT_INSPECTOR_CONFIG,
+      MCP_PROXY_AUTH_TOKEN: {
+        ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+        value: "",
+      },
+    };
+
+    // Mock initializeInspectorConfig to return our test config
+    const { initializeInspectorConfig } = require("../utils/configUtils");
+    initializeInspectorConfig.mockReturnValue(mockConfig);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:6277/config",
+        {
+          headers: {},
+        }
+      );
+    });
+  });
+
+  test("uses custom header name if getMCPProxyAuthToken returns different header", async () => {
+    const mockConfig = {
+      ...DEFAULT_INSPECTOR_CONFIG,
+      MCP_PROXY_AUTH_TOKEN: {
+        ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+        value: "test-proxy-token",
+      },
+    };
+
+    // Mock to return a custom header name
+    const { getMCPProxyAuthToken, initializeInspectorConfig } = require("../utils/configUtils");
+    getMCPProxyAuthToken.mockReturnValue({
+      token: "test-proxy-token",
+      header: "X-Custom-Auth",
+    });
+    initializeInspectorConfig.mockReturnValue(mockConfig);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:6277/config",
+        {
+          headers: {
+            "X-Custom-Auth": "Bearer test-proxy-token",
+          },
+        }
+      );
+    });
+  });
+
+  test("config endpoint response updates app state", async () => {
+    const mockConfig = {
+      ...DEFAULT_INSPECTOR_CONFIG,
+      MCP_PROXY_AUTH_TOKEN: {
+        ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+        value: "test-proxy-token",
+      },
+    };
+
+    const { initializeInspectorConfig } = require("../utils/configUtils");
+    initializeInspectorConfig.mockReturnValue(mockConfig);
+
+    const { container } = render(<App />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    // Verify the fetch was called with correct parameters
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://localhost:6277/config",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "X-MCP-Proxy-Auth": "Bearer test-proxy-token",
+        }),
+      })
+    );
+  });
+
+  test("handles config endpoint errors gracefully", async () => {
+    const mockConfig = {
+      ...DEFAULT_INSPECTOR_CONFIG,
+      MCP_PROXY_AUTH_TOKEN: {
+        ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+        value: "test-proxy-token",
+      },
+    };
+
+    const { initializeInspectorConfig } = require("../utils/configUtils");
+    initializeInspectorConfig.mockReturnValue(mockConfig);
+
+    // Mock fetch to reject
+    (global.fetch as jest.Mock).mockRejectedValue(new Error("Network error"));
+
+    // Spy on console.error
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Error fetching default environment:",
+        expect.any(Error)
+      );
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -329,7 +329,7 @@ describe("useConnection", () => {
       const testUrl = "http://test.com";
       await mockFetch?.(testUrl, {
         headers: {
-          "Accept": "text/event-stream",
+          Accept: "text/event-stream",
         },
         cache: "no-store",
         mode: "cors",

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -327,7 +327,16 @@ describe("useConnection", () => {
       // Verify the fetch function includes the proxy auth header
       const mockFetch = mockSSETransport.options?.eventSourceInit?.fetch;
       const testUrl = "http://test.com";
-      await mockFetch?.(testUrl);
+      await mockFetch?.(testUrl, {
+        headers: {
+          "Accept": "text/event-stream",
+        },
+        cache: "no-store",
+        mode: "cors",
+        signal: new AbortController().signal,
+        redirect: "follow",
+        credentials: "include",
+      });
 
       expect(global.fetch).toHaveBeenCalledTimes(2);
       expect(

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -3,6 +3,7 @@ import { useConnection } from "../useConnection";
 import { z } from "zod";
 import { ClientRequest } from "@modelcontextprotocol/sdk/types.js";
 import { DEFAULT_INSPECTOR_CONFIG } from "../../constants";
+import { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js";
 
 // Mock fetch
 global.fetch = jest.fn().mockResolvedValue({
@@ -23,21 +24,46 @@ const mockClient = {
   setRequestHandler: jest.fn(),
 };
 
+// Mock transport instances
+const mockSSETransport: {
+  start: jest.Mock;
+  url: URL | undefined;
+  options: SSEClientTransportOptions | undefined;
+} = {
+  start: jest.fn(),
+  url: undefined,
+  options: undefined,
+};
+
+const mockStreamableHTTPTransport: {
+  start: jest.Mock;
+  url: URL | undefined;
+  options: SSEClientTransportOptions | undefined;
+} = {
+  start: jest.fn(),
+  url: undefined,
+  options: undefined,
+};
+
 jest.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
   Client: jest.fn().mockImplementation(() => mockClient),
 }));
 
 jest.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
-  SSEClientTransport: jest.fn((url) => ({
-    toString: () => url,
-  })),
+  SSEClientTransport: jest.fn((url, options) => {
+    mockSSETransport.url = url;
+    mockSSETransport.options = options;
+    return mockSSETransport;
+  }),
   SseError: jest.fn(),
 }));
 
 jest.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
-  StreamableHTTPClientTransport: jest.fn((url) => ({
-    toString: () => url,
-  })),
+  StreamableHTTPClientTransport: jest.fn((url, options) => {
+    mockStreamableHTTPTransport.url = url;
+    mockStreamableHTTPTransport.options = options;
+    return mockStreamableHTTPTransport;
+  }),
 }));
 
 jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
@@ -257,6 +283,174 @@ describe("useConnection", () => {
       expect(call.toString()).toContain(
         "url=https%3A%2F%2Fexample.com%3A8443%2Fapi",
       );
+    });
+  });
+
+  describe("Proxy Authentication Headers", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      // Reset the mock transport objects
+      mockSSETransport.url = undefined;
+      mockSSETransport.options = undefined;
+      mockStreamableHTTPTransport.url = undefined;
+      mockStreamableHTTPTransport.options = undefined;
+    });
+
+    test("sends X-MCP-Proxy-Auth header when proxy auth token is configured", async () => {
+      const propsWithProxyAuth = {
+        ...defaultProps,
+        config: {
+          ...DEFAULT_INSPECTOR_CONFIG,
+          MCP_PROXY_AUTH_TOKEN: {
+            ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+            value: "test-proxy-token",
+          },
+        },
+      };
+
+      const { result } = renderHook(() => useConnection(propsWithProxyAuth));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Check that the transport was created with the correct headers
+      expect(mockSSETransport.options).toBeDefined();
+      expect(mockSSETransport.options?.requestInit).toBeDefined();
+
+      expect(mockSSETransport.options?.requestInit?.headers).toHaveProperty(
+        "X-MCP-Proxy-Auth",
+        "Bearer test-proxy-token",
+      );
+      expect(mockSSETransport?.options?.eventSourceInit?.fetch).toBeDefined();
+
+      // Verify the fetch function includes the proxy auth header
+      const mockFetch = mockSSETransport.options?.eventSourceInit?.fetch;
+      const testUrl = "http://test.com";
+      await mockFetch?.(testUrl);
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(
+        (global.fetch as jest.Mock).mock.calls[0][1].headers,
+      ).toHaveProperty("X-MCP-Proxy-Auth", "Bearer test-proxy-token");
+      expect((global.fetch as jest.Mock).mock.calls[1][0]).toBe(testUrl);
+      expect(
+        (global.fetch as jest.Mock).mock.calls[1][1].headers,
+      ).toHaveProperty("X-MCP-Proxy-Auth", "Bearer test-proxy-token");
+    });
+
+    test("does NOT send Authorization header for proxy auth", async () => {
+      const propsWithProxyAuth = {
+        ...defaultProps,
+        config: {
+          ...DEFAULT_INSPECTOR_CONFIG,
+          proxyAuthToken: "test-proxy-token",
+        },
+      };
+
+      const { result } = renderHook(() => useConnection(propsWithProxyAuth));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Check that Authorization header is NOT used for proxy auth
+      expect(mockSSETransport.options?.requestInit?.headers).not.toHaveProperty(
+        "Authorization",
+        "Bearer test-proxy-token",
+      );
+    });
+
+    test("preserves server Authorization header when proxy auth is configured", async () => {
+      const propsWithBothAuth = {
+        ...defaultProps,
+        bearerToken: "server-auth-token",
+        config: {
+          ...DEFAULT_INSPECTOR_CONFIG,
+          MCP_PROXY_AUTH_TOKEN: {
+            ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+            value: "test-proxy-token",
+          },
+        },
+      };
+
+      const { result } = renderHook(() => useConnection(propsWithBothAuth));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Check that both headers are present and distinct
+      const headers = mockSSETransport.options?.requestInit?.headers;
+      expect(headers).toHaveProperty(
+        "Authorization",
+        "Bearer server-auth-token",
+      );
+      expect(headers).toHaveProperty(
+        "X-MCP-Proxy-Auth",
+        "Bearer test-proxy-token",
+      );
+    });
+
+    test("sends X-MCP-Proxy-Auth in health check requests", async () => {
+      const fetchMock = global.fetch as jest.Mock;
+      fetchMock.mockClear();
+
+      const propsWithProxyAuth = {
+        ...defaultProps,
+        config: {
+          ...DEFAULT_INSPECTOR_CONFIG,
+          MCP_PROXY_AUTH_TOKEN: {
+            ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+            value: "test-proxy-token",
+          },
+        },
+      };
+
+      const { result } = renderHook(() => useConnection(propsWithProxyAuth));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Find the health check call
+      const healthCheckCall = fetchMock.mock.calls.find(
+        (call) => call[0].pathname === "/health",
+      );
+
+      expect(healthCheckCall).toBeDefined();
+      expect(healthCheckCall[1].headers).toHaveProperty(
+        "X-MCP-Proxy-Auth",
+        "Bearer test-proxy-token",
+      );
+    });
+
+    test("works correctly with streamable-http transport", async () => {
+      const propsWithStreamableHttp = {
+        ...defaultProps,
+        transportType: "streamable-http" as const,
+        config: {
+          ...DEFAULT_INSPECTOR_CONFIG,
+          MCP_PROXY_AUTH_TOKEN: {
+            ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+            value: "test-proxy-token",
+          },
+        },
+      };
+
+      const { result } = renderHook(() =>
+        useConnection(propsWithStreamableHttp),
+      );
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Check that the streamable HTTP transport was created with the correct headers
+      expect(mockStreamableHTTPTransport.options).toBeDefined();
+      expect(
+        mockStreamableHTTPTransport.options?.requestInit?.headers,
+      ).toHaveProperty("X-MCP-Proxy-Auth", "Bearer test-proxy-token");
     });
   });
 });

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -246,7 +246,7 @@ export function useConnection({
       const proxyAuthToken = getMCPProxyAuthToken(config);
       const headers: HeadersInit = {};
       if (proxyAuthToken) {
-        headers["Authorization"] = `Bearer ${proxyAuthToken}`;
+        headers["X-MCP-Proxy-Auth"] = `Bearer ${proxyAuthToken}`;
       }
       const proxyHealthResponse = await fetch(proxyHealthUrl, { headers });
       const proxyHealth = await proxyHealthResponse.json();
@@ -335,7 +335,7 @@ export function useConnection({
       const proxyAuthToken = getMCPProxyAuthToken(config);
       const proxyHeaders: HeadersInit = {};
       if (proxyAuthToken) {
-        proxyHeaders["Authorization"] = `Bearer ${proxyAuthToken}`;
+        proxyHeaders["X-MCP-Proxy-Auth"] = `Bearer ${proxyAuthToken}`;
       }
 
       // Create appropriate transport

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -243,10 +243,11 @@ export function useConnection({
   const checkProxyHealth = async () => {
     try {
       const proxyHealthUrl = new URL(`${getMCPProxyAddress(config)}/health`);
-      const proxyAuthToken = getMCPProxyAuthToken(config);
+      const { token: proxyAuthToken, header: proxyAuthTokenHeader } =
+        getMCPProxyAuthToken(config);
       const headers: HeadersInit = {};
       if (proxyAuthToken) {
-        headers["X-MCP-Proxy-Auth"] = `Bearer ${proxyAuthToken}`;
+        headers[proxyAuthTokenHeader] = `Bearer ${proxyAuthToken}`;
       }
       const proxyHealthResponse = await fetch(proxyHealthUrl, { headers });
       const proxyHealth = await proxyHealthResponse.json();
@@ -332,10 +333,11 @@ export function useConnection({
       }
 
       // Add proxy authentication
-      const proxyAuthToken = getMCPProxyAuthToken(config);
+      const { token: proxyAuthToken, header: proxyAuthTokenHeader } =
+        getMCPProxyAuthToken(config);
       const proxyHeaders: HeadersInit = {};
       if (proxyAuthToken) {
-        proxyHeaders["X-MCP-Proxy-Auth"] = `Bearer ${proxyAuthToken}`;
+        proxyHeaders[proxyAuthTokenHeader] = `Bearer ${proxyAuthToken}`;
       }
 
       // Create appropriate transport

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -357,7 +357,7 @@ export function useConnection({
             eventSourceInit: {
               fetch: (
                 url: string | URL | globalThis.Request,
-                init: RequestInit | undefined,
+                init?: RequestInit,
               ) =>
                 fetch(url, {
                   ...init,
@@ -377,7 +377,7 @@ export function useConnection({
             eventSourceInit: {
               fetch: (
                 url: string | URL | globalThis.Request,
-                init: RequestInit | undefined,
+                init?: RequestInit,
               ) =>
                 fetch(url, {
                   ...init,
@@ -397,7 +397,7 @@ export function useConnection({
             eventSourceInit: {
               fetch: (
                 url: string | URL | globalThis.Request,
-                init: RequestInit | undefined,
+                init?: RequestInit,
               ) =>
                 fetch(url, {
                   ...init,

--- a/client/src/utils/__tests__/configUtils.test.ts
+++ b/client/src/utils/__tests__/configUtils.test.ts
@@ -57,7 +57,7 @@ describe("configUtils", () => {
         ...DEFAULT_INSPECTOR_CONFIG,
         MCP_PROXY_AUTH_TOKEN: {
           ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
-          value: null as any,
+          value: null as unknown as string,
         },
       };
 

--- a/client/src/utils/__tests__/configUtils.test.ts
+++ b/client/src/utils/__tests__/configUtils.test.ts
@@ -1,0 +1,72 @@
+import { getMCPProxyAuthToken } from "../configUtils";
+import { DEFAULT_INSPECTOR_CONFIG } from "../../lib/constants";
+import { InspectorConfig } from "../../lib/configurationTypes";
+
+describe("configUtils", () => {
+  describe("getMCPProxyAuthToken", () => {
+    test("returns token and default header name", () => {
+      const config: InspectorConfig = {
+        ...DEFAULT_INSPECTOR_CONFIG,
+        MCP_PROXY_AUTH_TOKEN: {
+          ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+          value: "test-token-123",
+        },
+      };
+
+      const result = getMCPProxyAuthToken(config);
+
+      expect(result).toEqual({
+        token: "test-token-123",
+        header: "X-MCP-Proxy-Auth",
+      });
+    });
+
+    test("returns empty token when not configured", () => {
+      const config: InspectorConfig = {
+        ...DEFAULT_INSPECTOR_CONFIG,
+        MCP_PROXY_AUTH_TOKEN: {
+          ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+          value: "",
+        },
+      };
+
+      const result = getMCPProxyAuthToken(config);
+
+      expect(result).toEqual({
+        token: "",
+        header: "X-MCP-Proxy-Auth",
+      });
+    });
+
+    test("always returns X-MCP-Proxy-Auth as header name", () => {
+      const config: InspectorConfig = {
+        ...DEFAULT_INSPECTOR_CONFIG,
+        MCP_PROXY_AUTH_TOKEN: {
+          ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+          value: "any-token",
+        },
+      };
+
+      const result = getMCPProxyAuthToken(config);
+
+      expect(result.header).toBe("X-MCP-Proxy-Auth");
+    });
+
+    test("handles null/undefined value gracefully", () => {
+      const config: InspectorConfig = {
+        ...DEFAULT_INSPECTOR_CONFIG,
+        MCP_PROXY_AUTH_TOKEN: {
+          ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+          value: null as any,
+        },
+      };
+
+      const result = getMCPProxyAuthToken(config);
+
+      expect(result).toEqual({
+        token: null,
+        header: "X-MCP-Proxy-Auth",
+      });
+    });
+  });
+});

--- a/client/src/utils/configUtils.ts
+++ b/client/src/utils/configUtils.ts
@@ -28,8 +28,16 @@ export const getMCPServerRequestMaxTotalTimeout = (
   return config.MCP_REQUEST_MAX_TOTAL_TIMEOUT.value as number;
 };
 
-export const getMCPProxyAuthToken = (config: InspectorConfig): string => {
-  return config.MCP_PROXY_AUTH_TOKEN.value as string;
+export const getMCPProxyAuthToken = (
+  config: InspectorConfig,
+): {
+  token: string;
+  header: string;
+} => {
+  return {
+    token: config.MCP_PROXY_AUTH_TOKEN.value as string,
+    header: "X-MCP-Proxy-Auth",
+  };
 };
 
 const getSearchParam = (key: string): string | null => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -138,13 +138,17 @@ const authMiddleware = (
     });
   };
 
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+  const authHeader = req.headers["x-mcp-proxy-auth"];
+  const authHeaderValue = Array.isArray(authHeader)
+    ? authHeader[0]
+    : authHeader;
+
+  if (!authHeaderValue || !authHeaderValue.startsWith("Bearer ")) {
     sendUnauthorized();
     return;
   }
 
-  const providedToken = authHeader.substring(7); // Remove 'Bearer ' prefix
+  const providedToken = authHeaderValue.substring(7); // Remove 'Bearer ' prefix
   const expectedToken = sessionToken;
 
   // Convert to buffers for timing-safe comparison
@@ -196,7 +200,9 @@ const createTransport = async (req: express.Request): Promise<Transport> => {
 
     const headers = getHttpHeaders(req, transportType);
 
-    console.log(`SSE transport: url=${url}, headers=${Object.keys(headers)}`);
+    console.log(
+      `SSE transport: url=${url}, headers=${JSON.stringify(headers)}`,
+    );
 
     const transport = new SSEClientTransport(new URL(url), {
       eventSourceInit: {


### PR DESCRIPTION
## Problem

The MCP Inspector proxy was experiencing authentication failures (401 errors) when connecting to upstream MCP servers that require authentication. The issue occurred because:

1. The client sends both proxy authentication and server authentication using the Authorization header
2. When headers were merged with spread operators (`{ ...headers, ...proxyHeaders }`), the proxy's Authorization header would overwrite the server's Authorization header
3. The proxy server would receive its own auth token correctly, but the server auth token that needed to be forwarded to the upstream MCP server was lost

This resulted in the upstream server rejecting requests with 401 Unauthorized errors.


Video of this working with SSE and SHTTP, note that I'm using [this branch](https://github.com/modelcontextprotocol/typescript-sdk/pull/629) for the test shttp server in the sdk

https://github.com/user-attachments/assets/3f53bf7b-568a-43f9-8b9b-5f144b95bf97


## Solution

Changed proxy authentication to use a custom header (`X-MCP-Proxy-Auth`) instead of the standard Authorization header. This prevents conflicts when the proxy needs to forward the client's Authorization header to upstream MCP servers.

### Changes made:

- **Client-side**: Updated `useConnection.ts` to send proxy auth token in `X-MCP-Proxy-Auth` header
- **Server-side**: Updated auth middleware in `index.ts` to check `X-MCP-Proxy-Auth` header instead of `Authorization`
- **Applies to all transport types**: SSE, stdio, and streamable-http endpoints all use the same auth middleware

### Benefits:

1. No more header conflicts - proxy auth and server auth use different headers
2. The proxy can properly forward the Authorization header to upstream servers
3. Both authentication mechanisms work independently without interference

## How Has This Been Tested?

- Built the project successfully
- Manually tested with an MCP server that requires authentication
- Confirmed that 401 errors are resolved and authentication works correctly

## Breaking Changes

No - other than the user now needing to click the correct link from the command line. Follow up incoming with UX fixes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

This issue was discovered when trying to connect to an SSE-based MCP server that required bearer token authentication. The inspector would send the request but receive a 401 error because the wrong token was being forwarded.

🤖 Generated with [Claude Code](https://claude.ai/code)