### PR TITLE
bugfix: fix `npx @modelcontextprotoco/inspector` failing on main

### DIFF
--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -91,10 +91,10 @@ async function startProdServer(serverOptions) {
     "node",
     [
       inspectorServerPath,
-      command ? `--command=${command}` : "",
-      mcpServerArgs && mcpServerArgs.length > 0
-        ? `--args=${mcpServerArgs.join(" ")}`
-        : "",
+      ...(command ? [`--command=${command}`] : []),
+      ...(mcpServerArgs && mcpServerArgs.length > 0
+        ? [`--args=${mcpServerArgs.join(" ")}`]
+        : []),
     ],
     {
       env: {


### PR DESCRIPTION
## Summary
This fixes the regression introduced in dc5fa6a where `npx .` (without any arguments) fails with:
```
TypeError [ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL]: Unexpected argument ''. This command does not take positional arguments
```

## Problem
Commit dc5fa6a changed the argument passing from using spread syntax to directly including empty strings when no command/args are provided. The `parseArgs` function in the server interprets these empty strings as unexpected positional arguments.

## Solution
Reverted to using the spread operator approach that was used before dc5fa6a. This is more idiomatic and avoids creating empty strings that would need to be filtered out.

## Test plan
|Before|After|
|--|-|
|<img width="1804" height="686" alt="CleanShot 2025-08-05 at 12 02 13@2x" src="https://github.com/user-attachments/assets/83bae9be-ea60-4602-a023-0f6e40d0544a" />|<img width="1634" height="408" alt="CleanShot 2025-08-05 at 12 01 21@2x" src="https://github.com/user-attachments/assets/7c3471b5-d352-4403-8144-5a7c14dd68df" />|


- [x] Verified `npx .` now starts without the parseArgs error
- [x] Verified `npx . command args` still works correctly
- [x] All existing tests pass