### PR TITLE
feat: Adds optional _meta to request input forms.

### DIFF
--- a/cli/src/client/prompts.ts
+++ b/cli/src/client/prompts.ts
@@ -2,9 +2,12 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { McpResponse } from "./types.js";
 
 // List available prompts
-export async function listPrompts(client: Client): Promise<McpResponse> {
+export async function listPrompts(
+  client: Client,
+  _meta?: Record<string, unknown>,
+): Promise<McpResponse> {
   try {
-    const response = await client.listPrompts();
+    const response = await client.listPrompts({ _meta });
     return response;
   } catch (error) {
     throw new Error(
@@ -18,11 +21,13 @@ export async function getPrompt(
   client: Client,
   name: string,
   args?: Record<string, string>,
+  _meta?: Record<string, unknown>,
 ): Promise<McpResponse> {
   try {
     const response = await client.getPrompt({
       name,
       arguments: args || {},
+      _meta,
     });
 
     return response;

--- a/cli/src/client/resources.ts
+++ b/cli/src/client/resources.ts
@@ -2,9 +2,12 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { McpResponse } from "./types.js";
 
 // List available resources
-export async function listResources(client: Client): Promise<McpResponse> {
+export async function listResources(
+  client: Client,
+  _meta?: Record<string, unknown>,
+): Promise<McpResponse> {
   try {
-    const response = await client.listResources();
+    const response = await client.listResources({ _meta });
     return response;
   } catch (error) {
     throw new Error(
@@ -17,9 +20,10 @@ export async function listResources(client: Client): Promise<McpResponse> {
 export async function readResource(
   client: Client,
   uri: string,
+  _meta?: Record<string, unknown>,
 ): Promise<McpResponse> {
   try {
-    const response = await client.readResource({ uri });
+    const response = await client.readResource({ uri, _meta });
     return response;
   } catch (error) {
     throw new Error(
@@ -31,9 +35,10 @@ export async function readResource(
 // List resource templates
 export async function listResourceTemplates(
   client: Client,
+  _meta?: Record<string, unknown>,
 ): Promise<McpResponse> {
   try {
-    const response = await client.listResourceTemplates();
+    const response = await client.listResourceTemplates({ _meta });
     return response;
   } catch (error) {
     throw new Error(

--- a/cli/src/client/tools.ts
+++ b/cli/src/client/tools.ts
@@ -9,9 +9,12 @@ type JsonSchemaType = {
   items?: JsonSchemaType;
 };
 
-export async function listTools(client: Client): Promise<McpResponse> {
+export async function listTools(
+  client: Client,
+  _meta?: Record<string, unknown>,
+): Promise<McpResponse> {
   try {
-    const response = await client.listTools();
+    const response = await client.listTools({ _meta });
     return response;
   } catch (error) {
     throw new Error(
@@ -69,9 +72,10 @@ export async function callTool(
   client: Client,
   name: string,
   args: Record<string, string>,
+  _meta?: Record<string, unknown>,
 ): Promise<McpResponse> {
   try {
-    const toolsResponse = await listTools(client);
+    const toolsResponse = await listTools(client, _meta);
     const tools = toolsResponse.tools as Tool[];
     const tool = tools.find((t) => t.name === name);
 
@@ -85,6 +89,7 @@ export async function callTool(
     const response = await client.callTool({
       name: name,
       arguments: convertedArgs,
+      _meta,
     });
     return response;
   } catch (error) {

--- a/client/src/components/ListPane.tsx
+++ b/client/src/components/ListPane.tsx
@@ -1,8 +1,10 @@
 import { Button } from "./ui/button";
+import React, { useState } from "react"; // Import React and useState
+import MetaEditor from "./MetaEditor"; // Import MetaEditor
 
 type ListPaneProps<T> = {
   items: T[];
-  listItems: () => void;
+  listItems: (meta?: Record<string, unknown> | null) => void; // Updated signature
   clearItems: () => void;
   setSelectedItem: (item: T) => void;
   renderItem: (item: T) => React.ReactNode;
@@ -20,41 +22,52 @@ const ListPane = <T extends object>({
   title,
   buttonText,
   isButtonDisabled,
-}: ListPaneProps<T>) => (
-  <div className="bg-card border border-border rounded-lg shadow">
-    <div className="p-4 border-b border-gray-200 dark:border-border">
-      <h3 className="font-semibold dark:text-white">{title}</h3>
-    </div>
-    <div className="p-4">
-      <Button
-        variant="outline"
-        className="w-full mb-4"
-        onClick={listItems}
-        disabled={isButtonDisabled}
-      >
-        {buttonText}
-      </Button>
-      <Button
-        variant="outline"
-        className="w-full mb-4"
-        onClick={clearItems}
-        disabled={items.length === 0}
-      >
-        Clear
-      </Button>
-      <div className="space-y-2 overflow-y-auto max-h-96">
-        {items.map((item, index) => (
-          <div
-            key={index}
-            className="flex items-center py-2 px-4 rounded hover:bg-gray-50 dark:hover:bg-secondary cursor-pointer"
-            onClick={() => setSelectedItem(item)}
-          >
-            {renderItem(item)}
-          </div>
-        ))}
+}: ListPaneProps<T>) => {
+  const [metaValue, setMetaValue] = useState<Record<string, unknown> | null>(
+    null,
+  );
+
+  return (
+    <div className="bg-card border border-border rounded-lg shadow">
+      <div className="p-4 border-b border-gray-200 dark:border-border">
+        <h3 className="font-semibold dark:text-white">{title}</h3>
+      </div>
+      <div className="p-4">
+        <MetaEditor
+          onChange={setMetaValue}
+          initialCollapsed={true}
+          initialValue={{}}
+        />
+        <Button
+          variant="outline"
+          className="w-full mb-4 mt-2" // Added mt-2 for spacing after MetaEditor
+          onClick={() => listItems(metaValue)} // Pass metaValue
+          disabled={isButtonDisabled}
+        >
+          {buttonText}
+        </Button>
+        <Button
+          variant="outline"
+          className="w-full mb-4"
+          onClick={clearItems}
+          disabled={items.length === 0}
+        >
+          Clear
+        </Button>
+        <div className="space-y-2 overflow-y-auto max-h-96">
+          {items.map((item, index) => (
+            <div
+              key={index}
+              className="flex items-center py-2 px-4 rounded hover:bg-gray-50 dark:hover:bg-secondary cursor-pointer"
+              onClick={() => setSelectedItem(item)}
+            >
+              {renderItem(item)}
+            </div>
+          ))}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default ListPane;

--- a/client/src/components/MetaEditor.tsx
+++ b/client/src/components/MetaEditor.tsx
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from "react";
+import JsonEditor from "./JsonEditor";
+import { Button } from "./ui/button"; // Import Button
+import { cn } from "@/lib/utils";
+import { Minus, Plus } from "lucide-react";
+
+interface MetaEditorProps {
+  onChange: (value: Record<string, unknown> | null) => void;
+  initialCollapsed?: boolean;
+  initialValue?: Record<string, unknown>; // Default for the editor's content
+}
+
+const MetaEditor: React.FC<MetaEditorProps> = ({
+  onChange,
+  initialCollapsed = true,
+  initialValue = {}, // This ensures the editor has a default of {}
+}) => {
+  const [isCollapsed, setIsCollapsed] = useState(initialCollapsed);
+  const [jsonString, setJsonString] = useState<string>(() => {
+    try {
+      return JSON.stringify(initialValue, null, 2);
+    } catch {
+      return "{}";
+    }
+  });
+  const [parseError, setParseError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isCollapsed) {
+      onChange(null);
+    } else {
+      try {
+        const parsedJson = JSON.parse(jsonString);
+        onChange(parsedJson);
+        setParseError(null);
+      } catch (e) {
+        onChange(null);
+      }
+    }
+  }, [isCollapsed, jsonString, onChange]);
+
+  const handleToggleCollapse = () => {
+    setIsCollapsed((prevCollapsed) => !prevCollapsed);
+    // onChange will be handled by the useEffect above based on the new isCollapsed state
+  };
+
+  const handleEditorChange = (newJsonString: string) => {
+    console.log("change");
+    setJsonString(newJsonString);
+    try {
+      JSON.parse(newJsonString);
+      setParseError(null); // Clear error if current input is valid
+    } catch (e) {
+      setParseError("Invalid JSON format."); // Set error for JsonEditor to display
+    }
+  };
+
+  return (
+    <div className="mt-2">
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={handleToggleCollapse}
+        className={cn(
+          "w-full mb-2",
+          isCollapsed || "border-destructive",
+          "justify-start pl-2",
+        )} // Full-width and preserve margin
+      >
+        <div className="mr-1">
+          {isCollapsed ? <Plus size="16" /> : <Minus size="16" />}
+        </div>
+        {isCollapsed ? "Add" : "Remove"} Request Metadata
+      </Button>
+      {!isCollapsed && (
+        <JsonEditor
+          value={jsonString}
+          onChange={handleEditorChange}
+          error={parseError || undefined}
+        />
+      )}
+    </div>
+  );
+};
+
+export default MetaEditor;

--- a/client/src/components/PromptsTab.tsx
+++ b/client/src/components/PromptsTab.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from "react";
 import ListPane from "./ListPane";
 import { useCompletionState } from "@/lib/hooks/useCompletionState";
 import JsonView from "./JsonView";
+import MetaEditor from "./MetaEditor"; // Import MetaEditor
 
 export type Prompt = {
   name: string;
@@ -39,9 +40,13 @@ const PromptsTab = ({
   error,
 }: {
   prompts: Prompt[];
-  listPrompts: () => void;
+  listPrompts: (meta?: Record<string, unknown> | null) => void; // Updated signature
   clearPrompts: () => void;
-  getPrompt: (name: string, args: Record<string, string>) => void;
+  getPrompt: (
+    name: string,
+    args: Record<string, string>,
+    _meta: Record<string, unknown> | null,
+  ) => void; // Updated signature
   selectedPrompt: Prompt | null;
   setSelectedPrompt: (prompt: Prompt | null) => void;
   handleCompletion: (
@@ -55,6 +60,9 @@ const PromptsTab = ({
   error: string | null;
 }) => {
   const [promptArgs, setPromptArgs] = useState<Record<string, string>>({});
+  const [metaValue, setMetaValue] = useState<Record<string, unknown> | null>(
+    null,
+  ); // State for MetaEditor
   const { completions, clearCompletions, requestCompletions } =
     useCompletionState(handleCompletion, completionsSupported);
 
@@ -79,7 +87,8 @@ const PromptsTab = ({
 
   const handleGetPrompt = () => {
     if (selectedPrompt) {
-      getPrompt(selectedPrompt.name, promptArgs);
+      console.log(metaValue);
+      getPrompt(selectedPrompt.name, promptArgs, metaValue); // Pass metaValue
     }
   };
 
@@ -154,6 +163,11 @@ const PromptsTab = ({
                     )}
                   </div>
                 ))}
+                <MetaEditor
+                  onChange={setMetaValue}
+                  initialCollapsed={true}
+                  initialValue={{}}
+                />
                 <Button onClick={handleGetPrompt} className="w-full">
                   Get Prompt
                 </Button>

--- a/client/src/components/ResourcesTab.tsx
+++ b/client/src/components/ResourcesTab.tsx
@@ -41,11 +41,11 @@ const ResourcesTab = ({
 }: {
   resources: Resource[];
   resourceTemplates: ResourceTemplate[];
-  listResources: () => void;
+  listResources: (meta?: Record<string, unknown> | null) => void;
   clearResources: () => void;
-  listResourceTemplates: () => void;
+  listResourceTemplates: (meta?: Record<string, unknown> | null) => void;
   clearResourceTemplates: () => void;
-  readResource: (uri: string) => void;
+  readResource: (uri: string, meta?: Record<string, unknown>) => void;
   selectedResource: Resource | null;
   setSelectedResource: (resource: Resource | null) => void;
   handleCompletion: (

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -18,6 +18,7 @@ import { useEffect, useState } from "react";
 import ListPane from "./ListPane";
 import JsonView from "./JsonView";
 import ToolResults from "./ToolResults";
+import MetaEditor from "./MetaEditor"; // Import MetaEditor
 
 const ToolsTab = ({
   tools,
@@ -30,9 +31,13 @@ const ToolsTab = ({
   nextCursor,
 }: {
   tools: Tool[];
-  listTools: () => void;
+  listTools: (meta?: Record<string, unknown> | null) => void; // Updated signature
   clearTools: () => void;
-  callTool: (name: string, params: Record<string, unknown>) => Promise<void>;
+  callTool: (
+    name: string,
+    params: Record<string, unknown>,
+    meta: Record<string, unknown> | null,
+  ) => Promise<void>; // Updated signature
   selectedTool: Tool | null;
   setSelectedTool: (tool: Tool | null) => void;
   toolResult: CompatibilityCallToolResult | null;
@@ -42,6 +47,9 @@ const ToolsTab = ({
   const [params, setParams] = useState<Record<string, unknown>>({});
   const [isToolRunning, setIsToolRunning] = useState(false);
   const [isOutputSchemaExpanded, setIsOutputSchemaExpanded] = useState(false);
+  const [metaValue, setMetaValue] = useState<Record<string, unknown> | null>(
+    null,
+  ); // State for MetaEditor
 
   useEffect(() => {
     const params = Object.entries(
@@ -230,11 +238,16 @@ const ToolsTab = ({
                     </div>
                   </div>
                 )}
+                <MetaEditor
+                  onChange={setMetaValue}
+                  initialCollapsed={true}
+                  initialValue={{}}
+                />
                 <Button
                   onClick={async () => {
                     try {
                       setIsToolRunning(true);
-                      await callTool(selectedTool.name, params);
+                      await callTool(selectedTool.name, params, metaValue); // Pass metaValue
                     } finally {
                       setIsToolRunning(false);
                     }

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -106,9 +106,13 @@ describe("ToolsTab", () => {
       fireEvent.click(submitButton);
     });
 
-    expect(defaultProps.callTool).toHaveBeenCalledWith(mockTools[1].name, {
-      count: 42,
-    });
+    expect(defaultProps.callTool).toHaveBeenCalledWith(
+      mockTools[1].name,
+      {
+        count: 42,
+      },
+      null,
+    );
   });
 
   it("should disable button and change text while tool is running", async () => {

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -107,6 +107,7 @@ export function useConnection({
     schema: T,
     options?: RequestOptions & { suppressToast?: boolean },
   ): Promise<z.output<T>> => {
+    console.log("makeRequest:", request);
     if (!mcpClient) {
       throw new Error("MCP client not connected");
     }


### PR DESCRIPTION
## Motivation and Context

The inspector currently has no mechanism of sending `_meta` information which means it can't be used to inspect/debug custom metadata uses.

## How Has This Been Tested?

I've tested this out with my custom MCP server that depends on certain `_meta` keys and it seems to work well.

## Breaking Changes

No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

https://github.com/modelcontextprotocol/modelcontextprotocol/pull/710