### PR TITLE
Fix hard-coded CLI inspector version

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -63,10 +63,12 @@ function createTransportOptions(target: string[]): TransportOptions {
 async function callMethod(args: Args): Promise<void> {
   const transportOptions = createTransportOptions(args.target);
   const transport = createTransport(transportOptions);
-  const client = new Client({
-    name: "inspector-cli",
-    version: packageJson.version,
-  });
+
+  const [_, name = packageJson.name] = packageJson.name.split("/");
+  const version = packageJson.version;
+  const clientIdentity = { name, version };
+
+  const client = new Client(clientIdentity);
 
   try {
     await connect(client, transport);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -20,6 +20,8 @@ import {
 import { handleError } from "./error-handler.js";
 import { createTransport, TransportOptions } from "./transport.js";
 
+import packageJson from "../package.json" with { type: "json" };
+
 type Args = {
   target: string[];
   method?: string;
@@ -63,7 +65,7 @@ async function callMethod(args: Args): Promise<void> {
   const transport = createTransport(transportOptions);
   const client = new Client({
     name: "inspector-cli",
-    version: "0.5.1",
+    version: packageJson.version,
   });
 
   try {

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -287,19 +287,22 @@ export function useConnection({
   };
 
   const connect = async (_e?: unknown, retryCount: number = 0) => {
-    const client = new Client<Request, Notification, Result>(
-      {
-        name: "mcp-inspector",
-        version: packageJson.version,
-      },
-      {
-        capabilities: {
-          sampling: {},
-          roots: {
-            listChanged: true,
-          },
+    const [_, name = packageJson.name] = packageJson.name.split("/");
+    const version = packageJson.version;
+    const clientIdentity = { name, version };
+
+    const clientCapabilities = {
+      capabilities: {
+        sampling: {},
+        roots: {
+          listChanged: true,
         },
       },
+    };
+
+    const client = new Client<Request, Notification, Result>(
+      clientIdentity,
+      clientCapabilities,
     );
 
     try {


### PR DESCRIPTION
## Motivation and Context

The CLI is hard-coded at version `0.5.1`, from when it was merged in #177 f4e6f4d4ea67.

It can use the `package.json` version, as does [the client](https://github.com/modelcontextprotocol/inspector/blob/main/client/src/lib/hooks/useConnection.ts#L293).

## How Has This Been Tested?

Tested by inspecting raw protocol messages.

Incorrect version on `main`:

```json
{
  "method": "initialize",
  "params": {
    "protocolVersion": "2025-03-26",
    "capabilities": {},
    "clientInfo": {
      "name": "inspector-cli",
      "version": "0.5.1"
    }
  },
  "jsonrpc": "2.0",
  "id": 0
}
```

Corrected:

```json
{
  "method": "initialize",
  "params": {
    "protocolVersion": "2025-03-26",
    "capabilities": {},
    "clientInfo": {
      "name": "inspector-cli",
      "version": "0.14.3"
    }
  },
  "jsonrpc": "2.0",
  "id": 0
}
```

## Breaking Changes

Unlikely.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

### Broader discussion

I have few questions and comments, but Discussions aren't enabled, so I'm not sure where to raise
them --

TL;DR:

* Should the server use `NodeNext` modules?
* Should `"noUncheckedIndexedAccess": true` be used throughout?  Potential errors are detected.
* Code consistency across the sub-packages would be helpful


Despite this being a very tiny change, the varying TypeScript configurations across the sub-packages
tripped me up quite a bit, so I investigated a few details.  Overall, consistency throughout the
monorepo would result in less confusion when reading and working with the parts of the inspector.
Generally lower cognitive overhead -- because, personally, when the same thing is accomplished in
multiple ways, it slows me down because I wonder why and which is correct or preferrable; especially
with unfamiliar code.  Maybe this is second nature to experienced TS developers, working in
difficult contexts?

For example, the `package.json` import in the `cli` and `client` here.

The `cli` TypeScript config uses `NodeNext` modules, which requires an import attribute (`... with: { type: "json" }`).

The `client` uses `ESNext` (and `bundler` configuration), which tolerates an import attribute.  So
the quickest approach would be to add the import attribute in the `client` files,
`useConnection.tsx` and `Sidebar.tsx`.

However, I could not find an easy way to enforce it (detection), so one needs to know.  I briefly
checked the TS compiler options and `eslint-plugin-import`; a custom rule might be needed, which is
a bit too crufty, IMO.

Alternately, change the CLI to `Node16` (used by the server and the TypeScript SDK). This would
eliminate the requirement of an import attribute.  It seems less preferable because enforcing modern
usage is ideal.  __Perhaps the `server` should go to `NodeNext` too?__

Somewhat related, the `cli` compiler config uses `"noUncheckedIndexedAccess": true`, which caught
the potential bug in the destructuring of `split()` (but not in the `client`).  If this option is
enabled on the `client` and `server`, there are many errors.  __Should it be enabled?__
