### PR TITLE
fix: allow typing negative numbers in tool parameter inputs

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -163,12 +163,13 @@ const ToolsTab = ({
                             name={key}
                             placeholder={prop.description}
                             value={(params[key] as string) ?? ""}
-                            onChange={(e) =>
+                            onChange={(e) => {
+                              const value = e.target.value;
                               setParams({
                                 ...params,
-                                [key]: Number(e.target.value),
-                              })
-                            }
+                                [key]: value === "" ? "" : Number(value),
+                              });
+                            }}
                             className="mt-1"
                           />
                         ) : (

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -111,6 +111,27 @@ describe("ToolsTab", () => {
     });
   });
 
+  it("should allow typing negative numbers", async () => {
+    renderToolsTab({
+      selectedTool: mockTools[0],
+    });
+
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+
+    // Complete the negative number
+    fireEvent.change(input, { target: { value: "-42" } });
+    expect(input.value).toBe("-42");
+
+    const submitButton = screen.getByRole("button", { name: /run tool/i });
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+
+    expect(defaultProps.callTool).toHaveBeenCalledWith(mockTools[0].name, {
+      num: -42,
+    });
+  });
+
   it("should disable button and change text while tool is running", async () => {
     // Create a promise that we can resolve later
     let resolvePromise: ((value: unknown) => void) | undefined;


### PR DESCRIPTION
There's a bug in the number inputs for tools where you can't enter negative numbers. (You can paste them or use the little browser UI down arrow, but that thing is a joke). I can create a minimum test MCP server if requested, but you should be able to see the issue using any number number. 

## Motivation and Context

Number inputs were immediately converting values to Number() on every keystroke, which prevented users from typing negative numbers since the intermediate "-" character cannot be converted to a valid number.

Now the input stores the raw string value and only converts to Number when the value is non-empty, allowing proper negative number entry.

## How Has This Been Tested?

- Manually with an MCP server that exposes floats as params. 
- Added a unit test, but that might've been overkill 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

**Real world use case:** A tool that exposes latitude and longitude coordinates and you're constantly copy and pasting them into the inspector but when you double click the longitude coordinate, it never selects the "-" and so you end up just pasting the part that you can select and manually type the "-" in the inspector field, but that doesn't work so now you're either performing surgery trying to select the "-" and the number, or performing surgery trying to click the little down arrow in the browser UI. 
