### PR TITLE
fix: interpretation of unstructured content and tests

### DIFF
--- a/client/src/components/ToolResults.tsx
+++ b/client/src/components/ToolResults.tsx
@@ -27,7 +27,7 @@ const checkContentCompatibility = (
   if (textBlocks.length === 0) {
     return {
       isCompatible: false,
-      message: "No text blocks found",
+      message: "No text blocks to match structured content",
     };
   }
 
@@ -46,7 +46,7 @@ const checkContentCompatibility = (
       if (isEqual) {
         return {
           isCompatible: true,
-          message: `Matching JSON found${textBlocks.length > 1 ? " (multiple blocks)" : ""}${unstructuredContent.length > textBlocks.length ? " + other content" : ""}`,
+          message: `Structured content matches text block${textBlocks.length > 1 ? " (multiple blocks)" : ""}${unstructuredContent.length > textBlocks.length ? " + other content" : ""}`,
         };
       }
     } catch {
@@ -57,7 +57,7 @@ const checkContentCompatibility = (
 
   return {
     isCompatible: false,
-    message: "No matching JSON found",
+    message: "No text block matches structured content",
   };
 };
 

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -354,7 +354,9 @@ describe("ToolsTab", () => {
       });
 
       // Should show compatibility result
-      expect(screen.getByText(/matching json/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/structured content matches/i),
+      ).toBeInTheDocument();
     });
 
     it("should accept multiple content blocks with structured output", () => {
@@ -374,7 +376,9 @@ describe("ToolsTab", () => {
       });
 
       // Should show compatible result with multiple blocks
-      expect(screen.getByText(/matching json.*multiple/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/structured content matches.*multiple/i),
+      ).toBeInTheDocument();
     });
 
     it("should accept mixed content types with structured output", () => {
@@ -445,7 +449,9 @@ describe("ToolsTab", () => {
 
       // Should not show any compatibility messages
       expect(
-        screen.queryByText(/matching json|no text blocks|no matching/i),
+        screen.queryByText(
+          /structured content matches|no text blocks|no.*matches/i,
+        ),
       ).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Motivation and Context

Update structured output validation to align with spec allowing multiple unstructured content blocks.

Previously, the inspector incorrectly validated that unstructured output must contain *only* a single text block with JSON matching the structured output. This PR updates the validation to correctly reflect the spec, which allows unstructured output to include a JSON text block matching the structured output, alongside any number of other content blocks (text, image, linked/embedded resources, etc.) in any order, as clarified in modelcontextprotocol/modelcontextprotocol#889.

## How Has This Been Tested?

Ran it locally with my own MCP server:

<img width="757" height="146" alt="image" src="https://github.com/user-attachments/assets/23ab01aa-223a-4ec4-a054-eda9981a8c47" />

<img width="761" height="758" alt="image" src="https://github.com/user-attachments/assets/0c329c65-bd1b-40b6-99b9-6b54d79cb550" />

Also, the tests have been updated and are passing.

## Breaking Changes

No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This was written by Cursor Agents, but reviewed and run by me.
