### PR TITLE
fix: STDIO and SSE transports need MCP_FULL_PROXY_PATH

### DIFF
--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -714,4 +714,129 @@ describe("useConnection", () => {
       ).toHaveProperty("X-MCP-Proxy-Auth", "Bearer test-proxy-token");
     });
   });
+
+  describe("MCP_PROXY_FULL_ADDRESS Configuration", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      // Reset the mock transport objects
+      mockSSETransport.url = undefined;
+      mockSSETransport.options = undefined;
+      mockStreamableHTTPTransport.url = undefined;
+      mockStreamableHTTPTransport.options = undefined;
+    });
+
+    test("sends proxyFullAddress query parameter for stdio transport when configured", async () => {
+      const propsWithProxyFullAddress = {
+        ...defaultProps,
+        transportType: "stdio" as const,
+        command: "test-command",
+        args: "test-args",
+        env: {},
+        config: {
+          ...DEFAULT_INSPECTOR_CONFIG,
+          MCP_PROXY_FULL_ADDRESS: {
+            ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_FULL_ADDRESS,
+            value: "https://example.com/inspector/mcp_proxy",
+          },
+        },
+      };
+
+      const { result } = renderHook(() =>
+        useConnection(propsWithProxyFullAddress),
+      );
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Check that the URL contains the proxyFullAddress parameter
+      expect(mockSSETransport.url?.searchParams.get("proxyFullAddress")).toBe(
+        "https://example.com/inspector/mcp_proxy",
+      );
+    });
+
+    test("sends proxyFullAddress query parameter for sse transport when configured", async () => {
+      const propsWithProxyFullAddress = {
+        ...defaultProps,
+        transportType: "sse" as const,
+        sseUrl: "http://localhost:8080",
+        config: {
+          ...DEFAULT_INSPECTOR_CONFIG,
+          MCP_PROXY_FULL_ADDRESS: {
+            ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_FULL_ADDRESS,
+            value: "https://example.com/inspector/mcp_proxy",
+          },
+        },
+      };
+
+      const { result } = renderHook(() =>
+        useConnection(propsWithProxyFullAddress),
+      );
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Check that the URL contains the proxyFullAddress parameter
+      expect(mockSSETransport.url?.searchParams.get("proxyFullAddress")).toBe(
+        "https://example.com/inspector/mcp_proxy",
+      );
+    });
+
+    test("does not send proxyFullAddress parameter when MCP_PROXY_FULL_ADDRESS is empty", async () => {
+      const propsWithEmptyProxy = {
+        ...defaultProps,
+        transportType: "stdio" as const,
+        command: "test-command",
+        args: "test-args",
+        env: {},
+        config: {
+          ...DEFAULT_INSPECTOR_CONFIG,
+          MCP_PROXY_FULL_ADDRESS: {
+            ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_FULL_ADDRESS,
+            value: "",
+          },
+        },
+      };
+
+      const { result } = renderHook(() => useConnection(propsWithEmptyProxy));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Check that the URL does not contain the proxyFullAddress parameter
+      expect(
+        mockSSETransport.url?.searchParams.get("proxyFullAddress"),
+      ).toBeNull();
+    });
+
+    test("does not send proxyFullAddress parameter for streamable-http transport", async () => {
+      const propsWithStreamableHttp = {
+        ...defaultProps,
+        transportType: "streamable-http" as const,
+        sseUrl: "http://localhost:8080",
+        config: {
+          ...DEFAULT_INSPECTOR_CONFIG,
+          MCP_PROXY_FULL_ADDRESS: {
+            ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_FULL_ADDRESS,
+            value: "https://example.com/inspector/mcp_proxy",
+          },
+        },
+      };
+
+      const { result } = renderHook(() =>
+        useConnection(propsWithStreamableHttp),
+      );
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Check that streamable-http transport doesn't get proxyFullAddress parameter
+      expect(
+        mockStreamableHTTPTransport.url?.searchParams.get("proxyFullAddress"),
+      ).toBeNull();
+    });
+  });
 });

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -389,11 +389,20 @@ export function useConnection({
 
       let mcpProxyServerUrl;
       switch (transportType) {
-        case "stdio":
+        case "stdio": {
           mcpProxyServerUrl = new URL(`${getMCPProxyAddress(config)}/stdio`);
           mcpProxyServerUrl.searchParams.append("command", command);
           mcpProxyServerUrl.searchParams.append("args", args);
           mcpProxyServerUrl.searchParams.append("env", JSON.stringify(env));
+
+          const proxyFullAddress = config.MCP_PROXY_FULL_ADDRESS
+            .value as string;
+          if (proxyFullAddress) {
+            mcpProxyServerUrl.searchParams.append(
+              "proxyFullAddress",
+              proxyFullAddress,
+            );
+          }
           transportOptions = {
             authProvider: serverAuthProvider,
             eventSourceInit: {
@@ -411,10 +420,20 @@ export function useConnection({
             },
           };
           break;
+        }
 
-        case "sse":
+        case "sse": {
           mcpProxyServerUrl = new URL(`${getMCPProxyAddress(config)}/sse`);
           mcpProxyServerUrl.searchParams.append("url", sseUrl);
+
+          const proxyFullAddressSSE = config.MCP_PROXY_FULL_ADDRESS
+            .value as string;
+          if (proxyFullAddressSSE) {
+            mcpProxyServerUrl.searchParams.append(
+              "proxyFullAddress",
+              proxyFullAddressSSE,
+            );
+          }
           transportOptions = {
             eventSourceInit: {
               fetch: (
@@ -431,6 +450,7 @@ export function useConnection({
             },
           };
           break;
+        }
 
         case "streamable-http":
           mcpProxyServerUrl = new URL(`${getMCPProxyAddress(config)}/mcp`);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -378,7 +378,6 @@ app.get(
       let serverTransport: Transport | undefined;
       try {
         serverTransport = await createTransport(req);
-        console.log("Created server transport");
       } catch (error) {
         if (error instanceof SseError && error.code === 401) {
           console.error(
@@ -396,10 +395,11 @@ app.get(
       const endpoint = `${prefix}/message`;
 
       const webAppTransport = new SSEServerTransport(endpoint, res);
+      webAppTransports.set(webAppTransport.sessionId, webAppTransport);
       console.log("Created client transport");
 
-      webAppTransports.set(webAppTransport.sessionId, webAppTransport);
       serverTransports.set(webAppTransport.sessionId, serverTransport);
+      console.log("Created server transport");
 
       await webAppTransport.start();
 
@@ -446,7 +446,7 @@ app.get(
   async (req, res) => {
     try {
       console.log(
-        "New SSE connection request. NOTE: The sse transport is deprecated and has been replaced by StreamableHttp",
+        "New SSE connection request. NOTE: The SSE transport is deprecated and has been replaced by StreamableHttp",
       );
       let serverTransport: Transport | undefined;
       try {
@@ -480,6 +480,7 @@ app.get(
         const webAppTransport = new SSEServerTransport(endpoint, res);
         webAppTransports.set(webAppTransport.sessionId, webAppTransport);
         console.log("Created client transport");
+
         serverTransports.set(webAppTransport.sessionId, serverTransport!);
         console.log("Created server transport");
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -391,7 +391,11 @@ app.get(
         throw error;
       }
 
-      const webAppTransport = new SSEServerTransport("/message", res);
+      const proxyFullAddress = (req.query.proxyFullAddress as string) || "";
+      const prefix = proxyFullAddress || "";
+      const endpoint = `${prefix}/message`;
+
+      const webAppTransport = new SSEServerTransport(endpoint, res);
       console.log("Created client transport");
 
       webAppTransports.set(webAppTransport.sessionId, webAppTransport);
@@ -469,7 +473,11 @@ app.get(
       }
 
       if (serverTransport) {
-        const webAppTransport = new SSEServerTransport("/message", res);
+        const proxyFullAddress = (req.query.proxyFullAddress as string) || "";
+        const prefix = proxyFullAddress || "";
+        const endpoint = `${prefix}/message`;
+
+        const webAppTransport = new SSEServerTransport(endpoint, res);
         webAppTransports.set(webAppTransport.sessionId, webAppTransport);
         console.log("Created client transport");
         serverTransports.set(webAppTransport.sessionId, serverTransport!);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

#630

The MCP client needs to know the full path to the proxy server when opening the SSE transport for STDIO and SSE endpoints.

The client knows where it expects to see the server, so pass this to the server, to use when building the endpoint.

## How Has This Been Tested?

Open the Inspector, set the Inspector Proxy Address to a URL through an nginx proxy.

Using an nginx proxy:  `nginx -c inspector.conf`

```
# inspector.conf

daemon off;
error_log /dev/stdout info;
events {
}

http {
    upstream inspector-backend {
        server [::1]:6277;
        server 127.0.0.1:6277;
    }

    # Inspector backend only
    server {
        listen 9000;
        listen [::]:9000;

        server_name localhost;

        location /mcp/inspector/backend/ {
            proxy_pass http://inspector-backend/;
            proxy_http_version 1.1;
            proxy_set_header Connection "";
            proxy_buffering off;
            proxy_cache off;
            proxy_read_timeout 24h;
            proxy_set_header X-Accel-Buffering no;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
        }
    }
}
```

## Breaking Changes

No

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

There are other ways to fix this, but my hunch is treating the client as authoritative will be most flexible different deployment scenarios, and also prevent a server-side / client-side configuration mismatch.

Also, I'd add a server test for this, but there are no server tests at the moment.  Are server tests desired?

Issue #437 is related, for which there is a [fix in a fork](https://github.com/modelcontextprotocol/inspector/commit/3a36ed4c43b9c7a196e82bfed1dda299ba4ed9d3), not yet submitted as a PR.  It looks like the right approach, appending to the query params from the env.  This would close out the current proxy-related issues.