### PR TITLE
fix: filter out empty strings in server arguments to prevent parseArgs error

### DIFF
--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -95,7 +95,7 @@ async function startProdServer(serverOptions) {
       mcpServerArgs && mcpServerArgs.length > 0
         ? `--args=${mcpServerArgs.join(" ")}`
         : "",
-    ],
+    ].filter(arg => arg !== ""),
     {
       env: {
         ...process.env,


### PR DESCRIPTION
## Summary
- Fixed an issue where running `npx .` without arguments would crash with 'Unexpected argument' error
- The problem was introduced in commit dc5fa6a which changed argument passing to use equal sign notation
- Empty strings were being passed as positional arguments when no command/args were provided

## Changes
- Filter out empty strings from the arguments array before passing to spawnPromise
- Added test coverage to verify web client can start without arguments

## Test plan
- [x] All existing tests pass
- [x] New test added to verify `npx .` works without crashing
- [x] Manually tested that `npx .` starts the web client successfully