### PR TITLE
Add toast for misconfigured logging

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -581,7 +581,11 @@ export function useConnection({
       setMcpClient(client);
       setConnectionStatus("connected");
     } catch (e) {
-      if (lastRequest === "logging/setLevel" && e instanceof McpError && e.code === ErrorCode.MethodNotFound) {
+      if (
+        lastRequest === "logging/setLevel" &&
+        e instanceof McpError &&
+        e.code === ErrorCode.MethodNotFound
+      ) {
         toast({
           title: "Error",
           description: `Server declares logging capability but doesn't implement method: "${lastRequest}"`,


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of your changes -->
* In useConnection.ts
  - During initialization, if there is an error immediately following the client sending `logging/setLevel`, pop up a toast with the message `Server declares logging capability but doesn't implement method "logging/setLevel"`

## Motivation
<!-- Why is this change needed? What problem does it solve? -->
* #699 reported an "unknown regression" when connecting to a server. The problem was diagnosed by @KKonstantinov as stemming from #611 which sends a `logging/setLevel` message during initialization if the server advertises support for the `logging` capability. 
* This issue was also reported in #696.

## Context
The [MCP spec for logging](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging) states two relevant things:

> Servers that emit log message notifications MUST declare the logging capability:
>
> ```json
> {
> "capabilities": {
>    "logging": {}
>  }
>}
>```

> To configure the minimum log level, clients MAY send a logging/setLevel request:
>
> ```json
>{
>  "jsonrpc": "2.0",
>  "id": 1,
>  "method": "logging/setLevel",
>  "params": {
>    "level": "info"
>  }
>}
>```

The Inspector is clearly operating **in spec**. A server that advertises that it supports logging but actually doesn't is operating **out of spec**. 

Other clients in the wild which follow spec will naturally do this and when it fails with them, it's more likely a real "getting in the way of work" problem.

If we revert the automatic setLevel request, we're only encouraging server developers to continue doing the wrong thing. This is after all, a tool for developers to inspect their servers and determine if they're operating correctly. 

But clearly a failure to connect with no clear feedback as to why is a poor user experience and doesn't help the developer to diagnose and fix the problem. So we opted to add a toast message when a Method Not Found error is thrown as a result of sending the `logging/setLevel` request.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Commented out the request handler for `SetLevelRequestSchema` in the [server-everything](https://github.com/modelcontextprotocol/servers/blob/main/src/everything/everything.ts#L854) reference server, which declares support for the `logging` capability during the initialization. 

<img width="685" height="82" alt="Screenshot 2025-08-12 at 3 42 05 PM" src="https://github.com/user-attachments/assets/0bdecf97-3324-4f1a-9eb0-0c0d1792eafd" />

<img width="1130" height="681" alt="Screenshot 2025-08-12 at 2 03 36 PM" src="https://github.com/user-attachments/assets/baeb0b12-7984-48a8-8189-1c79d80628b6" />


## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This closes #696 & #699