### PR TITLE
Fix cli package.json import

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -31,7 +31,7 @@ type JsonValue =
   | JsonValue[]
   | { [key: string]: JsonValue };
 
-import packageJson from "../package.json" with { type: "json" };
+import packageJson from "../../package.json" with { type: "json" };
 
 type Args = {
   target: string[];

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import * as fs from "fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { Command } from "commander";
 import {
@@ -30,8 +31,6 @@ type JsonValue =
   | undefined
   | JsonValue[]
   | { [key: string]: JsonValue };
-
-import packageJson from "../../package.json" with { type: "json" };
 
 type Args = {
   target: string[];
@@ -101,6 +100,15 @@ function createTransportOptions(
 }
 
 async function callMethod(args: Args): Promise<void> {
+  // Read package.json to get name and version for client identity
+  const pathA = "../package.json"; // We're in package @modelcontextprotocol/inspector-cli
+  const pathB = "../../package.json"; // We're in package @modelcontextprotocol/inspector
+  let packageJson: { name: string; version: string };
+  let packageJsonData = await import(fs.existsSync(pathA) ? pathA : pathB, {
+    with: { type: "json" },
+  });
+  packageJson = packageJsonData.default;
+
   const transportOptions = createTransportOptions(
     args.target,
     args.transport,


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of your changes -->
* In `cli/src/index.ts`
  - load `package.json` from `../` or `../../` depending on file existence in parent.
  - move the load of `package.json` into `callMethod` function, which is the only place it is used, and is closer to where it is referenced.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
In #544, a change to `cli/src/index.ts` was introduced that reads `package.json` from one level up (`../package.json`). As reported in #834, It fails when running `@modelcontextprotocol/inspector` from the command line.

<img width="2294" height="866" alt="image" src="https://github.com/user-attachments/assets/6f5e0bfb-3a7d-42db-8869-f76ec3fa3561" />

* It works if the project is checked out locally, because the `package.json` of the workspace packages are present. 
* However, they are not included in the main `inspector` build, so it does not work in [`@modelcontextprotocol/inspector`](https://www.npmjs.com/package/@modelcontextprotocol/inspector?activeTab=code).
* We _can_ get that from two levels up (`../../package.json`) the in main inspector package.
* But... if running the npm package [`@modelcontextprotocol/inspector-cli`](https://www.npmjs.com/package/@modelcontextprotocol/inspector-cli?activeTab=code) , the location of the workspace's `package.json` will be in `../` and `../../package.json` will not exist. 
 
Therefore, this PR reads `../package.json` if present, otherwise it reads `../../package.json`. One of the two will exist.

### Location of `index.js` in main `inspector` package
<img width="1992" height="838" alt="image" src="https://github.com/user-attachments/assets/47e241cd-1c41-40bc-b345-9c4890b7516b" />

### No `package.json` in `../`
<img width="992" height="209" alt="Screenshot 2025-10-04 at 3 18 53 PM" src="https://github.com/user-attachments/assets/7571848f-a702-4492-85cb-e026e1fe2278" />

###  Present at `../../package.json`
<img width="1968" height="738" alt="image" src="https://github.com/user-attachments/assets/b13b6b3a-00e7-4f9a-b9c9-96670d6d7f57" />

### Location of `index.js` in `inspector-cli` package
<img width="991" height="422" alt="Screenshot 2025-10-04 at 3 20 13 PM" src="https://github.com/user-attachments/assets/67524d7e-2b1f-4798-a056-9191f6d6b528" />

### Present at`../package.json`
<img width="1002" height="201" alt="Screenshot 2025-10-04 at 3 22 49 PM" src="https://github.com/user-attachments/assets/4c9efab7-801a-42e3-af20-75ef8aa53abd" />

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Locally, running a CLI command
```shell
 node cli/build/cli.js --cli https://mcp.paypal.com/mcp --transport http --method tools/list --header "Authorization: Bearer <token>"
 ```

This is a problem that we only saw once published, but given the above known locations of the `package.json` in either published package, I'm confident it will work as expected. All tests still pass.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Fixes #834