### PR TITLE
Fix OAuth token endpoint authentication method regression (issue #726)

### DIFF
--- a/client/src/lib/__tests__/auth.test.ts
+++ b/client/src/lib/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { discoverScopes } from "../auth";
+import { discoverScopes, InspectorOAuthClientProvider } from "../auth";
 import { discoverAuthorizationServerMetadata } from "@modelcontextprotocol/sdk/client/auth.js";
 
 jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
@@ -152,4 +152,108 @@ describe("discoverScopes", () => {
       expect(result).toBeUndefined();
     },
   );
+});
+
+describe("InspectorOAuthClientProvider", () => {
+  let provider: InspectorOAuthClientProvider;
+
+  beforeEach(() => {
+    // Clear sessionStorage before each test
+    sessionStorage.clear();
+    provider = new InspectorOAuthClientProvider("https://example.com");
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  describe("client_secret handling", () => {
+    it("should temporarily store client_secret for OAuth flow", async () => {
+      const clientInfo = {
+        client_id: "test_client_id",
+        client_secret: "test_client_secret",
+        redirect_uris: ["http://localhost:3000/oauth/callback"],
+      };
+
+      // Save client information (this should store the secret temporarily)
+      provider.saveClientInformation(clientInfo);
+
+      // Retrieve client information (should include the temporary secret)
+      const retrievedInfo = await provider.clientInformation();
+      expect(retrievedInfo?.client_id).toBe("test_client_id");
+      expect(retrievedInfo?.client_secret).toBe("test_client_secret");
+
+      // Verify that the secret is not stored in sessionStorage
+      const storedValue = sessionStorage.getItem(
+        "[https://example.com] mcp_client_information",
+      );
+      expect(storedValue).toBeTruthy();
+      const storedInfo = JSON.parse(storedValue!);
+      expect(storedInfo.client_secret).toBeUndefined();
+      expect(storedInfo.client_id).toBe("test_client_id");
+    });
+
+    it("should clear temporary client_secret after saving tokens", async () => {
+      const clientInfo = {
+        client_id: "test_client_id",
+        client_secret: "test_client_secret",
+        redirect_uris: ["http://localhost:3000/oauth/callback"],
+      };
+
+      // Save client information
+      provider.saveClientInformation(clientInfo);
+
+      // Verify secret is available
+      let retrievedInfo = await provider.clientInformation();
+      expect(retrievedInfo?.client_secret).toBe("test_client_secret");
+
+      // Save tokens (this should clear the temporary secret)
+      provider.saveTokens({
+        access_token: "test_access_token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+
+      // Verify secret is no longer available
+      retrievedInfo = await provider.clientInformation();
+      expect(retrievedInfo?.client_secret).toBeUndefined();
+    });
+
+    it("should clear temporary client_secret when clear is called", async () => {
+      const clientInfo = {
+        client_id: "test_client_id",
+        client_secret: "test_client_secret",
+        redirect_uris: ["http://localhost:3000/oauth/callback"],
+      };
+
+      // Save client information
+      provider.saveClientInformation(clientInfo);
+
+      // Verify secret is available
+      let retrievedInfo = await provider.clientInformation();
+      expect(retrievedInfo?.client_secret).toBe("test_client_secret");
+
+      // Clear OAuth state
+      provider.clear();
+
+      // Verify secret is no longer available
+      retrievedInfo = await provider.clientInformation();
+      expect(retrievedInfo).toBeUndefined();
+    });
+
+    it("should handle client information without client_secret", async () => {
+      const clientInfo = {
+        client_id: "test_client_id",
+        redirect_uris: ["http://localhost:3000/oauth/callback"],
+      };
+
+      // Save client information without secret
+      provider.saveClientInformation(clientInfo);
+
+      // Retrieve client information
+      const retrievedInfo = await provider.clientInformation();
+      expect(retrievedInfo?.client_id).toBe("test_client_id");
+      expect(retrievedInfo?.client_secret).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
Resolves a regression introduced in PR #715 and reported in #726 where the OAuth flow always chose client_secret_post regardless of the server's token_endpoint_auth_methods_supported setting.

## Motivation and Context
- PR #715 removed client_secret from sessionStorage for security reasons
- This broke the MCP SDK's ability to determine the correct authentication method
- OAuth flows with servers requiring client_secret_basic would fail

## How Has This Been Tested?
Added tests but still needs testing with real flow through UI.

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
