### PR TITLE
`ToolsTab`: truncate longer tool descriptions for nicer rendering

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -95,7 +95,7 @@ const ToolsTab = ({
           renderItem={(tool) => (
             <div className="flex flex-col items-start">
               <span className="flex-1">{tool.name}</span>
-              <span className="text-sm text-gray-500 text-left">
+              <span className="text-sm text-gray-500 text-left line-clamp-3">
                 {tool.description}
               </span>
             </div>
@@ -114,9 +114,12 @@ const ToolsTab = ({
           <div className="p-4">
             {selectedTool ? (
               <div className="space-y-4">
-                <p className="text-sm text-gray-600 dark:text-gray-400">
+                <div className="text-sm font-medium">Description</div>
+                <div className="text-sm text-gray-600 dark:text-gray-400 whitespace-pre-wrap max-h-48 overflow-y-auto">
                   {selectedTool.description}
-                </p>
+                </div>
+                <hr className="border-t border-gray-300 my-4" />
+                <div className="text-sm font-medium">Inputs & Outputs</div>
                 {Object.entries(selectedTool.inputSchema.properties ?? []).map(
                   ([key, value]) => {
                     const prop = normalizeUnionType(value as JsonSchemaType);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Small PR that improves how MCP tool descriptions are rendered in the "Tools" tab when they're relatively verbose/lengthy.

- In the list view, descriptions are truncated/ellipsized after 3 lines
- In the right pane (a specific tool), I added:
  - `max-h-48` and `overflow-y-auto`: to limit the height of the description's "text area" shown in the window at once, and add vertical scrollbars a description is longer than that
  - `whitespace-pre-wrap`: To respect newline characters in descriptions [0]
  - Grey borders between the description & inputs/outputs of the tool and headings to better demarcate those

<kbd>

<img width="1785" height="993" alt="Screenshot 2025-09-21 at 10 00 38 AM" src="https://github.com/user-attachments/assets/e18e7f5c-6787-4887-a849-30853fc9542b" />

</kbd>

[0] I want to ideally use `ReactMarkdown` here for even better rendering for tools that have Markdown-friendly descriptions. But we can explore that in a future PR; I had trouble figuring out the EJS node modules setup with Jest here so I punted that work for now

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Ran locally and manually click tested with longer tool descriptions (our remote MCP server at Notion has a bunch of these 😅).

|Before|After (long description)|After (short description)
|-|-|-|
|<img width="1782" height="985" alt="Screenshot 2025-09-21 at 10 02 15 AM" src="https://github.com/user-attachments/assets/a452c216-ea16-45f1-8c9a-0784cbb09015" />|<img width="1785" height="993" alt="Screenshot 2025-09-21 at 10 00 38 AM" src="https://github.com/user-attachments/assets/8bbde821-405a-4d6b-9a1f-31feef75e21f" />|<img width="1780" height="980" alt="Screenshot 2025-09-21 at 10 10 56 AM" src="https://github.com/user-attachments/assets/f1410b76-9859-480a-87c6-793e98c7fd54" />|

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
N/A for now