### PR TITLE
chore: bump version to 0.16.7

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-cli",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "description": "CLI for the Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-client",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "description": "Client-side application for the Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/inspector",
-      "version": "0.16.6",
+      "version": "0.16.7",
       "license": "MIT",
       "workspaces": [
         "client",
@@ -14,9 +14,9 @@
         "cli"
       ],
       "dependencies": {
-        "@modelcontextprotocol/inspector-cli": "^0.16.6",
-        "@modelcontextprotocol/inspector-client": "^0.16.6",
-        "@modelcontextprotocol/inspector-server": "^0.16.6",
+        "@modelcontextprotocol/inspector-cli": "^0.16.7",
+        "@modelcontextprotocol/inspector-client": "^0.16.7",
+        "@modelcontextprotocol/inspector-server": "^0.16.7",
         "@modelcontextprotocol/sdk": "^1.18.0",
         "concurrently": "^9.2.0",
         "open": "^10.2.0",
@@ -46,7 +46,7 @@
     },
     "cli": {
       "name": "@modelcontextprotocol/inspector-cli",
-      "version": "0.16.6",
+      "version": "0.16.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",
@@ -69,7 +69,7 @@
     },
     "client": {
       "name": "@modelcontextprotocol/inspector-client",
-      "version": "0.16.6",
+      "version": "0.16.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",
@@ -11746,7 +11746,7 @@
     },
     "server": {
       "name": "@modelcontextprotocol/inspector-server",
-      "version": "0.16.6",
+      "version": "0.16.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "description": "Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",
@@ -47,9 +47,9 @@
     "check-version": "node scripts/check-version-consistency.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/inspector-cli": "^0.16.6",
-    "@modelcontextprotocol/inspector-client": "^0.16.6",
-    "@modelcontextprotocol/inspector-server": "^0.16.6",
+    "@modelcontextprotocol/inspector-cli": "^0.16.7",
+    "@modelcontextprotocol/inspector-client": "^0.16.7",
+    "@modelcontextprotocol/inspector-server": "^0.16.7",
     "@modelcontextprotocol/sdk": "^1.18.0",
     "concurrently": "^9.2.0",
     "open": "^10.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-server",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "description": "Server-side application for the Model Context Protocol inspector",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",


### PR DESCRIPTION
Bump MCP Inspector version to 0.16.7 as requested in #792.

Changes made:
- Updated version in all package.json files
- Updated workspace dependencies
- Rebuilt packages and updated package-lock.json
- Verified version consistency with check-version script

Closes #792

🤖 Generated with [Claude Code](https://claude.ai/code)