### PR TITLE
fix: Pass args as string from client to server

### DIFF
--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -93,7 +93,7 @@ async function startProdServer(serverOptions) {
       inspectorServerPath,
       ...(command ? [`--command`, command] : []),
       ...(mcpServerArgs && mcpServerArgs.length > 0
-        ? [`--args`, mcpServerArgs.join(" ")]
+        ? [`--args`, `"${mcpServerArgs.join(" ")}"`]
         : []),
     ],
     {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -522,7 +522,7 @@ app.get("/config", originValidationMiddleware, authMiddleware, (req, res) => {
     res.json({
       defaultEnvironment,
       defaultCommand: values.command,
-      defaultArgs: values.args,
+      defaultArgs: values.args.substring(1, values.args.length - 1), // Remove quotes from args
     });
   } catch (error) {
     console.error("Error in /config route:", error);


### PR DESCRIPTION
The arguments are passed a string between the client and the server.

See #649 

## Motivation and Context

When the first argument started with `--` (e.g. `--my-arg`), the following error was triggered:

```
~ » npx @modelcontextprotocol/inspector --config ~/mcp.json --server my-server
Starting MCP inspector...
node:internal/util/parse_args/parse_args:87
    throw new ERR_PARSE_ARGS_INVALID_OPTION_VALUE(errorMessage);
          ^

TypeError [ERR_PARSE_ARGS_INVALID_OPTION_VALUE]: Option '--args' argument is ambiguous.
Did you forget to specify the option argument for '--args'?
To specify an option argument starting with a dash use '--args=-XYZ'.
    at checkOptionLikeValue (node:internal/util/parse_args/parse_args:87:11)
    at node:internal/util/parse_args/parse_args:382:9
    at Array.forEach (<anonymous>)
    at parseArgs (node:internal/util/parse_args/parse_args:378:3)
    at file:///Users/alejandro.borbolla/.npm/_npx/5a9d879542beca3a/node_modules/@modelcontextprotocol/inspector/server/build/index.js:25:20
    at ModuleJob.run (node:internal/modules/esm/module_job:370:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:665:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:99:5) {
  code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE'
}
```

The reason is that the client passes the following argument to the server:

```
node <server-path> --command <command> --args <args>
```

So if the first argument of the MCP server started with `--`, it gives:

```
node <server-path> --command mcp-server-command --args --first-arg
```

This is an invalid syntax. The solution is to send the `args` as a string, and surrounded by `"`. Giving the following format:

```
node <server-path> --command <command> --args "<args>"
```

The `"` are simply removed by the server.

## How Has This Been Tested?

It has been tested by:
- Sending parameters directly on the command line: `npx @modelcontextprotocol/inspector -- myserver first-arg`
- Using the config file: `npx @modelcontextprotocol/inspector --config mcp.json --server myserver`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
