### PR TITLE
Add warning for DANGEROUSLY_OMIT_AUTH usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ If you need to disable authentication (NOT RECOMMENDED), you can set the `DANGER
 DANGEROUSLY_OMIT_AUTH=true npm start
 ```
 
+---
+
+**🚨 WARNING 🚨**
+
+Disabling authentication with `DANGEROUSLY_OMIT_AUTH` is incredibly dangerous! Disabling auth leaves your machine open to attack not just when exposed to the public internet, but also **via your web browser**. Meaning, visiting a malicious website OR viewing a malicious advertizement could allow an attacker to remotely compromise your computer. Do not disable this feature unless you truly understand the risks.
+
+Read more about the risks of this vulnerability on Oligo's blog: [Critical RCE Vulnerability in Anthropic MCP Inspector - CVE-2025-49596](https://www.oligo.security/blog/critical-rce-vulnerability-in-anthropic-mcp-inspector-cve-2025-49596)
+
+---
+
 You can also set the token via the `MCP_PROXY_AUTH_TOKEN` environment variable when starting the server:
 
 ```bash


### PR DESCRIPTION
Added warning about disabling authentication and its risks.

## Motivation and Context

With the addition of the `DANGEROUSLY_OMIT_AUTH` auth flag, we're observing a frightening number of places where this flag is being disabled. The risk is clearly misunderstood.

https://github.com/search?q=DANGEROUSLY_OMIT_AUTH&type=code

One blogger incorrectly represents that the `DANGEROUSLY_OMIT_AUTH` flag is only a risk if you expose the service to the public internet: https://danielecer.com/posts/mcp-inspector/

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
