### PR TITLE
Fix a typo in progress notification method name

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -167,7 +167,7 @@ export function useConnection({
           // Add progress notification to `Server Notification` window in the UI
           if (onNotification) {
             onNotification({
-              method: "notification/progress",
+              method: "notifications/progress",
               params,
             });
           }


### PR DESCRIPTION
It shoud be `notifications/progress` not `notification/progress` (not singular).

This matches the latest spec.

https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/progress

Fixed a typo that displayed the method name as `notification/progress` (singular) instead of `notifications/progress` (plural) in Server Notifications section.

## Motivation and Context
The typo led me to start looking to fastmcp python code as I thought that there was bug in fastmcp code.

## How Has This Been Tested?
I verified it in the inspector UI.

## Breaking Changes
It is a very minor change. Not a breaking change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A
