### PR TITLE
Fix stateless StreamableHttp connections

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,8 +53,8 @@ const getHttpHeaders = (req: express.Request): Record<string, string> => {
       lowerKey === "authorization" ||
       lowerKey === "last-event-id"
     ) {
-      // Exclude the proxy's own authentication header
-      if (lowerKey !== "x-mcp-proxy-auth") {
+      // Exclude the proxy's own authentication header and the Client <-> Proxy session ID header
+      if (lowerKey !== "x-mcp-proxy-auth" && lowerKey !== "mcp-session-id") {
         const value = req.headers[key];
 
         if (typeof value === "string") {


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of your changes -->
When the client sends a request, do not pass on the `mcp-session-id` header for the Client <-> Proxy connection. This causes a problem for stateless http connections. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The changes in #787 introduced an unexpected side effect for stateless StreamableHttp connections. They don't return an `mcp-session-id`, but the function that forwards headers was passing on the `mcp-session-id` for the Client <-> Proxy transport. Therefore the server, which does not recognize this session id will return a 404 error according to spec. 

Researching the headers being sent, it was that the Client <-> Proxy session id was being sent if no `mcp-session-id` was returned from the server.

This fixes #804

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
With the server in #804 that was failing before. Works now.
<img width="1133" height="585" alt="Screenshot 2025-09-15 at 6 21 15 PM" src="https://github.com/user-attachments/assets/8a2b7012-9d2d-44c8-80c3-8c2628efa05e" />

Still works with Everything server, which gets it's proper session id sent on the Proxy <-> Server transport.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
