### PR TITLE
Fix OAuth redirect URI mismatch in debug flow

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -117,9 +117,14 @@ export class InspectorOAuthClientProvider implements OAuthClientProvider {
     return window.location.origin + "/oauth/callback";
   }
 
+  get debugRedirectUrl() {
+    return window.location.origin + "/oauth/callback/debug";
+  }
+
   get clientMetadata(): OAuthClientMetadata {
+    // Register both redirect URIs to support both normal and debug flows
     return {
-      redirect_uris: [this.redirectUrl],
+      redirect_uris: [this.redirectUrl, this.debugRedirectUrl],
       token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
@@ -223,11 +228,13 @@ export class InspectorOAuthClientProvider implements OAuthClientProvider {
   }
 }
 
-// Overrides debug URL and allows saving server OAuth metadata to
+// Overrides redirect URL to use the debug endpoint and allows saving server OAuth metadata to
 // display in debug UI.
 export class DebugInspectorOAuthClientProvider extends InspectorOAuthClientProvider {
   get redirectUrl(): string {
-    return `${window.location.origin}/oauth/callback/debug`;
+    // We can use the debug redirect URL here because it was already registered
+    // in the parent class's clientMetadata along with the normal redirect URL
+    return this.debugRedirectUrl;
   }
 
   saveServerMetadata(metadata: OAuthMetadata) {


### PR DESCRIPTION
## Summary
- Registers both normal (`/oauth/callback`) and debug (`/oauth/callback/debug`) redirect URIs in OAuth client metadata
- Prevents redirect URI mismatch errors when switching between connection flow and Auth tab debug mode
- Adds `debugRedirectUrl` getter to base class for cleaner code organization

## Test plan
- Test normal OAuth connection flow works
- Test Auth tab debug mode OAuth flow works
- Verify both redirect URIs are registered in client metadata