### PR TITLE
Fix issue 766 - Completions not populated until you start typing

### DIFF
--- a/client/src/components/PromptsTab.tsx
+++ b/client/src/components/PromptsTab.tsx
@@ -63,9 +63,7 @@ const PromptsTab = ({
     clearCompletions();
   }, [clearCompletions, selectedPrompt]);
 
-  const handleInputChange = async (argName: string, value: string) => {
-    setPromptArgs((prev) => ({ ...prev, [argName]: value }));
-
+  const triggerCompletions = (argName: string, value: string) => {
     if (selectedPrompt) {
       requestCompletions(
         {
@@ -77,6 +75,16 @@ const PromptsTab = ({
         promptArgs,
       );
     }
+  };
+
+  const handleInputChange = async (argName: string, value: string) => {
+    setPromptArgs((prev) => ({ ...prev, [argName]: value }));
+    triggerCompletions(argName, value);
+  };
+
+  const handleFocus = async (argName: string) => {
+    const currentValue = promptArgs[argName] || "";
+    triggerCompletions(argName, currentValue);
   };
 
   const handleGetPrompt = () => {
@@ -143,6 +151,7 @@ const PromptsTab = ({
                       onInputChange={(value) =>
                         handleInputChange(arg.name, value)
                       }
+                      onFocus={() => handleFocus(arg.name)}
                       options={completions[arg.name] || []}
                     />
 

--- a/client/src/components/ui/combobox.tsx
+++ b/client/src/components/ui/combobox.tsx
@@ -19,6 +19,7 @@ interface ComboboxProps {
   value: string;
   onChange: (value: string) => void;
   onInputChange: (value: string) => void;
+  onFocus?: () => void;
   options: string[];
   placeholder?: string;
   emptyMessage?: string;
@@ -29,12 +30,23 @@ export function Combobox({
   value,
   onChange,
   onInputChange,
+  onFocus,
   options = [],
   placeholder = "Select...",
   emptyMessage = "No results found.",
   id,
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false);
+
+  const handleOpenChange = React.useCallback(
+    (newOpen: boolean) => {
+      setOpen(newOpen);
+      if (newOpen && onFocus) {
+        onFocus();
+      }
+    },
+    [onFocus],
+  );
 
   const handleSelect = React.useCallback(
     (option: string) => {
@@ -52,7 +64,7 @@ export function Combobox({
   );
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"


### PR DESCRIPTION
Fix for https://github.com/modelcontextprotocol/inspector/issues/766

Trigger completions immediately for prompts rather than only on property updates so that you get the list of options without having to type the first character. See the issue.

## Motivation and Context
https://github.com/modelcontextprotocol/inspector/issues/766

## How Has This Been Tested?
Compare this to the video in the issue: the drop down does not have the options populated before this fix.

https://github.com/user-attachments/assets/86abf014-3f0a-4830-b6ec-b1e9c8e0f45d

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
N/A
