### PR TITLE
fix: Argument notation to allow parseArgs to parse leading dash-options

### DIFF
--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -91,10 +91,10 @@ async function startProdServer(serverOptions) {
     "node",
     [
       inspectorServerPath,
-      ...(command ? [`--command`, command] : []),
-      ...(mcpServerArgs && mcpServerArgs.length > 0
-        ? [`--args`, mcpServerArgs.join(" ")]
-        : []),
+      command ? `--command=${command}` : "",
+      mcpServerArgs && mcpServerArgs.length > 0
+        ? `--args=${mcpServerArgs.join(" ")}`
+        : "",
     ],
     {
       env: {


### PR DESCRIPTION
Invoke the server with an argument notation that tolerates a dash-option.  Closes #649 

## Motivation and Context

There is an argument handling regression, and it is helpful to be able to pass a dash-option to the MCP server command.

## How Has This Been Tested?

Running locally with both CLI and config file options.

## Breaking Changes

No

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

This is not related to parsing of the initial command by `cli/build/cli.js` (package entry point)., i.e., no quoting or use of `--` separation will address this bug.  Arguments are parsed correctly, but the passing of the command and args during server invocation is the problem.
