### PR TITLE
Added UI to provide additional _meta values

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -698,7 +698,11 @@ const App = () => {
     cacheToolOutputSchemas(response.tools);
   };
 
-  const callTool = async (name: string, params: Record<string, unknown>) => {
+  const callTool = async (
+    name: string,
+    params: Record<string, unknown>,
+    meta?: Record<string, unknown>,
+  ) => {
     lastToolCallOriginTabRef.current = currentTabRef.current;
 
     try {
@@ -710,6 +714,7 @@ const App = () => {
             arguments: params,
             _meta: {
               progressToken: progressTokenRef.current++,
+              ...(meta ?? {}),
             },
           },
         },
@@ -1008,10 +1013,14 @@ const App = () => {
                         setNextToolCursor(undefined);
                         cacheToolOutputSchemas([]);
                       }}
-                      callTool={async (name, params) => {
+                      callTool={async (
+                        name: string,
+                        params: Record<string, unknown>,
+                        meta?: Record<string, unknown>,
+                      ) => {
                         clearError("tools");
                         setToolResult(null);
-                        await callTool(name, params);
+                        await callTool(name, params, meta);
                       }}
                       selectedTool={selectedTool}
                       setSelectedTool={(tool) => {

--- a/client/src/components/ToolResults.tsx
+++ b/client/src/components/ToolResults.tsx
@@ -156,7 +156,7 @@ const ToolResults = ({
         )}
         {structuredResult._meta && (
           <div className="mb-4">
-            <h5 className="font-semibold mb-2 text-sm">Meta:</h5>
+            <h5 className="font-semibold mb-2 text-sm">Meta Schema:</h5>
             <div className="bg-gray-50 dark:bg-gray-900 p-3 rounded-lg">
               <JsonView data={structuredResult._meta} />
             </div>


### PR DESCRIPTION
This PR adds a UI section inside the tools tab which enabled the user to provide extra key-value pairs for the `_meta` object. Fixes #559.

UI:
<img width="781" height="162" alt="image" src="https://github.com/user-attachments/assets/035f25bf-cc3a-4a5e-b8ac-f61c8f76f5ac" />

Request:
<img width="260" height="125" alt="image" src="https://github.com/user-attachments/assets/a83c3f0e-0fff-4f88-be20-b7f710917ca8" />

## Motivation and Context
Currently there is no way to provide additional `_meta` values in the UI. 

## How Has This Been Tested?
I provided values in the UI and checked that they are sent in the request. Also, I added a test.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
