### PR TITLE
[cli] Don't force specific endpoints for remote servers

### DIFF
--- a/cli/scripts/cli-tests.js
+++ b/cli/scripts/cli-tests.js
@@ -680,7 +680,7 @@ async function runTests() {
   // Test 26: HTTP transport with explicit --transport http flag
   await runBasicTest(
     "http_transport_with_explicit_flag",
-    "http://127.0.0.1:3001",
+    "http://127.0.0.1:3001/mcp",
     "--transport",
     "http",
     "--cli",

--- a/cli/scripts/cli-tests.js
+++ b/cli/scripts/cli-tests.js
@@ -710,6 +710,26 @@ async function runTests() {
     "tools/list",
   );
 
+  // Test 29: HTTP transport without URL (should fail)
+  await runErrorTest(
+    "http_transport_without_url",
+    "--transport",
+    "http",
+    "--cli",
+    "--method",
+    "tools/list",
+  );
+
+  // Test 30: SSE transport without URL (should fail)
+  await runErrorTest(
+    "sse_transport_without_url",
+    "--transport",
+    "sse",
+    "--cli",
+    "--method",
+    "tools/list",
+  );
+
   // Kill HTTP server
   try {
     process.kill(-httpServer.pid);


### PR DESCRIPTION
## Motivation and Context
At the moment, the CLI tool expects that remote MCP servers, either using SSE or streamable HTTP transport, have certain endpoints or fragments -- `/sse` and `/mcp`, respectively. These specific routes are not part of the MCP spec, nor should it be expected.

I also added a check to make sure a URL is provided if STDIO isn't picked, erroring out if not.

Fixes: #594
See: #578. Recreating it here with a pared-down version that addresses the review comments. I needed this locally now and am sharing it. Please merge whichever.

## How Has This Been Tested?
I have a local MCP server on a root endpoint (`/`) served by a little Express server (not `/mcp`). Currently, I can't use the inspector CLI as a little integration test in development. Only now can I do:

```console
$ ./build/cli.js --cli --transport http http://localhost:37242 --method tools/list
```


## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Yes. It used to implicitly append `/sse` and `/mcp` routes to remote transport URLs that didn't have them, now it doesn't.

People might have workflows set up that depend on these paths not being explicitly configured.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
