### PR TITLE
Handling of stderr on STDIO servers

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -34,7 +34,6 @@ import {
   useDraggablePane,
   useDraggableSidebar,
 } from "./lib/hooks/useDraggablePane";
-import { StdErrNotification } from "./lib/notificationTypes";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
@@ -106,9 +105,6 @@ const App = () => {
   >(getInitialTransportType);
   const [logLevel, setLogLevel] = useState<LoggingLevel>("debug");
   const [notifications, setNotifications] = useState<ServerNotification[]>([]);
-  const [stdErrNotifications, setStdErrNotifications] = useState<
-    StdErrNotification[]
-  >([]);
   const [roots, setRoots] = useState<Root[]>([]);
   const [env, setEnv] = useState<Record<string, string>>({});
 
@@ -223,12 +219,6 @@ const App = () => {
     config,
     onNotification: (notification) => {
       setNotifications((prev) => [...prev, notification as ServerNotification]);
-    },
-    onStdErrNotification: (notification) => {
-      setStdErrNotifications((prev) => [
-        ...prev,
-        notification as StdErrNotification,
-      ]);
     },
     onPendingRequest: (request, resolve, reject) => {
       setPendingSampleRequests((prev) => [
@@ -757,10 +747,6 @@ const App = () => {
     setLogLevel(level);
   };
 
-  const clearStdErrNotifications = () => {
-    setStdErrNotifications([]);
-  };
-
   const AuthDebuggerWrapper = () => (
     <TabsContent value="auth">
       <AuthDebugger
@@ -829,11 +815,9 @@ const App = () => {
           setOauthScope={setOauthScope}
           onConnect={connectMcpServer}
           onDisconnect={disconnectMcpServer}
-          stdErrNotifications={stdErrNotifications}
           logLevel={logLevel}
           sendLogLevelRequest={sendLogLevelRequest}
           loggingSupported={!!serverCapabilities?.logging || false}
-          clearStdErrNotifications={clearStdErrNotifications}
         />
         <div
           onMouseDown={handleSidebarDragStart}

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -24,7 +24,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { StdErrNotification } from "@/lib/notificationTypes";
 import {
   LoggingLevel,
   LoggingLevelSchema,
@@ -62,8 +61,6 @@ interface SidebarProps {
   setOauthScope: (scope: string) => void;
   onConnect: () => void;
   onDisconnect: () => void;
-  stdErrNotifications: StdErrNotification[];
-  clearStdErrNotifications: () => void;
   logLevel: LoggingLevel;
   sendLogLevelRequest: (level: LoggingLevel) => void;
   loggingSupported: boolean;
@@ -93,8 +90,6 @@ const Sidebar = ({
   setOauthScope,
   onConnect,
   onDisconnect,
-  stdErrNotifications,
-  clearStdErrNotifications,
   logLevel,
   sendLogLevelRequest,
   loggingSupported,
@@ -759,36 +754,6 @@ const Sidebar = ({
                   </SelectContent>
                 </Select>
               </div>
-            )}
-
-            {stdErrNotifications.length > 0 && (
-              <>
-                <div className="mt-4 border-t border-gray-200 pt-4">
-                  <div className="flex justify-between items-center">
-                    <h3 className="text-sm font-medium">
-                      Error output from MCP server
-                    </h3>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={clearStdErrNotifications}
-                      className="h-8 px-2"
-                    >
-                      Clear
-                    </Button>
-                  </div>
-                  <div className="mt-2 max-h-80 overflow-y-auto">
-                    {stdErrNotifications.map((notification, index) => (
-                      <div
-                        key={index}
-                        className="text-sm text-red-500 font-mono py-2 border-b border-gray-200 last:border-b-0"
-                      >
-                        {notification.params.content}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </>
             )}
           </div>
         </div>

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -36,7 +36,7 @@ import { useEffect, useState } from "react";
 import { useToast } from "@/lib/hooks/useToast";
 import { z } from "zod";
 import { ConnectionStatus } from "../constants";
-import { Notification, StdErrNotificationSchema } from "../notificationTypes";
+import { Notification } from "../notificationTypes";
 import {
   auth,
   discoverOAuthProtectedResourceMetadata,
@@ -92,7 +92,6 @@ export function useConnection({
   oauthScope,
   config,
   onNotification,
-  onStdErrNotification,
   onPendingRequest,
   onElicitationRequest,
   getRoots,
@@ -503,13 +502,6 @@ export function useConnection({
           onNotification(notification);
           return Promise.resolve();
         };
-      }
-
-      if (onStdErrNotification) {
-        client.setNotificationHandler(
-          StdErrNotificationSchema,
-          onStdErrNotification,
-        );
       }
 
       let capabilities;

--- a/client/src/lib/notificationTypes.ts
+++ b/client/src/lib/notificationTypes.ts
@@ -5,18 +5,8 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
-export const StdErrNotificationSchema = BaseNotificationSchema.extend({
-  method: z.literal("notifications/stderr"),
-  params: z.object({
-    content: z.string(),
-  }),
-});
-
 export const NotificationSchema = ClientNotificationSchema.or(
-  StdErrNotificationSchema,
-)
-  .or(ServerNotificationSchema)
-  .or(BaseNotificationSchema);
+  ServerNotificationSchema,
+).or(BaseNotificationSchema);
 
-export type StdErrNotification = z.infer<typeof StdErrNotificationSchema>;
 export type Notification = z.infer<typeof NotificationSchema>;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -458,7 +458,7 @@ app.get(
               level,
               logger: "stdio",
               data: {
-                error: message,
+                message,
               },
             },
           });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -409,7 +409,7 @@ app.get(
             params: {
               level: "alert",
               data: {
-                error: message,
+                message,
               },
             },
           });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -421,7 +421,7 @@ app.get(
         } else {
           // Inspect message and attempt to assign a RFC 5424 Syslog Protocol level
           let level;
-          let message = chunk.toString();
+          let message = chunk.toString().trim();
           let ucMsg = chunk.toString().toUpperCase();
           if (ucMsg.includes("DEBUG")) {
             level = "debug";

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -407,7 +407,7 @@ app.get(
             jsonrpc: "2.0",
             method: "notifications/message",
             params: {
-              level: "alert",
+              level: "emergency",
               logger: "proxy",
               data: {
                 message,
@@ -441,14 +441,14 @@ app.get(
           } else if (ucMsg.includes("EMERGENCY")) {
             level = "emergency";
           } else if (ucMsg.includes("SIGINT")) {
-            level = "alert";
             message = "SIGINT received. Server shutdown.";
+            level = "emergency";
           } else if (ucMsg.includes("SIGHUP")) {
-            level = "alert";
             message = "SIGHUP received. Server shutdown.";
+            level = "emergency";
           } else if (ucMsg.includes("SIGTERM")) {
-            level = "alert";
             message = "SIGTERM received. Server shutdown.";
+            level = "emergency";
           } else {
             level = "info";
           }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -408,6 +408,7 @@ app.get(
             method: "notifications/message",
             params: {
               level: "alert",
+              logger: "proxy",
               data: {
                 message,
               },


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of your changes -->
* Remove handling of out-of-spec `notification/stderr` messages. It's not a thing. See https://github.com/modelcontextprotocol/servers/pull/2469

* Inspect the `stderr` output of STDIO servers and attempt to assign an appropriate [RFC 5424 Syslog Protocol level](https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1) before sending as leveled logging message to the client, as per [MCP Logging Spec](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging#log-levels).

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
A [recent change](https://github.com/modelcontextprotocol/servers/pull/2469) to the `server-everything` reference server raised the point that `notification/stderr` is not a valid MCP message type. It was only added to the server because handling for it existed in the Inspector, [added some time ago](https://github.com/modelcontextprotocol/inspector/commit/22bf78720b76b8df33c57be777d180df37b945bb). 

Clearly, handling for this message type needs to also be removed from the Inspector so as not to confuse developers who may come across it as I myself did, leading to my [erroneously adding](https://github.com/modelcontextprotocol/servers/pull/1423) the periodic sending of `notification/stderr` messages from `server-everything`.

As far as I can tell, it only existed as a way to indicate that the message came from the`stderr` output of a STDIO server, so that it could be handled differently from other logging messages, placing the output prominently in the sidebar in red to indicate error. However, another [recent issue](https://github.com/modelcontextprotocol/inspector/issues/732) highlights that this is not a valid approach, since all output, even innocuous server welcome messages must be sent via `stderr` in STDIO servers.

Therefore, I have removed the handling of this out-of-spec message type and am sending all `stderr` output to the client as MCP compliant logging messages. I attempt to set an appropriate logging level by inspecting the contents of the message and searching for levels. So if a STDIO server output the following line on `stderr`:

```shell
[info] The fetch tool was used.
```

...the following message would be sent to the client...

```json
{
  "jsonrpc": "2.0",
  "method": "notifications/message",
  "params": {
    "level": "info",
    "logger": "stdio",
    "data": {
      "message": "[info] The fetch tool was used",
    },
  },
}
```

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Using an STDIO server that outputs a welcome message on `stderr`
<img width="658" height="345" alt="Screenshot 2025-08-21 at 7 15 45 PM" src="https://github.com/user-attachments/assets/eff5cbad-2365-4a30-aeeb-e9cfd9a0a737" />

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
