### PR TITLE
fweinberger/fix sensitive local storage

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -110,10 +110,17 @@ export class InspectorOAuthClientProvider implements OAuthClientProvider {
   }
 
   saveClientInformation(clientInformation: OAuthClientInformation) {
+    // Remove client_secret before storing (not needed after initial OAuth flow)
+    const safeInfo = Object.fromEntries(
+      Object.entries(clientInformation).filter(
+        ([key]) => key !== "client_secret",
+      ),
+    ) as OAuthClientInformation;
+
     // Save the dynamically registered client information to session storage
     saveClientInformationToSessionStorage({
       serverUrl: this.serverUrl,
-      clientInformation,
+      clientInformation: safeInfo,
       isPreregistered: false,
     });
   }


### PR DESCRIPTION
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
CodeQL pointed out we were storing some OAuth information unencrypted in SessionStorage which is not ideal: https://github.com/modelcontextprotocol/inspector/security/code-scanning/8

Not all of this information is sensitive, but the `client_secret` potentially is. We're actually unnecessarily storing this, as it's not used at any point after storage - we're storing it by default right now becu

This PR filters out the `client_secret` before storage of OAuth information to the sessionStorage for improved security.

More details:
<details>
From @claude:

⏺ When client_secret Gets Supplied

  Based on my investigation:

  1. During Dynamic Client Registration (DCR)

  - When registerClient() is called, it sends a POST request to the OAuth server's registration endpoint
  - The server responds with OAuthClientInformationFullSchema which MAY include client_secret
  - Whether it includes client_secret depends on the OAuth server's policy:
    - Public clients (SPAs, mobile apps): No client_secret
    - Confidential clients (server apps): Includes client_secret

  2. When client_secret is Used

  - During token exchange (exchangeAuthorization()), the SDK uses client_secret if present
  - It applies different authentication methods based on what the server supports:
    - client_secret_basic: Sends as HTTP Basic Auth header
    - client_secret_post: Sends in POST body
    - none: Public client, no secret needed

  3. The Problem

  - The MCP Inspector is a browser-based SPA (Single Page Application)
  - SPAs should be public clients (no client_secret)
  - BUT some OAuth servers might incorrectly return a client_secret anyway
  - We store whatever the server returns, including client_secret if present

  4. Why It's Not Actually Used After Storage

  - The client_secret is only needed during exchangeAuthorization()
  - The SDK reads it from the clientInformation object passed to it
  - After token exchange, the client_secret is never needed again
  - We only store OAuth tokens for future use, not the client credentials

  Conclusion

  The client_secret:
  1. Comes from the OAuth server during dynamic client registration
  2. Is used once during token exchange
  3. Doesn't need to be stored after that
  4. Shouldn't even exist for browser-based apps (but might due to misconfigured servers)

  The simplest fix is to filter it out when storing, since it's not needed after the initial OAuth flow completes.
</details>

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Ran inspector to do some smoke testing with local MCP servers, OAuth still worked, including on refresh.
Ran tests with `npm run test` and these still passed.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
