### PR TITLE
Add a toast on connection error

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -624,6 +624,11 @@ export function useConnection({
           variant: "destructive",
         });
       }
+      toast({
+        title: "Connection error",
+        description: `Connection failed: "${e}"`,
+        variant: "destructive",
+      });
       console.error(e);
       setConnectionStatus("error");
     }

--- a/server/src/mcpProxy.ts
+++ b/server/src/mcpProxy.ts
@@ -36,7 +36,9 @@ export default function mcpProxy({
           id: message.id,
           error: {
             code: -32001,
-            message: error.message,
+            message: error.cause
+              ? `${error.message} (cause: ${error.cause})`
+              : error.message,
             data: error,
           },
         };


### PR DESCRIPTION

<!-- Provide a brief summary of your changes -->

## Motivation and Context
When failing to connect to an MCP server, its very hard to understand why. There is only an opaque "Connection Error" message with no additional info. This also doesn't change at all on repeated attempts, so there is no indication we attempted again and failed.

This change introduces a `toast` to visualize the error, and adds the `cause` into the error message for further debugging


## How Has This Been Tested?
Manually tested
<img width="2123" height="1047" alt="2025-08-28_15-03-26" src="https://github.com/user-attachments/assets/feda36e2-f6dd-4c25-a42f-d40f36ae7a13" />


## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
