### PR TITLE
Update ToolsTab to handle empty number inputs correctly

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -188,12 +188,16 @@ const ToolsTab = ({
                             id={key}
                             name={key}
                             placeholder={prop.description}
-                            value={(params[key] as string) ?? ""}
+                            value={
+                              typeof params[key] === "number"
+                                ? (params[key] as number).toString()
+                                : ""
+                            }
                             onChange={(e) => {
                               const value = e.target.value;
                               setParams({
                                 ...params,
-                                [key]: value === "" ? "" : Number(value),
+                                [key]: value === "" ? undefined : Number(value),
                               });
                             }}
                             className="mt-1"


### PR DESCRIPTION
This pull request updates the number handling for empty text fields. Fixes https://github.com/modelcontextprotocol/inspector/issues/623.

## Motivation and Context
When adding a number as tool parameter and removing it again, it is parsed as empty string which breaks the parsing at the server side. The error looks something like this:
```
MCP error 0: unmarshaling: json: cannot unmarshal string into Go struct field Request.count of type uint32
```

## How Has This Been Tested?
I tested the changes by changing the input parameters and verifying the the values are sent as expected.

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally (actually no, the same tests as on the main branch are failing)
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
No