### PR TITLE
fix: bind client to localhost to match server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in contributing! This guide explains how to get involve
 1. Fork the repository and clone it locally
 2. Install dependencies with `npm install`
 3. Run `npm run dev` to start both client and server in development mode
-4. Use the web UI at http://127.0.0.1:6274 to interact with the inspector
+4. Use the web UI at http://localhost:6274 to interact with the inspector
 
 ## Development Process & Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ DANGEROUSLY_OMIT_AUTH=true npm start
 
 #### Local-only Binding
 
-By default, both the MCP Inspector proxy server and client bind only to `127.0.0.1` (localhost) to prevent network access. This ensures they are not accessible from other devices on the network. If you need to bind to all interfaces for development purposes, you can override this with the `HOST` environment variable:
+By default, both the MCP Inspector proxy server and client bind only to `localhost` to prevent network access. This ensures they are not accessible from other devices on the network. If you need to bind to all interfaces for development purposes, you can override this with the `HOST` environment variable:
 
 ```bash
 HOST=0.0.0.0 npm start
@@ -181,7 +181,7 @@ HOST=0.0.0.0 npm start
 To prevent DNS rebinding attacks, the MCP Inspector validates the `Origin` header on incoming requests. By default, only requests from the client origin are allowed (respects `CLIENT_PORT` if set, defaulting to port 6274). You can configure additional allowed origins by setting the `ALLOWED_ORIGINS` environment variable (comma-separated list):
 
 ```bash
-ALLOWED_ORIGINS=http://localhost:6274,http://127.0.0.1:6274,http://localhost:8000 npm start
+ALLOWED_ORIGINS=http://localhost:6274,http://localhost:8000 npm start
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -168,13 +168,13 @@ DANGEROUSLY_OMIT_AUTH=true npm start
 
 #### Local-only Binding
 
-By default, the MCP Inspector proxy server binds only to `127.0.0.1` (localhost) to prevent network access. This ensures the server is not accessible from other devices on the network. If you need to bind to all interfaces for development purposes, you can override this with the `HOST` environment variable:
+By default, both the MCP Inspector proxy server and client bind only to `127.0.0.1` (localhost) to prevent network access. This ensures they are not accessible from other devices on the network. If you need to bind to all interfaces for development purposes, you can override this with the `HOST` environment variable:
 
 ```bash
 HOST=0.0.0.0 npm start
 ```
 
-**Warning:** Only bind to all interfaces in trusted network environments, as this exposes the proxy server's ability to execute local processes.
+**Warning:** Only bind to all interfaces in trusted network environments, as this exposes the proxy server's ability to execute local processes and both services to network access.
 
 #### DNS Rebinding Protection
 

--- a/client/bin/client.js
+++ b/client/bin/client.js
@@ -39,7 +39,7 @@ const server = http.createServer((request, response) => {
   return handler(request, response, handlerOptions);
 });
 
-const port = process.env.PORT || 6274;
+const port = parseInt(process.env.CLIENT_PORT || "6274", 10);
 const host = process.env.HOST || "localhost";
 server.on("listening", () => {
   console.log(

--- a/client/bin/client.js
+++ b/client/bin/client.js
@@ -40,18 +40,19 @@ const server = http.createServer((request, response) => {
 });
 
 const port = process.env.PORT || 6274;
+const host = process.env.HOST || "127.0.0.1";
 server.on("listening", () => {
   console.log(
-    `🔍 MCP Inspector is up and running at http://127.0.0.1:${port} 🚀`,
+    `🔍 MCP Inspector is up and running at http://${host}:${port} 🚀`,
   );
 });
 server.on("error", (err) => {
   if (err.message.includes(`EADDRINUSE`)) {
     console.error(
-      `❌  MCP Inspector PORT IS IN USE at http://127.0.0.1:${port} ❌ `,
+      `❌  MCP Inspector PORT IS IN USE at http://${host}:${port} ❌ `,
     );
   } else {
     throw err;
   }
 });
-server.listen(port);
+server.listen(port, host);

--- a/client/bin/client.js
+++ b/client/bin/client.js
@@ -40,7 +40,7 @@ const server = http.createServer((request, response) => {
 });
 
 const port = process.env.PORT || 6274;
-const host = process.env.HOST || "127.0.0.1";
+const host = process.env.HOST || "localhost";
 server.on("listening", () => {
   console.log(
     `🔍 MCP Inspector is up and running at http://${host}:${port} 🚀`,

--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -31,7 +31,7 @@ async function startDevServer(serverOptions) {
     cwd: resolve(__dirname, "../..", "server"),
     env: {
       ...process.env,
-      PORT: SERVER_PORT,
+      SERVER_PORT: SERVER_PORT,
       CLIENT_PORT: CLIENT_PORT,
       MCP_PROXY_TOKEN: sessionToken,
       MCP_ENV_VARS: JSON.stringify(envVars),
@@ -90,7 +90,7 @@ async function startProdServer(serverOptions) {
     {
       env: {
         ...process.env,
-        PORT: SERVER_PORT,
+        SERVER_PORT: SERVER_PORT,
         CLIENT_PORT: CLIENT_PORT,
         MCP_PROXY_TOKEN: sessionToken,
         MCP_ENV_VARS: JSON.stringify(envVars),
@@ -115,7 +115,7 @@ async function startDevClient(clientOptions) {
 
   const client = spawn(clientCommand, clientArgs, {
     cwd: resolve(__dirname, ".."),
-    env: { ...process.env, PORT: CLIENT_PORT },
+    env: { ...process.env, CLIENT_PORT: CLIENT_PORT },
     signal: abort.signal,
     echoOutput: true,
   });
@@ -163,7 +163,7 @@ async function startProdClient(clientOptions) {
   }
 
   await spawnPromise("node", [inspectorClientPath], {
-    env: { ...process.env, PORT: CLIENT_PORT },
+    env: { ...process.env, CLIENT_PORT: CLIENT_PORT },
     signal: abort.signal,
     echoOutput: true,
   });

--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -12,6 +12,14 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms, true));
 }
 
+function getClientUrl(port, authDisabled, sessionToken) {
+  const host = process.env.HOST || "localhost";
+  const baseUrl = `http://${host}:${port}`;
+  return authDisabled
+    ? baseUrl
+    : `${baseUrl}/?MCP_PROXY_AUTH_TOKEN=${sessionToken}`;
+}
+
 async function startDevServer(serverOptions) {
   const { SERVER_PORT, CLIENT_PORT, sessionToken, envVars, abort } =
     serverOptions;
@@ -102,7 +110,7 @@ async function startDevClient(clientOptions) {
   const { CLIENT_PORT, authDisabled, sessionToken, abort, cancelled } =
     clientOptions;
   const clientCommand = "npx";
-  const host = process.env.HOST || "127.0.0.1";
+  const host = process.env.HOST || "localhost";
   const clientArgs = ["vite", "--port", CLIENT_PORT, "--host", host];
 
   const client = spawn(clientCommand, clientArgs, {
@@ -114,10 +122,7 @@ async function startDevClient(clientOptions) {
 
   // Auto-open browser after vite starts
   if (process.env.MCP_AUTO_OPEN_ENABLED !== "false") {
-    const clientHost = process.env.HOST || "127.0.0.1";
-    const url = authDisabled
-      ? `http://${clientHost}:${CLIENT_PORT}`
-      : `http://${clientHost}:${CLIENT_PORT}/?MCP_PROXY_AUTH_TOKEN=${sessionToken}`;
+    const url = getClientUrl(CLIENT_PORT, authDisabled, sessionToken);
 
     // Give vite time to start before opening browser
     setTimeout(() => {
@@ -153,10 +158,7 @@ async function startProdClient(clientOptions) {
 
   // Only auto-open browser if not cancelled
   if (process.env.MCP_AUTO_OPEN_ENABLED !== "false" && !cancelled) {
-    const clientHost = process.env.HOST || "127.0.0.1";
-    const url = authDisabled
-      ? `http://${clientHost}:${CLIENT_PORT}`
-      : `http://${clientHost}:${CLIENT_PORT}/?MCP_PROXY_AUTH_TOKEN=${sessionToken}`;
+    const url = getClientUrl(CLIENT_PORT, authDisabled, sessionToken);
     open(url);
   }
 

--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -102,7 +102,8 @@ async function startDevClient(clientOptions) {
   const { CLIENT_PORT, authDisabled, sessionToken, abort, cancelled } =
     clientOptions;
   const clientCommand = "npx";
-  const clientArgs = ["vite", "--port", CLIENT_PORT];
+  const host = process.env.HOST || "127.0.0.1";
+  const clientArgs = ["vite", "--port", CLIENT_PORT, "--host", host];
 
   const client = spawn(clientCommand, clientArgs, {
     cwd: resolve(__dirname, ".."),
@@ -113,9 +114,10 @@ async function startDevClient(clientOptions) {
 
   // Auto-open browser after vite starts
   if (process.env.MCP_AUTO_OPEN_ENABLED !== "false") {
+    const clientHost = process.env.HOST || "127.0.0.1";
     const url = authDisabled
-      ? `http://127.0.0.1:${CLIENT_PORT}`
-      : `http://127.0.0.1:${CLIENT_PORT}/?MCP_PROXY_AUTH_TOKEN=${sessionToken}`;
+      ? `http://${clientHost}:${CLIENT_PORT}`
+      : `http://${clientHost}:${CLIENT_PORT}/?MCP_PROXY_AUTH_TOKEN=${sessionToken}`;
 
     // Give vite time to start before opening browser
     setTimeout(() => {
@@ -139,7 +141,8 @@ async function startDevClient(clientOptions) {
 }
 
 async function startProdClient(clientOptions) {
-  const { CLIENT_PORT, authDisabled, sessionToken, abort } = clientOptions;
+  const { CLIENT_PORT, authDisabled, sessionToken, abort, cancelled } =
+    clientOptions;
   const inspectorClientPath = resolve(
     __dirname,
     "../..",
@@ -148,11 +151,12 @@ async function startProdClient(clientOptions) {
     "client.js",
   );
 
-  // Auto-open browser with token
-  if (process.env.MCP_AUTO_OPEN_ENABLED !== "false") {
+  // Only auto-open browser if not cancelled
+  if (process.env.MCP_AUTO_OPEN_ENABLED !== "false" && !cancelled) {
+    const clientHost = process.env.HOST || "127.0.0.1";
     const url = authDisabled
-      ? `http://127.0.0.1:${CLIENT_PORT}`
-      : `http://127.0.0.1:${CLIENT_PORT}/?MCP_PROXY_AUTH_TOKEN=${sessionToken}`;
+      ? `http://${clientHost}:${CLIENT_PORT}`
+      : `http://${clientHost}:${CLIENT_PORT}/?MCP_PROXY_AUTH_TOKEN=${sessionToken}`;
     open(url);
   }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -528,7 +528,7 @@ app.get("/config", originValidationMiddleware, authMiddleware, (req, res) => {
   }
 });
 
-const PORT = parseInt(process.env.PORT || "6277", 10);
+const PORT = parseInt(process.env.SERVER_PORT || "6277", 10);
 const HOST = process.env.HOST || "localhost";
 
 const server = app.listen(PORT, HOST);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -104,12 +104,10 @@ const originValidationMiddleware = (
 
   // Default origins based on CLIENT_PORT or use environment variable
   const clientPort = process.env.CLIENT_PORT || "6274";
-  const defaultOrigins = [
-    `http://localhost:${clientPort}`,
-    `http://127.0.0.1:${clientPort}`,
+  const defaultOrigin = `http://localhost:${clientPort}`;
+  const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(",") || [
+    defaultOrigin,
   ];
-  const allowedOrigins =
-    process.env.ALLOWED_ORIGINS?.split(",") || defaultOrigins;
 
   if (origin && !allowedOrigins.includes(origin)) {
     console.error(`Invalid origin: ${origin}`);
@@ -531,7 +529,7 @@ app.get("/config", originValidationMiddleware, authMiddleware, (req, res) => {
 });
 
 const PORT = parseInt(process.env.PORT || "6277", 10);
-const HOST = process.env.HOST || "127.0.0.1";
+const HOST = process.env.HOST || "localhost";
 
 const server = app.listen(PORT, HOST);
 server.on("listening", () => {
@@ -544,7 +542,8 @@ server.on("listening", () => {
 
     // Display clickable URL with pre-filled token
     const clientPort = process.env.CLIENT_PORT || "6274";
-    const clientUrl = `http://localhost:${clientPort}/?MCP_PROXY_AUTH_TOKEN=${sessionToken}`;
+    const clientHost = process.env.HOST || "localhost";
+    const clientUrl = `http://${clientHost}:${clientPort}/?MCP_PROXY_AUTH_TOKEN=${sessionToken}`;
     console.log(
       `\n🔗 Open inspector with token pre-filled:\n   ${clientUrl}\n`,
     );


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Bind client to localhost instead of all interfaces to match server

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Complete the security hardening started in https://github.com/modelcontextprotocol/inspector/commit/e8e990987c544f9e9c2603acbf990866f9c91891 by also binding the client to localhost only.
Previously only the server was protected while the client remained exposed to the network,
allowing attackers to access the server through the client as a proxy.

Changes:
- Add HOST environment variable support to client (prod mode)
- Configure Vite dev server to bind to localhost by default
- Update browser auto-open URLs to use actual host instead of hardcoded 127.0.0.1
- Fix missing cancelled parameter in startProdClient function

|Before|After|
|--|--|
|![CleanShot 2025-06-18 at 17 56 03@2x](https://github.com/user-attachments/assets/82e5f83e-8b5a-46a4-8f34-2043028f2a8e)|![CleanShot 2025-06-18 at 17 59 25@2x](https://github.com/user-attachments/assets/8bb031c8-467d-4818-ad25-984814400410)|

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
prod: `npm run build && npm run start` - works
dev: `npm run dev` - works
test: `npm test` - works

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
There may be instances where clients were inadvertently relying on clients binding to `*:6274` in their setup - e.g. if accessing the inspector UI via a remotely hosted machine or similar.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
