### PR TITLE
Encrypt and store client_secret

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -232,6 +232,8 @@ const App = () => {
     handleDragStart: handleSidebarDragStart,
   } = useDraggableSidebar(320);
 
+  const [clientEncryptionKey, setClientEncryptionKey] = useState<string>("");
+
   const {
     connectionStatus,
     serverCapabilities,
@@ -254,6 +256,7 @@ const App = () => {
     oauthClientId,
     oauthScope,
     config,
+    clientEncryptionKey,
     onNotification: (notification) => {
       setNotifications((prev) => [...prev, notification as ServerNotification]);
     },
@@ -422,9 +425,13 @@ const App = () => {
         };
 
         try {
-          const stateMachine = new OAuthStateMachine(sseUrl, (updates) => {
-            currentState = { ...currentState, ...updates };
-          });
+          const stateMachine = new OAuthStateMachine(
+            sseUrl,
+            clientEncryptionKey,
+            (updates) => {
+              currentState = { ...currentState, ...updates };
+            },
+          );
 
           while (
             currentState.oauthStep !== "complete" &&
@@ -462,7 +469,7 @@ const App = () => {
         });
       }
     },
-    [sseUrl],
+    [sseUrl, clientEncryptionKey],
   );
 
   useEffect(() => {
@@ -514,6 +521,9 @@ const App = () => {
         }
         if (data.defaultServerUrl) {
           setSseUrl(data.defaultServerUrl);
+        }
+        if (data.clientEncryptionKey) {
+          setClientEncryptionKey(data.clientEncryptionKey);
         }
       })
       .catch((error) =>
@@ -820,6 +830,7 @@ const App = () => {
         onBack={() => setIsAuthDebuggerVisible(false)}
         authState={authState}
         updateAuthState={updateAuthState}
+        clientEncryptionKey={clientEncryptionKey}
       />
     </TabsContent>
   );
@@ -830,7 +841,10 @@ const App = () => {
     );
     return (
       <Suspense fallback={<div>Loading...</div>}>
-        <OAuthCallback onConnect={onOAuthConnect} />
+        <OAuthCallback
+          onConnect={onOAuthConnect}
+          clientEncryptionKey={clientEncryptionKey}
+        />
       </Suspense>
     );
   }
@@ -841,7 +855,10 @@ const App = () => {
     );
     return (
       <Suspense fallback={<div>Loading...</div>}>
-        <OAuthDebugCallback onConnect={onOAuthDebugConnect} />
+        <OAuthDebugCallback
+          onConnect={onOAuthDebugConnect}
+          clientEncryptionKey={clientEncryptionKey}
+        />
       </Suspense>
     );
   }

--- a/client/src/components/JsonView.tsx
+++ b/client/src/components/JsonView.tsx
@@ -51,7 +51,7 @@ const JsonView = memo(
           variant: "destructive",
         });
       }
-    }, [toast, normalizedData]);
+    }, [toast, normalizedData, setCopied]);
 
     return (
       <div className={clsx("p-4 border rounded relative", className)}>

--- a/client/src/components/OAuthCallback.tsx
+++ b/client/src/components/OAuthCallback.tsx
@@ -10,9 +10,13 @@ import {
 
 interface OAuthCallbackProps {
   onConnect: (serverUrl: string) => void;
+  clientEncryptionKey: string;
 }
 
-const OAuthCallback = ({ onConnect }: OAuthCallbackProps) => {
+const OAuthCallback = ({
+  onConnect,
+  clientEncryptionKey,
+}: OAuthCallbackProps) => {
   const { toast } = useToast();
   const hasProcessedRef = useRef(false);
 
@@ -44,7 +48,10 @@ const OAuthCallback = ({ onConnect }: OAuthCallbackProps) => {
       let result;
       try {
         // Create an auth provider with the current server URL
-        const serverAuthProvider = new InspectorOAuthClientProvider(serverUrl);
+        const serverAuthProvider = new InspectorOAuthClientProvider(
+          serverUrl,
+          clientEncryptionKey,
+        );
 
         result = await auth(serverAuthProvider, {
           serverUrl,
@@ -73,7 +80,7 @@ const OAuthCallback = ({ onConnect }: OAuthCallbackProps) => {
     handleCallback().finally(() => {
       window.history.replaceState({}, document.title, "/");
     });
-  }, [toast, onConnect]);
+  }, [toast, onConnect, clientEncryptionKey]);
 
   return (
     <div className="flex items-center justify-center h-screen">

--- a/client/src/components/OAuthFlowProgress.tsx
+++ b/client/src/components/OAuthFlowProgress.tsx
@@ -56,6 +56,7 @@ interface OAuthFlowProgressProps {
   authState: AuthDebuggerState;
   updateAuthState: (updates: Partial<AuthDebuggerState>) => void;
   proceedToNextStep: () => Promise<void>;
+  clientEncryptionKey: string;
 }
 
 const steps: Array<OAuthStep> = [
@@ -72,11 +73,12 @@ export const OAuthFlowProgress = ({
   authState,
   updateAuthState,
   proceedToNextStep,
+  clientEncryptionKey,
 }: OAuthFlowProgressProps) => {
   const { toast } = useToast();
   const provider = useMemo(
-    () => new DebugInspectorOAuthClientProvider(serverUrl),
-    [serverUrl],
+    () => new DebugInspectorOAuthClientProvider(serverUrl, clientEncryptionKey),
+    [serverUrl, clientEncryptionKey],
   );
   const [clientInfo, setClientInfo] = useState<OAuthClientInformation | null>(
     null,

--- a/client/src/components/__tests__/AuthDebugger.test.tsx
+++ b/client/src/components/__tests__/AuthDebugger.test.tsx
@@ -141,6 +141,8 @@ Object.defineProperty(window, "sessionStorage", {
   value: sessionStorageMock,
 });
 
+const clientEncryptionKey = "test-encryption-key";
+
 describe("AuthDebugger", () => {
   const defaultAuthState = EMPTY_DEBUGGER_STATE;
 
@@ -149,6 +151,7 @@ describe("AuthDebugger", () => {
     onBack: jest.fn(),
     authState: defaultAuthState,
     updateAuthState: jest.fn(),
+    clientEncryptionKey,
   };
 
   beforeEach(() => {

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -20,6 +20,7 @@ global.fetch = jest.fn().mockResolvedValue({
   json: () => Promise.resolve({ status: "ok" }),
 });
 
+const clientEncryptionKey = "test-encryption-key";
 // Mock the SDK dependencies
 const mockRequest = jest.fn().mockResolvedValue({ test: "response" });
 const mockClient = {
@@ -124,6 +125,7 @@ describe("useConnection", () => {
     sseUrl: "http://localhost:8080",
     env: {},
     config: DEFAULT_INSPECTOR_CONFIG,
+    clientEncryptionKey,
   };
 
   describe("Request Configuration", () => {

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -79,6 +79,7 @@ interface UseConnectionOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getRoots?: () => any[];
   defaultLoggingLevel?: LoggingLevel;
+  clientEncryptionKey: string;
 }
 
 export function useConnection({
@@ -96,6 +97,7 @@ export function useConnection({
   onElicitationRequest,
   getRoots,
   defaultLoggingLevel,
+  clientEncryptionKey,
 }: UseConnectionOptions) {
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>("disconnected");
@@ -124,8 +126,9 @@ export function useConnection({
       serverUrl: sseUrl,
       clientInformation: { client_id: oauthClientId },
       isPreregistered: true,
+      clientEncryptionKey,
     });
-  }, [oauthClientId, sseUrl]);
+  }, [oauthClientId, sseUrl, clientEncryptionKey]);
 
   const pushHistory = (request: object, response?: object) => {
     setRequestHistory((prev) => [
@@ -333,6 +336,7 @@ export function useConnection({
       }
       const serverAuthProvider = new InspectorOAuthClientProvider(
         sseUrl,
+        clientEncryptionKey,
         scope,
       );
 
@@ -377,7 +381,10 @@ export function useConnection({
       const headers: HeadersInit = {};
 
       // Create an auth provider with the current server URL
-      const serverAuthProvider = new InspectorOAuthClientProvider(sseUrl);
+      const serverAuthProvider = new InspectorOAuthClientProvider(
+        sseUrl,
+        clientEncryptionKey,
+      );
 
       // Use custom headers (migration is handled in App.tsx)
       let finalHeaders: CustomHeaders = customHeaders || [];
@@ -667,7 +674,10 @@ export function useConnection({
         clientTransport as StreamableHTTPClientTransport
       ).terminateSession();
     await mcpClient?.close();
-    const authProvider = new InspectorOAuthClientProvider(sseUrl);
+    const authProvider = new InspectorOAuthClientProvider(
+      sseUrl,
+      clientEncryptionKey,
+    );
     authProvider.clear();
     setMcpClient(null);
     setClientTransport(null);

--- a/client/src/lib/hooks/useCopy.ts
+++ b/client/src/lib/hooks/useCopy.ts
@@ -21,7 +21,7 @@ function useCopy({ timeout = 500 }: UseCopyProps = {}) {
         clearTimeout(timeoutId);
       }
     };
-  }, [copied]);
+  }, [copied, setCopied, timeout]);
 
   return { copied, setCopied };
 }

--- a/client/src/lib/oauth-state-machine.ts
+++ b/client/src/lib/oauth-state-machine.ts
@@ -203,11 +203,15 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
 export class OAuthStateMachine {
   constructor(
     private serverUrl: string,
+    private clientEncryptionKey: string,
     private updateState: (updates: Partial<AuthDebuggerState>) => void,
   ) {}
 
   async executeStep(state: AuthDebuggerState): Promise<void> {
-    const provider = new DebugInspectorOAuthClientProvider(this.serverUrl);
+    const provider = new DebugInspectorOAuthClientProvider(
+      this.serverUrl,
+      this.clientEncryptionKey,
+    );
     const context: StateMachineContext = {
       state,
       serverUrl: this.serverUrl,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -160,6 +160,9 @@ const sessionToken =
   process.env.MCP_PROXY_AUTH_TOKEN || randomBytes(32).toString("hex");
 const authDisabled = !!process.env.DANGEROUSLY_OMIT_AUTH;
 
+const clientEncryptionKey =
+  process.env.MCP_CLIENT_ENCRYPTION_KEY || randomBytes(32).toString("hex");
+
 // Origin validation middleware to prevent DNS rebinding attacks
 const originValidationMiddleware = (
   req: express.Request,
@@ -747,6 +750,7 @@ app.get("/config", originValidationMiddleware, authMiddleware, (req, res) => {
       defaultArgs: values.args,
       defaultTransport: values.transport,
       defaultServerUrl: values["server-url"],
+      clientEncryptionKey,
     });
   } catch (error) {
     console.error("Error in /config route:", error);


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of your changes -->
- An clientEncryptionKey is now generated by the proxy server and exposed via the `/config` endpoint.
- The client stores it in state and passes it to all OAuth-related providers and flows.
- Client-side session storage of `OAuthClientInformation` will encrypt `client_secret` when saving and decrypt when reading, using a simple XOR+base64 scheme via new `encodeWithKey` and `decodeWithKey` functions.
- During the Auth Debugger flow, the `client_secret` is encrypted in the temporary `SESSION_KEYS.AUTH_DEBUGGER_STATE` before redirect and decrypted on the debug callback.
- Tests were updated to inject a deterministic `clientEncryptionKey`.
- **Plus a minor drive-by fix**: `useCopy` & `JsonView` effect dependency arrays updated to silence linter

* In `client/src/App.tsx`
  - Added state for clientEncryptionKey initialized to an empty string.
  - Updated OAuthStateMachine construction to accept clientEncryptionKey as the second argument and forward updates callback.
  - Updated onOAuthConnect handler dependency array to include clientEncryptionKey.
  - When fetching /config, read clientEncryptionKey from the returned JSON and call setClientEncryptionKey if present.
  - Passed clientEncryptionKey into AuthDebugger as prop.
  - Passed clientEncryptionKey to OAuthCallback component.
  - Passed clientEncryptionKey to OAuthDebugCallback component

* In `client/src/lib/auth.ts`
  - Added `encodeWithKey` function
    - XOR bytes of plaintext with key bytes, base64-encode the result.
  - Added `decodeWithKey` function
    - base64-decode then XOR with key bytes to recover plaintext.
  - Storage readers/writers updated to support encryption:
     - In `getClientInformationFromSessionStorage` 
       - now accepts clientEncryptionKey 
       - After parsing JSON into `OAuthClientInformation`, attempt to decrypt `client_secret` using `clientEncryptionKey` 
       - Log a warning if decryption fails and proceed with the parsed object.
     - In `saveClientInformationToSessionStorage`
       - now accepts `clientEncryptionKey`
       - If `clientEncryptionKey` and a `client_secret` are present, encrypt the `client_secret` before writing to session storage
    - In `InspectorOAuthClientProvider` 
      - Add protected `clientEncryptionKey` param to constructor
    - in `clientInformation` method,
      - Pass `clientEncryptionKey` through when calling `getClientInformationFromSessionStorage` for both preregistered and dynamically stored client info.
    - In `saveClientInformation` method, 
      - Stop stripping `client_secret`. 
      - Now save full `clientInformation` to session storage via `saveClientInformationToSessionStorage`, passing clientEncryptionKey

* In `client/src/components/tests/AuthDebugger.test.tsx`
  - Define test `clientEncryptionKey`
  - Provide `clientEncryptionKey` in default props passed to `AuthDebugger` in tests

* In `client/src/components/AuthDebugger.tsx`
  - Import `encodeWithKey`
  - Added `clientEncryptionKey` to `AuthDebuggerProps`.
  - When checking existing tokens, pass `clientEncryptionKey` to `DebugInspectorOAuthClientProvider` constructor.
  - Added `clientEncryptionKey` to the `useEffect` dependency array.
  - Whenever creating the `OAuthStateMachine`, pass `clientEncryptionKey` to constructor.
  - Before storing state in session storage before  redirect, encrypt `oauthClientInfo.client_secret` if present using `encodeWithKey`
  - Store the modified `stateToStore`.
  - Add `clientEncryptionKey` to the dependencies of the `proceedToNextStep` callback.
  - In `handleClearOAuth`,
    - pass `clientEncryptionKey` to `DebugInspectorOAuthClientProvider` constructor
    - Add `clientEncryptionKey` to `handleClearOAuth` dependencies.
  - Pass `clientEncryptionKey` down into `OAuthFlowProgress` component

* In `client/src/lib/oauth-state-machine.ts`
  - In `OAuthStateMachine` constructor, added private `clientEncryptionKey` parameter.
  - When creating `DebugInspectorOAuthClientProvider`, pass `clientEncryptionKey` to constructor

* In `client/src/components/OAuthCallback.tsx`
  - Added `clientEncryptionKey` to `OAuthCallbackProps`.
  - Component now accepts `clientEncryptionKey` prop.
  - Pass `clientEncryptionKey` to `InspectorOAuthClientProvider` constructor
  - Add `clientEncryptionKey` to the `useEffect` dependency array

* In `client/src/components/OAuthDebugCallback.tsx`
  - Import `decodeWithKey`
  - Added `clientEncryptionKey` to `OAuthCallbackProps` prop and accept it.
  - When loading `restoredState` from session storage, if `oauthClientInfo.client_secret` is present, decrypt it using `decodeWithKey` and write back the plaintext to `restoredState.oauthClientInfo.client_secret` prior to use.
  - Remove stored state afterward.
  - Add `clientEncryptionKey` to the `useEffect` dependencies

* In `client/src/components/OAuthFlowProgress.tsx`
  - Added `clientEncryptionKey` to `OAuthFlowProgressProps` and accept it.
  - Pass `clientEncryptionKey` to `DebugInspectorOAuthClientProvider`
  - Add `clientEncryptionKey` to `useMemo` dependencies

* In `client/src/lib/hooks/tests/useConnection.test.tsx`
  - Define test `clientEncryptionKey`
  - Include `clientEncryptionKey` when rendering/testing `useConnection` hook options

* In `client/src/lib/hooks/useConnection.ts`
  - Added `clientEncryptionKey` to `UseConnectionOptions`
  - Accept `clientEncryptionKey` parameter
  - Pass `clientEncryptionKey` into `saveClientInformationToSessionStorage`.
  - Add it to the `useEffect` dependency array
  - Whenever constructing `InspectorOAuthClientProvider`, pass `clientEncryptionKey`.

* In `server/src/index.ts`
  - Generate `clientEncryptionKey` on the server side:
    - Create `clientEncryptionKey` in same way as `mcpProxyAuthToken`, allowing it to be provided explicitly as `MCP_CLIENT_ENCRYPTION_KEY` in the environment
    - Include `clientEncryptionKey` in the JSON response of `/config` endpoint along with existing defaults so the client can retrieve and use it

* In `client/src/components/JsonView.tsx`
  - In an effect that references `setCopied`, the dependency array is updated to satisfy `exhaustive-deps`

* In `client/src/lib/hooks/useCopy.ts`
  - Effect dependency array corrected to include `setCopied` and `timeout` for proper cleanup and lint compliance.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
While researching #726, I discovered that a change made in Inspector [Release 0.16.4](https://github.com/modelcontextprotocol/inspector/releases/tag/0.16.4) - specifically [fix sensitive local storage](https://github.com/modelcontextprotocol/inspector/pull/715), where we removed `client_secret` from the client info stored in `localStorage` was causing authentication failures. 

The reason is that after an OAuth redirect, that information is read back from storage, and used to create the Authentication header for the `/token` call. In that call, the `client_id` and `client_secret` must be sent to the AS either via post body or Authentication header depending upon the challenge type (`client_secret_post` or`client_secret_basic`).

Using an example Python/Flask OAuth server provided by the author of #726, [I was able to see](https://github.com/modelcontextprotocol/inspector/issues/726#issuecomment-3313476635) that the versions of the Inspector prior to 0.16.4 will get the `/token` endpoint to return a token, but 0.16.4 and later could not. 

I suspected the removal of `client_secret` from storage was the problem, so I commented it out and [was able to show](https://github.com/modelcontextprotocol/inspector/issues/726#issuecomment-3313509085) that the `/token` endpoint would once again return a token.

We clearly need to preserve the `client_secret` across the OAuth redirect boundary. 

At the time of the fix that removed it from local storage, we discussed encrypting it before storing, but could not come up with a non-obvious way of doing so. The key would need to be ephemeral, and not itself placed in local storage. That rules out generating it or hardcoding it on the client side. 

Faced with this dilemma, I decided to generate the key on the proxy server and provide it to the client via the `/config` endpoint, which is called each the client loads. That server is protected with an ephemeral `MCP_PROXY_AUTH_TOKEN` so that only the client can make connections. So long as the client does not store this retrieved encryption key, it could use it to encrypt `client_secret` anytime the client information is stored in local storage, and decrypt it upon reading it back from local storage after an OAuth redirect.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
* The hosted, auth-enabled, [version of the Everything server](https://github.com/modelcontextprotocol/example-remote-server) - discovered that it is actually not checking for `client_secret` on its `client_secret_post` challenge!
 
* The example Python/Flask OAuth server provided in #726 
<img width="932" height="377" alt="Image" src="https://github.com/user-attachments/assets/7e71547b-20f0-471e-bf45-7247fb41974d" />


## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
