### PR TITLE
Fix OAuth scope selection to use resource server scopes

### DIFF
--- a/client/src/lib/oauth-state-machine.ts
+++ b/client/src/lib/oauth-state-machine.ts
@@ -110,8 +110,11 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
       const clientInformation = context.state.oauthClientInfo!;
 
       let scope: string | undefined = undefined;
-      if (metadata.scopes_supported) {
-        scope = metadata.scopes_supported.join(" ");
+      const scopesSupported =
+        context.state.resourceMetadata?.scopes_supported ||
+        metadata.scopes_supported;
+      if (scopesSupported) {
+        scope = scopesSupported.join(" ");
       }
 
       const { authorizationUrl, codeVerifier } = await startAuthorization(


### PR DESCRIPTION
## Summary
- Fixed OAuth scope selection bug where Inspector was requesting all scopes from the authorization server instead of using resource server scopes
- This caused failures with dynamic OAuth clients that don't have access to all authorization server scopes (e.g., public_metadata, private_metadata)

## Changes
- Modified the `authorization_redirect` step in oauth-state-machine.ts to prefer resource server scopes over authorization server scopes
- This matches the existing behavior in the `client_registration` step

## Test plan
- [x] Tested with OAuth server that has additional scopes not available to dynamic clients
- [x] Verified that Inspector now requests only the scopes supported by the resource server
- [x] OAuth flow completes successfully without scope-related errors

🤖 Generated with [Claude Code](https://claude.ai/code)