### PR TITLE
fix: correct authState.authorizationUrl type to URL

### DIFF
--- a/client/src/components/AuthDebugger.tsx
+++ b/client/src/components/AuthDebugger.tsx
@@ -187,7 +187,7 @@ const AuthDebugger = ({
             JSON.stringify(currentState),
           );
           // Open the authorization URL automatically
-          window.location.href = currentState.authorizationUrl;
+          window.location.href = currentState.authorizationUrl.toString();
           break;
         }
       }

--- a/client/src/components/OAuthFlowProgress.tsx
+++ b/client/src/components/OAuthFlowProgress.tsx
@@ -240,7 +240,7 @@ export const OAuthFlowProgress = ({
               <p className="font-medium mb-2 text-sm">Authorization URL:</p>
               <div className="flex items-center gap-2">
                 <p className="text-xs break-all">
-                  {authState.authorizationUrl}
+                  {String(authState.authorizationUrl)}
                 </p>
                 <button
                   onClick={() => {

--- a/client/src/components/__tests__/AuthDebugger.test.tsx
+++ b/client/src/components/__tests__/AuthDebugger.test.tsx
@@ -482,7 +482,9 @@ describe("AuthDebugger", () => {
       await waitFor(() => {
         expect(updateAuthState).toHaveBeenCalledWith(
           expect.objectContaining({
-            authorizationUrl: expect.stringContaining("scope="),
+            authorizationUrl: expect.objectContaining({
+              href: "https://oauth.example.com/authorize?scope=read+write",
+            }),
           }),
         );
       });
@@ -496,7 +498,9 @@ describe("AuthDebugger", () => {
       await waitFor(() => {
         expect(updateAuthState).toHaveBeenCalledWith(
           expect.objectContaining({
-            authorizationUrl: expect.stringContaining("scope="),
+            authorizationUrl: expect.objectContaining({
+              href: "https://oauth.example.com/authorize?scope=read+write",
+            }),
           }),
         );
       });

--- a/client/src/lib/auth-types.ts
+++ b/client/src/lib/auth-types.ts
@@ -34,7 +34,7 @@ export interface AuthDebuggerState {
   authServerUrl: URL | null;
   oauthMetadata: OAuthMetadata | null;
   oauthClientInfo: OAuthClientInformationFull | OAuthClientInformation | null;
-  authorizationUrl: string | null;
+  authorizationUrl: URL | null;
   authorizationCode: string;
   latestError: Error | null;
   statusMessage: StatusMessage | null;

--- a/client/src/lib/oauth-state-machine.ts
+++ b/client/src/lib/oauth-state-machine.ts
@@ -132,7 +132,7 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
 
       context.provider.saveCodeVerifier(codeVerifier);
       context.updateState({
-        authorizationUrl: authorizationUrl.toString(),
+        authorizationUrl: authorizationUrl,
         oauthStep: "authorization_code",
       });
     },

--- a/client/src/utils/urlValidation.ts
+++ b/client/src/utils/urlValidation.ts
@@ -5,7 +5,7 @@
  * @param url - The URL string to validate
  * @throws Error if the URL has an unsafe protocol
  */
-export function validateRedirectUrl(url: string): void {
+export function validateRedirectUrl(url: string | URL): void {
   try {
     const parsedUrl = new URL(url);
     if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Closes https://github.com/modelcontextprotocol/inspector/issues/785 which occurs due to the rendering of the URL prop directly as a react component:

https://github.com/modelcontextprotocol/inspector/blob/main/client/src/components/OAuthFlowProgress.tsx#L242-L244

the URL prop is incorrectly typed as a string when it should be a URL. When the URL prop is restored from local storage during the quick connect flow, the type mismatch causes an error.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
