### PR TITLE
cli: allow custom URL endpoints for HTTP/SSE URLs

### DIFF
--- a/cli/src/transport.ts
+++ b/cli/src/transport.ts
@@ -15,20 +15,30 @@ export type TransportOptions = {
 };
 
 function createSSETransport(options: TransportOptions): Transport {
-  const baseUrl = new URL(options.url ?? "");
-  const sseUrl = baseUrl.pathname.endsWith("/sse")
-    ? baseUrl
-    : new URL("/sse", baseUrl);
+  if (!options.url) {
+    throw new Error("URL is required for SSE transport");
+  }
 
+  const sseUrl = new URL(options.url);
+  
+  if (!sseUrl.pathname.endsWith("/sse")) {
+    console.warn(`[warn] SSE transport URL does not end with /sse: ${options.url}`);
+  }
+  
   return new SSEClientTransport(sseUrl);
 }
 
 function createHTTPTransport(options: TransportOptions): Transport {
-  const baseUrl = new URL(options.url ?? "");
-  const mcpUrl = baseUrl.pathname.endsWith("/mcp")
-    ? baseUrl
-    : new URL("/mcp", baseUrl);
+  if (!options.url) {
+    throw new Error("URL is required for HTTP transport");
+  }
 
+  const mcpUrl = new URL(options.url);
+  
+  if (!mcpUrl.pathname.endsWith("/mcp")) {
+    console.warn(`[warn] HTTP transport URL does not end with /mcp: ${options.url}`);
+  }
+  
   return new StreamableHTTPClientTransport(mcpUrl);
 }
 


### PR DESCRIPTION
The current CLI implementation for HTTP Transport re-writes any CLI URL argument that does not end in `/mcp`. This limits the functionality of the CLI to support other paths like `/mcp/:uuid` or `/mcp/http` and doesn't seem to conform to [the spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) which only _suggests_ the path of `/mcp` as an example but does not require it.

> The server MUST provide a single HTTP endpoint path (hereafter referred to as the MCP endpoint) that supports both POST and GET methods. For example, this could be a URL like https://example.com/mcp.

[https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http)

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Applications may reasonably wish to support multiple transports (including custom transports like SSE and websockets) under paths like `/mcp/http`, `/mcp/sse`, `/mcp/websockets` or nest under other URL paths for any other technical or business reason.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

```
node cli/build/cli.js --cli http://localhost:4417/mcp/claude/http --method tools/list --transport http
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
It is possible that a CLI user could be providing URL like `https://example.com/mcp/sse-not-at-end` that is currently getting re-written to `https://example.com/sse` and maybe the remote backend was configured to serve on `/sse` so while this had previously been working, it would now break that user's CLI invocation -- but they are simply passing the wrong URL. I would view this as a bug myself.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
We are adding HTTP Streamable support to [django-mcp](https://github.com/kitespark/django-mcp/pull/8) and are considering the use of an endpoint pattern like `/mcp/sse`, `/mcp/http`, `/mcp/health` etc (and possibly websockets as a custom transport in the future). This library already supports launching the web UI for `inspector` using the Django management command `python manage.py mcp_inspector` and I want to make sure we conform to the actual `inspector` URL endpoint patterns. Thanks!