### PR TITLE
Make cli output awaitable to prevent truncating the result

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -19,6 +19,7 @@ import {
 } from "./client/index.js";
 import { handleError } from "./error-handler.js";
 import { createTransport, TransportOptions } from "./transport.js";
+import { awaitableLog } from "./utils/awaitable-log.js";
 
 type Args = {
   target: string[];
@@ -150,7 +151,7 @@ async function callMethod(args: Args): Promise<void> {
       );
     }
 
-    console.log(JSON.stringify(result, null, 2));
+    await awaitableLog(JSON.stringify(result, null, 2));
   } finally {
     try {
       await disconnect(transport);

--- a/cli/src/utils/awaitable-log.ts
+++ b/cli/src/utils/awaitable-log.ts
@@ -1,0 +1,7 @@
+export function awaitableLog(logValue: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    process.stdout.write(logValue, () => {
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
This PR solves this issue:
https://github.com/modelcontextprotocol/inspector/issues/753

## Motivation and Context
The `console.log` was not blocking until its completion so the process.exit(0) was being hit before it could finish. This change uses the callback function of process.stdout.write to make an awaitable log command.

## How Has This Been Tested?
Tested with the [GitKraken MCP](https://github.com/gitkraken/gk-cli) to reproduce the issue, and then tested again with the fix.

```
node build/cli.js --cli gk mcp --method tools/list
```

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
I created a utils directory and single file for the utility method, `awaitableLog`. I would be happy to change where that function lives, or even inline its logic into the place it is used.

Fixes #753 