### PR TITLE
Register oauth clients with a preferred auth method

### DIFF
--- a/client/src/lib/oauth-state-machine.ts
+++ b/client/src/lib/oauth-state-machine.ts
@@ -88,6 +88,16 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
         clientMetadata.scope = scopesSupported.join(" ");
       }
 
+      // Select a preferred auth method
+      const authMethodsSupported =
+        metadata.token_endpoint_auth_methods_supported;
+      for (const authMethod of ["client_secret_basic", "client_secret_post"]) {
+        if (authMethodsSupported && authMethodsSupported.includes(authMethod)) {
+          clientMetadata.token_endpoint_auth_method = authMethod;
+          break;
+        }
+      }
+
       const fullInformation = await registerClient(context.serverUrl, {
         metadata,
         clientMetadata,


### PR DESCRIPTION
This PR registers oauth clients with a `token_endpoint_auth_method` as preferred by the authorization server metadata `token_endpoint_auth_methods_supported` field, instead of always sending `none`.

If the authorization server expresses multiple preferences in `token_endpoint_auth_methods_supported`, the first match from: `client_secret_basic, client_secret_post, none` is picked. If no preference is expressed, `none` is picked. Unknown values are ignored.

I don't see any tests around client registration, unfortunately. I could add some with a little help from you experts!

## Motivation and Context
Some MCP clients (e.g. vscode) don't currently support any token endpoint auth (https://github.com/microsoft/vscode/issues/257277), but the MCP SDKs do (https://github.com/modelcontextprotocol/typescript-sdk/pull/720). Without this change, one has to guess at when clients actually support token endpoint auth based on other metadata or simply always use None.

## How Has This Been Tested?
I tested this locally with my MCP server and authorization server, stepping through the inspector's guided flow to check that client registration matches expectations.

* token_endpoint_auth_methods_supported is empty/absent -> client registration request is sent with client_secret_basic
* token_endpoint_auth_methods_supported=["none"] -> client registration request is sent with none
* token_endpoint_auth_methods_supported=["client_secret_basic", "client_secret_post"] -> client registration request is sent with client_secret_basic
* token_endpoint_auth_methods_supported=["client_secret_post"] -> client registration request is sent with client_secret_post
* token_endpoint_auth_methods_supported=["client_secret_basic", "client_secret_post", "none"] -> client registration request is sent with client_secret_basic

## Breaking Changes
No, existing authorization server preferences continue to be respected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
