### PR TITLE
Fix Quick OAuth Flow to use automatic callback instead of debug callback

### DIFF
--- a/client/src/components/AuthDebugger.tsx
+++ b/client/src/components/AuthDebugger.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { DebugInspectorOAuthClientProvider } from "../lib/auth";
+import { DebugInspectorOAuthClientProvider, InspectorOAuthClientProvider } from "../lib/auth";
 import { AlertCircle } from "lucide-react";
 import { AuthDebuggerState, EMPTY_DEBUGGER_STATE } from "../lib/auth-types";
 import { OAuthFlowProgress } from "./OAuthFlowProgress";
@@ -149,11 +149,13 @@ const AuthDebugger = ({
         latestError: null,
       };
 
+      // Use regular provider for quick flow (automatic callback)
+      const provider = new InspectorOAuthClientProvider(serverUrl);
       const oauthMachine = new OAuthStateMachine(serverUrl, (updates) => {
         // Update our temporary state during the process
         currentState = { ...currentState, ...updates };
         // But don't call updateAuthState yet
-      });
+      }, provider);
 
       // Manually step through each stage of the OAuth flow
       while (currentState.oauthStep !== "complete") {


### PR DESCRIPTION
This PR fixes an issue where the "Quick OAuth Flow" button was using the debug callback URL (`/oauth/callback/debug`) instead of the automatic callback URL (`/oauth/callback`), requiring users to manually copy-paste authorization codes.

## Changes Made

1. **Updated `OAuthStateMachine`** to accept an optional provider parameter
   - Maintains backward compatibility by defaulting to `DebugInspectorOAuthClientProvider`
   - Handles provider-specific methods (`saveServerMetadata`, `getServerMetadata`) gracefully

2. **Updated `AuthDebugger.tsx`** to use the appropriate provider for each flow:
   - **Quick OAuth Flow**: Uses `InspectorOAuthClientProvider` → `/oauth/callback` (automatic)
   - **Guided OAuth Flow**: Uses `DebugInspectorOAuthClientProvider` → `/oauth/callback/debug` (manual)

## Testing

- ✅ Build passes without TypeScript errors
- ✅ Maintains backward compatibility for existing guided flow
- ✅ Quick OAuth Flow now uses automatic callback for seamless UX
- ✅ Tested end-to-end: OAuth flow completes automatically and redirects back to inspector

## Important Note about Magic Links

When using magic link authentication (like Supabase), ensure the magic link is opened in the **same tab** as the MCP Inspector to preserve the proxy authentication token context. If the magic link opens in a new tab, copy the URL and paste it into the original inspector tab.

This behavior affects all OAuth flows in the inspector, not just this fix, as the proxy auth token is required for the inspector to communicate with its proxy server.

## Before

Quick OAuth Flow redirected to `/oauth/callback/debug` requiring manual code copying, making it identical to the Guided OAuth Flow.

## After

Quick OAuth Flow redirects to `/oauth/callback` for automatic callback handling, providing the seamless authentication experience users expect from a "quick" flow.

Fixes #598