### PR TITLE
Fix: Pre-registered Client ID as fallback to DCR

### DIFF
--- a/client/src/lib/oauth-state-machine.ts
+++ b/client/src/lib/oauth-state-machine.ts
@@ -88,20 +88,14 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
         clientMetadata.scope = scopesSupported.join(" ");
       }
 
-      // Try DCR first, with static client as fallback
-      let fullInformation;
-      try {
+      // Try Static client first, with DCR as fallback
+      let fullInformation = await context.provider.clientInformation();
+      if (!fullInformation) {
         fullInformation = await registerClient(context.serverUrl, {
           metadata,
           clientMetadata,
         });
         context.provider.saveClientInformation(fullInformation);
-      } catch (dcrError) {
-        // DCR failed, fallback to preregistered client
-        fullInformation = await context.provider.clientInformation();
-        if (!fullInformation) {
-          throw dcrError;
-        }
       }
 
       context.updateState({

--- a/client/src/lib/oauth-state-machine.ts
+++ b/client/src/lib/oauth-state-machine.ts
@@ -89,33 +89,26 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
       }
 
       // Try DCR first, with static client as fallback
+      let fullInformation;
       try {
-        const fullInformation = await registerClient(context.serverUrl, {
+        fullInformation = await registerClient(context.serverUrl, {
           metadata,
           clientMetadata,
         });
-
         context.provider.saveClientInformation(fullInformation);
-        context.updateState({
-          oauthClientInfo: fullInformation,
-          oauthStep: "authorization_redirect",
-        });
-        console.log({ fullInformation });
-        return;
       } catch (dcrError) {
-        console.error(dcrError);
-
         // DCR failed, fallback to preregistered client
-        const existingClientInfo = await context.provider.clientInformation();
-        if (!existingClientInfo) {
+        fullInformation = await context.provider.clientInformation();
+        if (!fullInformation) {
           console.error("Neither dynamic client registration or preregistered client information was found");
           throw dcrError;
         }
-        context.updateState({
-          oauthClientInfo: existingClientInfo,
-          oauthStep: "authorization_redirect",
-        });
       }
+
+      context.updateState({
+        oauthClientInfo: fullInformation,
+        oauthStep: "authorization_redirect",
+      });
     },
   },
 

--- a/client/src/lib/oauth-state-machine.ts
+++ b/client/src/lib/oauth-state-machine.ts
@@ -100,7 +100,6 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
         // DCR failed, fallback to preregistered client
         fullInformation = await context.provider.clientInformation();
         if (!fullInformation) {
-          console.error("Neither dynamic client registration or preregistered client information was found");
           throw dcrError;
         }
       }


### PR DESCRIPTION
## Motivation and Context
The guided auth flow did not support static client fallback after dynamic client registration (DCR) had failed. This doesn't meet the MCP spec.

The [MCP spec authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) states:
> "Authorization servers and MCP clients **SHOULD** support the OAuth 2.0 Dynamic Client Registration Protocol ([RFC7591](https://datatracker.ietf.org/doc/html/rfc7591)).". The lack of fallback here means the auth debug flow doesn't meet MCP spec as it mandates that resource servers **MUST** support DCR.

This PR adds a static client credentials attempt as a fallback for failed DCR. If DCR is supported and successful, the static client will not be used. 

Addresses #683.

## How Has This Been Tested?
Tested locally with MCP servers with both DCR and static fallback.

## Breaking Changes
No, purely an additive fallback.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Additional context
Potentially static client should take precedence if provided. That's the behaviour i'd personally expect, but that's opinionated. Either way, changes are expected to DCR as [MCP spec roadmap](https://modelcontextprotocol.io/development/roadmap#authentication-and-security) already states looking for DCR alternatives

LMK if any changes needed, happy to change this around if another approach works better with the codebase, haven't worked with MCP inspector before.