### PR TITLE
fix: enhance OAuth token handling in useConnection hook to prevent infinite auth loops

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -165,7 +165,13 @@ const App = () => {
     }
 
     // Default to empty array
-    return [];
+    return [
+      {
+        name: "Authorization",
+        value: "Bearer ",
+        enabled: false,
+      },
+    ];
   });
 
   const [pendingSampleRequests, setPendingSampleRequests] = useState<

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -162,14 +162,8 @@ const App = () => {
       return migrateFromLegacyAuth(legacyToken, legacyHeaderName);
     }
 
-    // Default to Authorization: Bearer as the most common case
-    return [
-      {
-        name: "Authorization",
-        value: "Bearer ",
-        enabled: true,
-      },
-    ];
+    // Default to empty array
+    return [];
   });
 
   const [pendingSampleRequests, setPendingSampleRequests] = useState<

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -97,9 +97,10 @@ jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
 }));
 
 // Mock the toast hook
+const mockToast = jest.fn();
 jest.mock("@/lib/hooks/useToast", () => ({
   useToast: () => ({
-    toast: jest.fn(),
+    toast: mockToast,
   }),
 }));
 
@@ -940,6 +941,13 @@ describe("useConnection", () => {
       expect(headers).toHaveProperty("Authorization", "Bearer mock-token");
       // Should not have the x-custom-auth-headers since Authorization is standard
       expect(headers).not.toHaveProperty("x-custom-auth-headers");
+
+      // Should show toast notification for empty Authorization header
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "Invalid Authorization Header",
+        description: expect.any(String),
+        variant: "destructive",
+      });
     });
 
     test("prioritizes custom headers over legacy auth", async () => {

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -914,14 +914,14 @@ describe("useConnection", () => {
       expect(headers).toHaveProperty("Authorization", "Bearer mock-token");
     });
 
-    test("replaces empty Bearer token placeholder with OAuth token", async () => {
+    test("warns of enabled empty Bearer token", async () => {
       // This test prevents regression of the bug where default "Bearer " header
       // prevented OAuth token injection, causing infinite auth loops
       const customHeaders: CustomHeaders = [
         {
           name: "Authorization",
           value: "Bearer ", // Empty Bearer token placeholder
-          enabled: true,
+          enabled: true, // enabled
         },
       ];
 
@@ -937,8 +937,8 @@ describe("useConnection", () => {
       });
 
       const headers = mockSSETransport.options?.requestInit?.headers;
-      // Should replace the empty "Bearer " with actual OAuth token
-      expect(headers).toHaveProperty("Authorization", "Bearer mock-token");
+
+      expect(headers).toHaveProperty("Authorization", "Bearer");
       // Should not have the x-custom-auth-headers since Authorization is standard
       expect(headers).not.toHaveProperty("x-custom-auth-headers");
 

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -413,7 +413,7 @@ export function useConnection({
         toast({
           title: "Invalid Authorization Header",
           description:
-            "Authorization header is enabled but empty. Please add a token or disable the header. It will be added automatically.",
+            "Authorization header is enabled but empty. Please add a token or disable the header.",
           variant: "destructive",
         });
       }

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -400,12 +400,13 @@ export function useConnection({
       // Use custom headers (migration is handled in App.tsx)
       let finalHeaders: CustomHeaders = customHeaders || [];
 
+      const isEmptyAuthHeader = (header: CustomHeaders[number]) =>
+        header.name.trim().toLowerCase() === "authorization" &&
+        header.value.trim() === "Bearer";
+
       // Check for empty Authorization headers and show validation error
       const hasEmptyAuthHeader = finalHeaders.some(
-        (header) =>
-          header.enabled &&
-          header.name.trim().toLowerCase() === "authorization" &&
-          (!header.value.trim() || header.value.trim() === "Bearer"),
+        (header) => header.enabled && isEmptyAuthHeader(header),
       );
 
       if (hasEmptyAuthHeader) {
@@ -417,17 +418,7 @@ export function useConnection({
         });
       }
 
-      // Check if we need to inject OAuth token
-      // This handles both empty headers and default "Bearer " placeholder headers
-      const isEmptyAuthHeader = (header: CustomHeaders[number]) =>
-        header.name.trim().toLowerCase() === "authorization" &&
-        header.value.trim() === "Bearer";
-
-      const needsOAuthToken =
-        finalHeaders.length === 0 ||
-        finalHeaders.some(
-          (header) => header.enabled && isEmptyAuthHeader(header),
-        );
+      const needsOAuthToken = finalHeaders.length === 0 || hasEmptyAuthHeader;
 
       if (needsOAuthToken) {
         const oauthToken = (await serverAuthProvider.tokens())?.access_token;

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -400,6 +400,23 @@ export function useConnection({
       // Use custom headers (migration is handled in App.tsx)
       let finalHeaders: CustomHeaders = customHeaders || [];
 
+      // Check for empty Authorization headers and show validation error
+      const hasEmptyAuthHeader = finalHeaders.some(
+        (header) =>
+          header.enabled &&
+          header.name.trim().toLowerCase() === "authorization" &&
+          (!header.value.trim() || header.value.trim() === "Bearer"),
+      );
+
+      if (hasEmptyAuthHeader) {
+        toast({
+          title: "Invalid Authorization Header",
+          description:
+            "Authorization header is enabled but empty. Please add a token or disable the header. It will be added automatically.",
+          variant: "destructive",
+        });
+      }
+
       // Check if we need to inject OAuth token
       // This handles both empty headers and default "Bearer " placeholder headers
       const isEmptyAuthHeader = (header: CustomHeaders[number]) =>

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -402,7 +402,7 @@ export function useConnection({
 
       const isEmptyAuthHeader = (header: CustomHeaders[number]) =>
         header.name.trim().toLowerCase() === "authorization" &&
-        header.value.trim() === "Bearer";
+        header.value.trim().toLowerCase() === "bearer";
 
       // Check for empty Authorization headers and show validation error
       const hasEmptyAuthHeader = finalHeaders.some(
@@ -418,7 +418,11 @@ export function useConnection({
         });
       }
 
-      const needsOAuthToken = finalHeaders.length === 0 || hasEmptyAuthHeader;
+      const needsOAuthToken = !finalHeaders.some(
+        (header) =>
+          header.enabled &&
+          header.name.trim().toLowerCase() === "authorization",
+      );
 
       if (needsOAuthToken) {
         const oauthToken = (await serverAuthProvider.tokens())?.access_token;


### PR DESCRIPTION
Fix OAuth token injection when default `"Bearer "` header is present, preventing infinite auth loops

Closes #829

## Motivation and Context

This change fixes a critical authentication bug that caused infinite OAuth loops in the inspector. The issue occurred when users had the default `customHeaders` configuration with an empty "Bearer " placeholder header. The authentication logic would send "Bearer " (without an actual token) to the server, which would return a 401 error, triggering OAuth flow, but the same empty header would be sent again, creating an infinite loop.

The root cause was that the OAuth token injection logic only triggered when `finalHeaders.length === 0`, but the default configuration always included a placeholder header `{ name: "Authorization", value: "Bearer ", enabled: true }`, so the condition was never met.

## How Has This Been Tested?

- Added a specific regression test case `"replaces empty Bearer token placeholder with OAuth token"` that verifies the fix
- All existing tests in the useConnection test suite pass (36/36 tests)
- The test verifies that when a default "Bearer " header is present, it gets replaced with the actual OAuth token "Bearer mock-token"

## Breaking Changes

None. This is a bug fix that preserves existing behavior while fixing the authentication issue.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

I'm actually open to instead changing the default header to exclude the empty `Bearer `. Arguably that's a more appropriate fix. But I figured there's a reason that default was added so I decided to just handle it gracefully.