### PR TITLE
reusable generateOAuthState helper, introduce in InspectorOAuthClient…

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -8,6 +8,7 @@ import {
   OAuthMetadata,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { SESSION_KEYS, getServerSpecificKey } from "./constants";
+import { generateOAuthState } from "@/utils/oauthUtils";
 
 export const getClientInformationFromSessionStorage = async ({
   serverUrl,
@@ -73,6 +74,10 @@ export class InspectorOAuthClientProvider implements OAuthClientProvider {
 
   get redirectUrl() {
     return window.location.origin + "/oauth/callback";
+  }
+
+  state(): string | Promise<string> {
+    return generateOAuthState();
   }
 
   get clientMetadata(): OAuthClientMetadata {

--- a/client/src/lib/oauth-state-machine.ts
+++ b/client/src/lib/oauth-state-machine.ts
@@ -12,6 +12,7 @@ import {
   OAuthMetadataSchema,
   OAuthProtectedResourceMetadata,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { generateOAuthState } from "@/utils/oauthUtils";
 
 export interface StateMachineContext {
   state: AuthDebuggerState;
@@ -113,13 +114,6 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
         scope = metadata.scopes_supported.join(" ");
       }
 
-      // Generate a random state
-      const array = new Uint8Array(32);
-      crypto.getRandomValues(array);
-      const state = Array.from(array, (byte) =>
-        byte.toString(16).padStart(2, "0"),
-      ).join("");
-
       const { authorizationUrl, codeVerifier } = await startAuthorization(
         context.serverUrl,
         {
@@ -127,7 +121,7 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
           clientInformation,
           redirectUrl: context.provider.redirectUrl,
           scope,
-          state: state,
+          state: generateOAuthState(),
           resource: context.state.resource ?? undefined,
         },
       );

--- a/client/src/utils/__tests__/oauthUtils.test.ts
+++ b/client/src/utils/__tests__/oauthUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   generateOAuthErrorDescription,
   parseOAuthCallbackParams,
+  generateOAuthState,
 } from "@/utils/oauthUtils.ts";
 
 describe("parseOAuthCallbackParams", () => {
@@ -74,5 +75,12 @@ describe("generateOAuthErrorDescription", () => {
     ).toEqual(
       "Error: invalid_request.\nDetails: The request could not be completed as dialed.\nMore info: https://example.com/error-docs.",
     );
+  });
+
+  describe("generateOAuthState", () => {
+    it("Returns a string", () => {
+      expect(generateOAuthState()).toBeDefined();
+      expect(generateOAuthState()).toHaveLength(64);
+    });
   });
 });

--- a/client/src/utils/oauthUtils.ts
+++ b/client/src/utils/oauthUtils.ts
@@ -48,6 +48,20 @@ export const parseOAuthCallbackParams = (location: string): CallbackParams => {
   };
 };
 
+/**
+ * Generate a random state for the OAuth 2.0 flow.
+ *
+ * @returns A random state for the OAuth 2.0 flow.
+ */
+export const generateOAuthState = () => {
+  // Generate a random state
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+};
+
 export const generateOAuthErrorDescription = (
   params: Extract<CallbackParams, { successful: false }>,
 ): string => {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
An extension to https://github.com/modelcontextprotocol/inspector/pull/615, which adds the `state` parameter to the newly introduced flow in the `InspectorOAuthClientProvider` class.

## How Has This Been Tested?
Tested via a real MCP server, added unit tests.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
