### PR TITLE
Bump auth SDK to use Improved AS Discovery

### DIFF
--- a/client/src/components/__tests__/AuthDebugger.test.tsx
+++ b/client/src/components/__tests__/AuthDebugger.test.tsx
@@ -36,7 +36,7 @@ const mockOAuthClientInfo = {
 // Mock MCP SDK functions - must be before imports
 jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
   auth: jest.fn(),
-  discoverOAuthMetadata: jest.fn(),
+  discoverAuthorizationServerMetadata: jest.fn(),
   registerClient: jest.fn(),
   startAuthorization: jest.fn(),
   exchangeAuthorization: jest.fn(),
@@ -46,7 +46,7 @@ jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
 
 // Import the functions to get their types
 import {
-  discoverOAuthMetadata,
+  discoverAuthorizationServerMetadata,
   registerClient,
   startAuthorization,
   exchangeAuthorization,
@@ -57,9 +57,10 @@ import { OAuthMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { EMPTY_DEBUGGER_STATE } from "@/lib/auth-types";
 
 // Type the mocked functions properly
-const mockDiscoverOAuthMetadata = discoverOAuthMetadata as jest.MockedFunction<
-  typeof discoverOAuthMetadata
->;
+const mockDiscoverAuthorizationServerMetadata =
+  discoverAuthorizationServerMetadata as jest.MockedFunction<
+    typeof discoverAuthorizationServerMetadata
+  >;
 const mockRegisterClient = registerClient as jest.MockedFunction<
   typeof registerClient
 >;
@@ -102,7 +103,9 @@ describe("AuthDebugger", () => {
     // Suppress console errors in tests to avoid JSDOM navigation noise
     jest.spyOn(console, "error").mockImplementation(() => {});
 
-    mockDiscoverOAuthMetadata.mockResolvedValue(mockOAuthMetadata);
+    mockDiscoverAuthorizationServerMetadata.mockResolvedValue(
+      mockOAuthMetadata,
+    );
     mockRegisterClient.mockResolvedValue(mockOAuthClientInfo);
     mockDiscoverOAuthProtectedResourceMetadata.mockRejectedValue(
       new Error("No protected resource metadata found"),
@@ -203,7 +206,7 @@ describe("AuthDebugger", () => {
       });
 
       // Should first discover and save OAuth metadata
-      expect(mockDiscoverOAuthMetadata).toHaveBeenCalledWith(
+      expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenCalledWith(
         new URL("https://example.com/"),
       );
 
@@ -216,7 +219,7 @@ describe("AuthDebugger", () => {
     });
 
     it("should show error when quick OAuth flow fails to discover metadata", async () => {
-      mockDiscoverOAuthMetadata.mockRejectedValue(
+      mockDiscoverAuthorizationServerMetadata.mockRejectedValue(
         new Error("Metadata discovery failed"),
       );
 
@@ -362,7 +365,7 @@ describe("AuthDebugger", () => {
         fireEvent.click(screen.getByText("Continue"));
       });
 
-      expect(mockDiscoverOAuthMetadata).toHaveBeenCalledWith(
+      expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenCalledWith(
         new URL("https://example.com/"),
       );
     });
@@ -509,7 +512,9 @@ describe("AuthDebugger", () => {
       mockDiscoverOAuthProtectedResourceMetadata.mockResolvedValue(
         mockResourceMetadata,
       );
-      mockDiscoverOAuthMetadata.mockResolvedValue(mockOAuthMetadata);
+      mockDiscoverAuthorizationServerMetadata.mockResolvedValue(
+        mockOAuthMetadata,
+      );
 
       await act(async () => {
         renderAuthDebugger({
@@ -563,7 +568,9 @@ describe("AuthDebugger", () => {
       // Mock failed metadata discovery
       mockDiscoverOAuthProtectedResourceMetadata.mockRejectedValue(mockError);
       // But OAuth metadata should still work with the original URL
-      mockDiscoverOAuthMetadata.mockResolvedValue(mockOAuthMetadata);
+      mockDiscoverAuthorizationServerMetadata.mockResolvedValue(
+        mockOAuthMetadata,
+      );
 
       await act(async () => {
         renderAuthDebugger({
@@ -603,7 +610,7 @@ describe("AuthDebugger", () => {
       });
 
       // Verify that regular OAuth metadata discovery was still called
-      expect(mockDiscoverOAuthMetadata).toHaveBeenCalledWith(
+      expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenCalledWith(
         new URL("https://example.com/"),
       );
     });

--- a/client/src/lib/oauth-state-machine.ts
+++ b/client/src/lib/oauth-state-machine.ts
@@ -1,7 +1,7 @@
 import { OAuthStep, AuthDebuggerState } from "./auth-types";
 import { DebugInspectorOAuthClientProvider } from "./auth";
 import {
-  discoverOAuthMetadata,
+  discoverAuthorizationServerMetadata,
   registerClient,
   startAuthorization,
   exchangeAuthorization,
@@ -56,7 +56,7 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
         resourceMetadata ?? undefined,
       );
 
-      const metadata = await discoverOAuthMetadata(authServerUrl);
+      const metadata = await discoverAuthorizationServerMetadata(authServerUrl);
       if (!metadata) {
         throw new Error("Failed to discover OAuth metadata");
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@modelcontextprotocol/inspector-cli": "^0.16.3",
         "@modelcontextprotocol/inspector-client": "^0.16.3",
         "@modelcontextprotocol/inspector-server": "^0.16.3",
-        "@modelcontextprotocol/sdk": "^1.17.0",
+        "@modelcontextprotocol/sdk": "^1.17.2",
         "concurrently": "^9.2.0",
         "open": "^10.2.0",
         "shell-quote": "^1.8.3",
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.0.tgz",
-      "integrity": "sha512-qFfbWFA7r1Sd8D697L7GkTd36yqDuTkvz0KfOGkgXR8EUhQn3/EDNIR/qUdQNMT8IjmasBvHWuXeisxtXTQT2g==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.2.tgz",
+      "integrity": "sha512-EFLRNXR/ixpXQWu6/3Cu30ndDFIFNaqUXcTqsGebujeMan9FzhAaFFswLRiFj61rgygDRr8WO1N+UijjgRxX9g==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@modelcontextprotocol/inspector-cli": "^0.16.3",
     "@modelcontextprotocol/inspector-client": "^0.16.3",
     "@modelcontextprotocol/inspector-server": "^0.16.3",
-    "@modelcontextprotocol/sdk": "^1.17.0",
+    "@modelcontextprotocol/sdk": "^1.17.2",
     "concurrently": "^9.2.0",
     "open": "^10.2.0",
     "shell-quote": "^1.8.3",


### PR DESCRIPTION
Bump the MCP SDK pin from `^1.17.0` to `^1.17.2`, to update the debugger to the latest AS metadata endpoint discovery method (`discoverAuthorizationServerMetadata` introduced in https://github.com/modelcontextprotocol/typescript-sdk/pull/652) and include the CORS retry bug fix introduced in `1.17.2` (https://github.com/modelcontextprotocol/typescript-sdk/pull/827).

## Motivation and Context
Needed to connect Inspector's auth debugger to MCP servers that use Azure for AS. Needed support for metadata at `/.well-known/openid-configuration`, and needed CORS fix so it didn't fail on earlier attempted incorrect endpoints.

## How Has This Been Tested?
Run all tests locally (and needed to update the mocks to the new method).
As tests were changed, also manually tested against an OOB MCP server (Neon's) and a custom one using Azure AD.

## Breaking Changes
- It shouldn't, bump to SDK is within same major version.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Related Issues
I suspect this will resolve these issues that are all related to metadata:
- #700 
- #675 
- #563
    - Steps explicitly use guided flow here so I'm sure it resolves this.
- #634 
    - Latest comment on there mentions the that discovery method in base SDK not being in inspector yet.