### PR TITLE
Run the CLI tests in CI

### DIFF
--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -15,15 +15,19 @@ jobs:
       run:
         working-directory: ./cli
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: "14"
+          node-version-file: package.json
+          cache: npm
 
-      - name: Install dependencies
-        run: npm install
+      # Working around https://github.com/npm/cli/issues/4828
+      - run: npm install --no-package-lock
+
+      - name: Build CLI
+        run: npm run build
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -23,8 +23,7 @@ jobs:
           node-version-file: package.json
           cache: npm
 
-      # Working around https://github.com/npm/cli/issues/4828
-      - run: npm install --no-package-lock
+      - run: npm install
 
       - name: Build CLI
         run: npm run build

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./cli
     steps:
       - uses: actions/checkout@v4
 
@@ -21,10 +24,10 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install --workspace=cli
+        run: npm install --ignore-scripts
 
       - name: Build CLI
-        run: npm run build --workspace=cli
+        run: npm run build
 
       - name: Run tests
-        run: npm run test --workspace=cli
+        run: npm test

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -1,0 +1,26 @@
+name: CLI Tests
+
+on:
+  push:
+    paths:
+      - 'cli/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./cli
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -31,5 +31,8 @@ jobs:
       - name: Build CLI
         run: npm run build
 
+      - name: Explicitly pre-install test dependencies
+        run: npx -y @modelcontextprotocol/server-everything --help || true
+
       - name: Run tests
         run: npm test

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -24,7 +24,9 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install --ignore-scripts
+        run: |
+          cd ..
+          npm ci --ignore-scripts
 
       - name: Build CLI
         run: npm run build

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -11,26 +11,20 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./cli
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: package.json
+          node-version-file: cli/package.json
           cache: npm
 
-      - name: Current directory
-        run: pwd
-
       - name: Install dependencies
-        run: npm install
+        run: npm install --workspace=cli
 
       - name: Build CLI
-        run: npm run build
+        run: npm run build --workspace=cli
 
       - name: Run tests
-        run: npm test
+        run: npm run test --workspace=cli

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -3,7 +3,7 @@ name: CLI Tests
 on:
   push:
     paths:
-      - 'cli/**'
+      - "cli/**"
 
 jobs:
   test:
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "14"
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Run tests
         run: npm test
+        env:
+          NPM_CONFIG_YES: true
+          CI: true

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -23,7 +23,11 @@ jobs:
           node-version-file: package.json
           cache: npm
 
-      - run: npm install
+      - name: Current directory
+        run: pwd
+
+      - name: Install dependencies
+        run: npm install
 
       - name: Build CLI
         run: npm run build

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: cli/package.json
+          node-version-file: package.json
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - "cli/**"
+  pull_request:
+    paths:
+      - "cli/**"
 
 jobs:
   test:

--- a/cli/scripts/cli-tests.js
+++ b/cli/scripts/cli-tests.js
@@ -12,7 +12,7 @@ const colors = {
 
 import fs from "fs";
 import path from "path";
-import { execSync, spawn } from "child_process";
+import { spawn } from "child_process";
 import os from "os";
 import { fileURLToPath } from "url";
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -233,7 +233,7 @@ async function main(): Promise<void> {
     const args = parseArgs();
 
     if (args.cli) {
-      runCli(args);
+      await runCli(args);
     } else {
       await runWebClient(args);
     }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -287,6 +287,8 @@ async function main(): Promise<void> {
   try {
     const args = parseArgs();
     await callMethod(args);
+    // Explicitly exit to ensure process terminates in CI
+    process.exit(0);
   } catch (error) {
     handleError(error);
   }


### PR DESCRIPTION
Right now, the inspector has a CLI feature as well as a series of tests. However, they're not currently run in CI. For the moment, they are only triggered on file changes in the CLI folder, as AFAICT it is currently a separate code base.


## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
I pushed up a PR that touches files in the CLI folder (#595) and had to manually show the test run results. 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
The check itself within the GitHub UI should be sufficient. 

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
