### PR TITLE
feat: Auto-detect transport type from config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ sdk
 client/playwright-report/
 client/results.json
 client/test-results/
+mcp.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ packages
 server/build
 CODE_OF_CONDUCT.md
 SECURITY.md
+mcp.json

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ You can launch the inspector without specifying a server name if your config has
 
 ```bash
 # Automatically uses "my-server" if it's the only one
-npx @modelcontextprotocol/inspector --config config.json
+npx @modelcontextprotocol/inspector --config mcp.json
 ```
 
 2. **A server named "default-server"** - automatically selected:

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Example server configuration file:
 The inspector automatically detects the transport type from your config file. You can specify different transport types:
 
 **STDIO (default):**
+
 ```json
 {
   "mcpServers": {
@@ -252,6 +253,7 @@ The inspector automatically detects the transport type from your config file. Yo
 ```
 
 **SSE (Server-Sent Events):**
+
 ```json
 {
   "mcpServers": {
@@ -264,6 +266,7 @@ The inspector automatically detects the transport type from your config file. Yo
 ```
 
 **Streamable HTTP:**
+
 ```json
 {
   "mcpServers": {
@@ -280,12 +283,14 @@ The inspector automatically detects the transport type from your config file. Yo
 You can launch the inspector without specifying a server name if your config has:
 
 1. **A single server** - automatically selected:
+
 ```bash
 # Automatically uses "my-server" if it's the only one
 npx @modelcontextprotocol/inspector --config config.json
 ```
 
 2. **A server named "default-server"** - automatically selected:
+
 ```json
 {
   "mcpServers": {

--- a/README.md
+++ b/README.md
@@ -234,6 +234,73 @@ Example server configuration file:
 }
 ```
 
+#### Transport Types in Config Files
+
+The inspector automatically detects the transport type from your config file. You can specify different transport types:
+
+**STDIO (default):**
+```json
+{
+  "mcpServers": {
+    "my-stdio-server": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-everything"]
+    }
+  }
+}
+```
+
+**SSE (Server-Sent Events):**
+```json
+{
+  "mcpServers": {
+    "my-sse-server": {
+      "type": "sse",
+      "url": "http://localhost:3000/sse"
+    }
+  }
+}
+```
+
+**Streamable HTTP:**
+```json
+{
+  "mcpServers": {
+    "my-http-server": {
+      "type": "streamable-http",
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}
+```
+
+#### Default Server Selection
+
+You can launch the inspector without specifying a server name if your config has:
+
+1. **A single server** - automatically selected:
+```bash
+# Automatically uses "my-server" if it's the only one
+npx @modelcontextprotocol/inspector --config config.json
+```
+
+2. **A server named "default-server"** - automatically selected:
+```json
+{
+  "mcpServers": {
+    "default-server": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-everything"]
+    },
+    "other-server": {
+      "command": "node",
+      "args": ["other.js"]
+    }
+  }
+}
+```
+
 > **Tip:** You can easily generate this configuration format using the **Server Entry** and **Servers File** buttons in the Inspector UI, as described in the Servers File Export section above.
 
 You can also set the initial `transport` type, `serverUrl`, `serverCommand`, and `serverArgs` via query params, for example:

--- a/cli/scripts/cli-tests.js
+++ b/cli/scripts/cli-tests.js
@@ -781,6 +781,102 @@ async function runTests() {
   );
 
   console.log(
+    `\n${colors.YELLOW}=== Running Default Server Tests ===${colors.NC}`,
+  );
+
+  // Create config with single server for auto-selection
+  const singleServerConfigPath = path.join(TEMP_DIR, "single-server-config.json");
+  fs.writeFileSync(
+    singleServerConfigPath,
+    JSON.stringify(
+      {
+        mcpServers: {
+          "only-server": {
+            command: "npx",
+            args: ["@modelcontextprotocol/server-everything"],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  // Create config with default-server
+  const defaultServerConfigPath = path.join(TEMP_DIR, "default-server-config.json");
+  fs.writeFileSync(
+    defaultServerConfigPath,
+    JSON.stringify(
+      {
+        mcpServers: {
+          "default-server": {
+            command: "npx",
+            args: ["@modelcontextprotocol/server-everything"],
+          },
+          "other-server": {
+            command: "node",
+            args: ["other.js"],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  // Create config with multiple servers (no default)
+  const multiServerConfigPath = path.join(TEMP_DIR, "multi-server-config.json");
+  fs.writeFileSync(
+    multiServerConfigPath,
+    JSON.stringify(
+      {
+        mcpServers: {
+          "server1": {
+            command: "npx",
+            args: ["@modelcontextprotocol/server-everything"],
+          },
+          "server2": {
+            command: "node",
+            args: ["other.js"],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  // Test 29: Config with single server auto-selection
+  await runBasicTest(
+    "single_server_auto_select",
+    "--config",
+    singleServerConfigPath,
+    "--cli",
+    "--method",
+    "tools/list",
+  );
+
+  // Test 30: Config with default-server auto-selection
+  await runBasicTest(
+    "default_server_auto_select",
+    "--config",
+    defaultServerConfigPath,
+    "--cli",
+    "--method",
+    "tools/list",
+  );
+
+  // Test 31: Config with multiple servers and no default (should fail)
+  await runErrorTest(
+    "multi_server_no_default",
+    "--config",
+    multiServerConfigPath,
+    "--cli",
+    "--method",
+    "tools/list",
+  );
+
+  console.log(
     `\n${colors.YELLOW}=== Running HTTP Transport Tests ===${colors.NC}`,
   );
 
@@ -799,7 +895,7 @@ async function runTests() {
 
   await new Promise((resolve) => setTimeout(resolve, 3000));
 
-  // Test 29: HTTP transport inferred from URL ending with /mcp
+  // Test 32: HTTP transport inferred from URL ending with /mcp
   await runBasicTest(
     "http_transport_inferred",
     "http://127.0.0.1:3001/mcp",
@@ -808,7 +904,7 @@ async function runTests() {
     "tools/list",
   );
 
-  // Test 30: HTTP transport with explicit --transport http flag
+  // Test 33: HTTP transport with explicit --transport http flag
   await runBasicTest(
     "http_transport_with_explicit_flag",
     "http://127.0.0.1:3001/mcp",
@@ -819,7 +915,7 @@ async function runTests() {
     "tools/list",
   );
 
-  // Test 31: HTTP transport with suffix and --transport http flag
+  // Test 34: HTTP transport with suffix and --transport http flag
   await runBasicTest(
     "http_transport_with_explicit_flag_and_suffix",
     "http://127.0.0.1:3001/mcp",
@@ -830,7 +926,7 @@ async function runTests() {
     "tools/list",
   );
 
-  // Test 32: SSE transport given to HTTP server (should fail)
+  // Test 35: SSE transport given to HTTP server (should fail)
   await runErrorTest(
     "sse_transport_given_to_http_server",
     "http://127.0.0.1:3001",
@@ -841,7 +937,7 @@ async function runTests() {
     "tools/list",
   );
 
-  // Test 33: HTTP transport without URL (should fail)
+  // Test 36: HTTP transport without URL (should fail)
   await runErrorTest(
     "http_transport_without_url",
     "--transport",
@@ -851,7 +947,7 @@ async function runTests() {
     "tools/list",
   );
 
-  // Test 34: SSE transport without URL (should fail)
+  // Test 37: SSE transport without URL (should fail)
   await runErrorTest(
     "sse_transport_without_url",
     "--transport",

--- a/cli/scripts/cli-tests.js
+++ b/cli/scripts/cli-tests.js
@@ -744,8 +744,8 @@ async function runTests() {
     "tools/list",
   );
 
-  // Test 26: Config with SSE transport type (CLI mode)
-  await runBasicTest(
+  // Test 26: Config with SSE transport type (CLI mode) - expects connection error
+  await runErrorTest(
     "config_sse_type_cli",
     "--config",
     sseConfigPath,
@@ -756,8 +756,8 @@ async function runTests() {
     "tools/list",
   );
 
-  // Test 27: Config with streamable-http transport type (CLI mode)
-  await runBasicTest(
+  // Test 27: Config with streamable-http transport type (CLI mode) - expects connection error
+  await runErrorTest(
     "config_http_type_cli",
     "--config",
     httpConfigPath,

--- a/cli/scripts/cli-tests.js
+++ b/cli/scripts/cli-tests.js
@@ -744,26 +744,28 @@ async function runTests() {
     "tools/list",
   );
 
-  // Test 26: Config with SSE transport type (should pass transport to client)
+  // Test 26: Config with SSE transport type (CLI mode)
   await runBasicTest(
-    "config_sse_type",
+    "config_sse_type_cli",
     "--config",
     sseConfigPath,
     "--server",
     "test-sse",
-    "echo",
-    "test",
+    "--cli",
+    "--method",
+    "tools/list",
   );
 
-  // Test 27: Config with streamable-http transport type
+  // Test 27: Config with streamable-http transport type (CLI mode)
   await runBasicTest(
-    "config_http_type",
+    "config_http_type_cli",
     "--config",
     httpConfigPath,
     "--server",
     "test-http",
-    "echo",
-    "test",
+    "--cli",
+    "--method",
+    "tools/list",
   );
 
   // Test 28: Legacy config without type field (backward compatibility)

--- a/cli/scripts/cli-tests.js
+++ b/cli/scripts/cli-tests.js
@@ -785,7 +785,10 @@ async function runTests() {
   );
 
   // Create config with single server for auto-selection
-  const singleServerConfigPath = path.join(TEMP_DIR, "single-server-config.json");
+  const singleServerConfigPath = path.join(
+    TEMP_DIR,
+    "single-server-config.json",
+  );
   fs.writeFileSync(
     singleServerConfigPath,
     JSON.stringify(
@@ -803,7 +806,10 @@ async function runTests() {
   );
 
   // Create config with default-server
-  const defaultServerConfigPath = path.join(TEMP_DIR, "default-server-config.json");
+  const defaultServerConfigPath = path.join(
+    TEMP_DIR,
+    "default-server-config.json",
+  );
   fs.writeFileSync(
     defaultServerConfigPath,
     JSON.stringify(
@@ -831,11 +837,11 @@ async function runTests() {
     JSON.stringify(
       {
         mcpServers: {
-          "server1": {
+          server1: {
             command: "npx",
             args: ["@modelcontextprotocol/server-everything"],
           },
-          "server2": {
+          server2: {
             command: "node",
             args: ["other.js"],
           },

--- a/cli/scripts/cli-tests.js
+++ b/cli/scripts/cli-tests.js
@@ -862,9 +862,9 @@ async function runTests() {
     "tools/list",
   );
 
-  // Test 30: Config with default-server auto-selection
-  await runBasicTest(
-    "default_server_auto_select",
+  // Test 30: Config with default-server should now require explicit selection (multiple servers)
+  await runErrorTest(
+    "default_server_requires_explicit_selection",
     "--config",
     defaultServerConfigPath,
     "--cli",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -130,7 +130,8 @@ async function runCli(args: Args): Promise<void> {
     // Add transport flag if specified
     if (args.transport && args.transport !== "stdio") {
       // Convert streamable-http back to http for CLI mode
-      const cliTransport = args.transport === "streamable-http" ? "http" : args.transport;
+      const cliTransport =
+        args.transport === "streamable-http" ? "http" : args.transport;
       cliArgs.push("--transport", cliTransport);
     }
 
@@ -307,7 +308,7 @@ function parseArgs(): Args {
   // Otherwise use command line arguments
   const command = finalArgs[0] || "";
   const args = finalArgs.slice(1);
-  
+
   // Map "http" shorthand to "streamable-http"
   let transport = options.transport;
   if (transport === "http") {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -122,7 +122,18 @@ async function runCli(args: Args): Promise<void> {
   });
 
   try {
-    await spawnPromise("node", [cliPath, args.command, ...args.args], {
+    // Build CLI arguments
+    const cliArgs = [cliPath];
+
+    // Add transport flag if specified
+    if (args.transport && args.transport !== "stdio") {
+      cliArgs.push("--transport", args.transport);
+    }
+
+    // Add command and remaining args
+    cliArgs.push(args.command, ...args.args);
+
+    await spawnPromise("node", cliArgs, {
       env: { ...process.env, ...args.envArgs },
       signal: abort.signal,
       echoOutput: true,
@@ -268,7 +279,7 @@ function parseArgs(): Args {
       };
     } else if (config.type === "sse" || config.type === "streamable-http") {
       return {
-        command: "",
+        command: config.url,
         args: finalArgs,
         envArgs: options.e || {},
         cli: options.cli || false,

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -24,6 +24,7 @@ type CliOptions = {
   server?: string;
   cli?: boolean;
   transport?: string;
+  serverUrl?: string;
 };
 
 type ServerConfig =
@@ -224,7 +225,8 @@ function parseArgs(): Args {
     .option("--config <path>", "config file path")
     .option("--server <n>", "server name from config file")
     .option("--cli", "enable CLI mode")
-    .option("--transport <type>", "transport type (stdio, sse, http)");
+    .option("--transport <type>", "transport type (stdio, sse, http)")
+    .option("--server-url <url>", "server URL for SSE/HTTP transport");
 
   // Parse only the arguments before --
   program.parse(preArgs);
@@ -318,6 +320,7 @@ function parseArgs(): Args {
     envArgs: options.e || {},
     cli: options.cli || false,
     transport: transport as "stdio" | "sse" | "streamable-http" | undefined,
+    serverUrl: options.serverUrl,
   };
 }
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -222,9 +222,7 @@ function parseArgs(): Args {
 
   // Validate config and server options
   if (!options.config && options.server) {
-    throw new Error(
-      "--server requires --config to be specified",
-    );
+    throw new Error("--server requires --config to be specified");
   }
 
   // If config is provided without server, try to auto-select
@@ -233,11 +231,11 @@ function parseArgs(): Args {
       path.isAbsolute(options.config)
         ? options.config
         : path.resolve(process.cwd(), options.config),
-      "utf8"
+      "utf8",
     );
     const parsedConfig = JSON.parse(configContent);
     const servers = Object.keys(parsedConfig.mcpServers || {});
-    
+
     if (servers.includes("default-server")) {
       // Use default-server if it exists
       options.server = "default-server";
@@ -249,7 +247,7 @@ function parseArgs(): Args {
     } else {
       // Multiple servers, no default-server
       throw new Error(
-        `Multiple servers found in config file. Please specify one with --server.\nAvailable servers: ${servers.join(", ")}`
+        `Multiple servers found in config file. Please specify one with --server.\nAvailable servers: ${servers.join(", ")}`,
       );
     }
   }

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -254,16 +254,13 @@ function parseArgs(): Args {
     const parsedConfig = JSON.parse(configContent);
     const servers = Object.keys(parsedConfig.mcpServers || {});
 
-    if (servers.includes("default-server")) {
-      // Use default-server if it exists
-      options.server = "default-server";
-    } else if (servers.length === 1) {
+    if (servers.length === 1) {
       // Use the only server if there's just one
       options.server = servers[0];
     } else if (servers.length === 0) {
       throw new Error("No servers found in config file");
     } else {
-      // Multiple servers, no default-server
+      // Multiple servers, require explicit selection
       throw new Error(
         `Multiple servers found in config file. Please specify one with --server.\nAvailable servers: ${servers.join(", ")}`,
       );

--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -13,12 +13,7 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms, true));
 }
 
-function getClientUrl(
-  port,
-  authDisabled,
-  sessionToken,
-  serverPort,
-) {
+function getClientUrl(port, authDisabled, sessionToken, serverPort) {
   const host = process.env.HOST || "localhost";
   const baseUrl = `http://${host}:${port}`;
 

--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -18,8 +18,6 @@ function getClientUrl(
   authDisabled,
   sessionToken,
   serverPort,
-  transport,
-  serverUrl,
 ) {
   const host = process.env.HOST || "localhost";
   const baseUrl = `http://${host}:${port}`;
@@ -30,12 +28,6 @@ function getClientUrl(
   }
   if (!authDisabled) {
     params.set("MCP_PROXY_AUTH_TOKEN", sessionToken);
-  }
-  if (transport) {
-    params.set("transport", transport);
-  }
-  if (serverUrl) {
-    params.set("serverUrl", serverUrl);
   }
   return params.size > 0 ? `${baseUrl}/?${params.toString()}` : baseUrl;
 }
@@ -136,8 +128,6 @@ async function startDevClient(clientOptions) {
     sessionToken,
     abort,
     cancelled,
-    transport,
-    serverUrl,
   } = clientOptions;
   const clientCommand = "npx";
   const host = process.env.HOST || "localhost";
@@ -155,8 +145,6 @@ async function startDevClient(clientOptions) {
     authDisabled,
     sessionToken,
     SERVER_PORT,
-    transport,
-    serverUrl,
   );
 
   // Give vite time to start before opening or logging the URL
@@ -190,8 +178,6 @@ async function startProdClient(clientOptions) {
     sessionToken,
     abort,
     cancelled,
-    transport,
-    serverUrl,
   } = clientOptions;
   const inspectorClientPath = resolve(
     __dirname,
@@ -206,8 +192,6 @@ async function startProdClient(clientOptions) {
     authDisabled,
     sessionToken,
     SERVER_PORT,
-    transport,
-    serverUrl,
   );
 
   await spawnPromise("node", [inspectorClientPath], {
@@ -229,8 +213,6 @@ async function main() {
   let command = null;
   let parsingFlags = true;
   let isDev = false;
-  let transport = null;
-  let serverUrl = null;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -256,10 +238,6 @@ async function main() {
       } else {
         envVars[envVar] = "";
       }
-    } else if (parsingFlags && arg === "--transport" && i + 1 < args.length) {
-      transport = args[++i];
-    } else if (parsingFlags && arg === "--server-url" && i + 1 < args.length) {
-      serverUrl = args[++i];
     } else if (!command && !isDev) {
       command = arg;
     } else if (!isDev) {
@@ -319,8 +297,6 @@ async function main() {
         sessionToken,
         abort,
         cancelled,
-        transport,
-        serverUrl,
       };
 
       await (isDev

--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -28,8 +28,15 @@ function getClientUrl(port, authDisabled, sessionToken, serverPort) {
 }
 
 async function startDevServer(serverOptions) {
-  const { SERVER_PORT, CLIENT_PORT, sessionToken, envVars, abort } =
-    serverOptions;
+  const {
+    SERVER_PORT,
+    CLIENT_PORT,
+    sessionToken,
+    envVars,
+    abort,
+    transport,
+    serverUrl,
+  } = serverOptions;
   const serverCommand = "npx";
   const serverArgs = ["tsx", "watch", "--clear-screen=false", "src/index.ts"];
   const isWindows = process.platform === "win32";
@@ -42,6 +49,8 @@ async function startDevServer(serverOptions) {
       CLIENT_PORT,
       MCP_PROXY_AUTH_TOKEN: sessionToken,
       MCP_ENV_VARS: JSON.stringify(envVars),
+      ...(transport ? { MCP_TRANSPORT: transport } : {}),
+      ...(serverUrl ? { MCP_SERVER_URL: serverUrl } : {}),
     },
     signal: abort.signal,
     echoOutput: true,
@@ -78,6 +87,8 @@ async function startProdServer(serverOptions) {
     abort,
     command,
     mcpServerArgs,
+    transport,
+    serverUrl,
   } = serverOptions;
   const inspectorServerPath = resolve(
     __dirname,
@@ -95,6 +106,8 @@ async function startProdServer(serverOptions) {
       ...(mcpServerArgs && mcpServerArgs.length > 0
         ? [`--args=${mcpServerArgs.join(" ")}`]
         : []),
+      ...(transport ? [`--transport=${transport}`] : []),
+      ...(serverUrl ? [`--server-url=${serverUrl}`] : []),
     ],
     {
       env: {
@@ -208,6 +221,8 @@ async function main() {
   let command = null;
   let parsingFlags = true;
   let isDev = false;
+  let transport = null;
+  let serverUrl = null;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -219,6 +234,16 @@ async function main() {
 
     if (parsingFlags && arg === "--dev") {
       isDev = true;
+      continue;
+    }
+
+    if (parsingFlags && arg === "--transport" && i + 1 < args.length) {
+      transport = args[++i];
+      continue;
+    }
+
+    if (parsingFlags && arg === "--server-url" && i + 1 < args.length) {
+      serverUrl = args[++i];
       continue;
     }
 
@@ -273,6 +298,8 @@ async function main() {
       abort,
       command,
       mcpServerArgs,
+      transport,
+      serverUrl,
     };
 
     const result = isDev

--- a/client/e2e/cli-arguments.spec.ts
+++ b/client/e2e/cli-arguments.spec.ts
@@ -7,7 +7,9 @@ test.describe("CLI Arguments @cli", () => {
     page,
   }) => {
     // Simulate: npx . --transport sse --server-url http://localhost:3000/sse
-    await page.goto("http://localhost:6274/?transport=sse&serverUrl=http://localhost:3000/sse");
+    await page.goto(
+      "http://localhost:6274/?transport=sse&serverUrl=http://localhost:3000/sse",
+    );
 
     // Wait for the Transport Type dropdown to be visible
     const selectTrigger = page.getByLabel("Transport Type");
@@ -26,7 +28,9 @@ test.describe("CLI Arguments @cli", () => {
     page,
   }) => {
     // Simulate config with streamable-http transport
-    await page.goto("http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:3000/mcp");
+    await page.goto(
+      "http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:3000/mcp",
+    );
 
     // Wait for the Transport Type dropdown to be visible
     const selectTrigger = page.getByLabel("Transport Type");

--- a/client/e2e/cli-arguments.spec.ts
+++ b/client/e2e/cli-arguments.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+
+// These tests verify that CLI arguments correctly set URL parameters
+// The CLI should parse config files and pass transport/serverUrl as URL params
+test.describe("CLI Arguments @cli", () => {
+  test("should pass transport parameter from command line", async ({
+    page,
+  }) => {
+    // Simulate: npx . --transport sse --server-url http://localhost:3000/sse
+    await page.goto("http://localhost:6274/?transport=sse&serverUrl=http://localhost:3000/sse");
+
+    // Wait for the Transport Type dropdown to be visible
+    const selectTrigger = page.getByLabel("Transport Type");
+    await expect(selectTrigger).toBeVisible();
+
+    // Verify transport dropdown shows SSE
+    await expect(selectTrigger).toContainText("SSE");
+
+    // Verify URL field is visible and populated
+    const urlInput = page.locator("#sse-url-input");
+    await expect(urlInput).toBeVisible();
+    await expect(urlInput).toHaveValue("http://localhost:3000/sse");
+  });
+
+  test("should pass transport parameter for streamable-http", async ({
+    page,
+  }) => {
+    // Simulate config with streamable-http transport
+    await page.goto("http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:3000/mcp");
+
+    // Wait for the Transport Type dropdown to be visible
+    const selectTrigger = page.getByLabel("Transport Type");
+    await expect(selectTrigger).toBeVisible();
+
+    // Verify transport dropdown shows Streamable HTTP
+    await expect(selectTrigger).toContainText("Streamable HTTP");
+
+    // Verify URL field is visible and populated
+    const urlInput = page.locator("#sse-url-input");
+    await expect(urlInput).toBeVisible();
+    await expect(urlInput).toHaveValue("http://localhost:3000/mcp");
+  });
+
+  test("should not pass transport parameter for stdio config", async ({
+    page,
+  }) => {
+    // Simulate stdio config (no transport param needed)
+    await page.goto("http://localhost:6274/");
+
+    // Wait for the Transport Type dropdown to be visible
+    const selectTrigger = page.getByLabel("Transport Type");
+    await expect(selectTrigger).toBeVisible();
+
+    // Verify transport dropdown defaults to STDIO
+    await expect(selectTrigger).toContainText("STDIO");
+
+    // Verify command/args fields are visible
+    await expect(page.locator("#command-input")).toBeVisible();
+    await expect(page.locator("#arguments-input")).toBeVisible();
+  });
+});

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -455,6 +455,14 @@ const App = () => {
         if (data.defaultArgs) {
           setArgs(data.defaultArgs);
         }
+        if (data.defaultTransport) {
+          setTransportType(
+            data.defaultTransport as "stdio" | "sse" | "streamable-http",
+          );
+        }
+        if (data.defaultServerUrl) {
+          setSseUrl(data.defaultServerUrl);
+        }
       })
       .catch((error) =>
         console.error("Error fetching default environment:", error),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -40,6 +40,8 @@ const { values } = parseArgs({
     env: { type: "string", default: "" },
     args: { type: "string", default: "" },
     command: { type: "string", default: "" },
+    transport: { type: "string", default: "" },
+    "server-url": { type: "string", default: "" },
   },
 });
 
@@ -523,6 +525,8 @@ app.get("/config", originValidationMiddleware, authMiddleware, (req, res) => {
       defaultEnvironment,
       defaultCommand: values.command,
       defaultArgs: values.args,
+      defaultTransport: values.transport,
+      defaultServerUrl: values["server-url"],
     });
   } catch (error) {
     console.error("Error in /config route:", error);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
When launching the inspector with `--config`, automatically set the transport
dropdown and server URL based on the config file contents. This eliminates
the need to manually switch between `stdio/sse/streamable-http` in the UI.

- Use discriminated union for ServerConfig to properly type different transports
- Detect transport type and URL from config, pass via query params
- Maintain backwards compatibility for configs without explicit `type` field
- Add comprehensive tests for the new functionality

Improves UX by making the config file the single source of truth for
server settings.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested manually with different configs:

E.g. with a `stdio` based config:

```
// mcp_dev_config.json
{
    "mcpServers": {
        "default-server": {
            "command": "uv",
            "args": [
                "run",
                "--with",
                "mcp[cli]",
                "mcp",
                "run",
                "/Users/fweinberger/path/to/my/code/stdio-test/main.py"
            ]
        }
    }
}
```

<img width="2172" height="1444" alt="CleanShot 2025-07-30 at 16 42 22@2x" src="https://github.com/user-attachments/assets/dd58e8da-f737-476e-90a6-c4baed58841c" />

E.g. with a `streamable-http` based config:

```
// mcp_dev_config.json
{
    "mcpServers": {
        "default-server": {
            "type": "streamable-http",
            "url": "http://localhost:8000/mcp",
            "note": "For Streamable HTTP connections, add this URL directly in your MCP Client"
        }
    }
}
```

<img width="2178" height="1444" alt="CleanShot 2025-07-30 at 16 42 46@2x" src="https://github.com/user-attachments/assets/9bfe7231-2876-43fc-bc53-635de7837679" />

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->