### PR TITLE
chore: Add engines to `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,9 @@
         "prettier": "3.3.3",
         "rimraf": "^6.0.1",
         "typescript": "^5.4.2"
+      },
+      "engines": {
+        "node": ">=22.7.5"
       }
     },
     "cli": {


### PR DESCRIPTION
Clone and run `npm install`; `package-lock.json` immediately has changes -- `engines` are added.

## Motivation and Context

Running `npm install` after a fresh clone should not result in any changes to NPM files.

I suspect this was missed in PR #473 

## How Has This Been Tested?

`npm run test` and `npm run test:e2e` both pass all tests.

## Breaking Changes

No

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
