### PR TITLE
Add input validation guidelines to CLAUDE.md and fix the case where there are null defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,14 @@ The project is organized as a monorepo with workspaces:
 - `client/`: React frontend with Vite, TypeScript and Tailwind
 - `server/`: Express backend with TypeScript
 - `cli/`: Command-line interface for testing and invoking MCP server methods directly
+
+## Tool Input Validation Guidelines
+
+When handling tool input parameters and form fields:
+
+- **Optional fields with empty values should be omitted entirely** - Do not send empty strings or null values for optional parameters, UNLESS the field has an explicit default value in the schema that matches the current value
+- **Fields with explicit defaults should preserve their default values** - If a field has an explicit default in its schema (e.g., `default: null`), and the current value matches that default, include it in the request. This is a meaningful value the tool expects
+- **Required fields should preserve their values even when empty** - This allows the server to properly validate and return appropriate error messages
+- **Deeper validation should be handled by the server** - Inspector should focus on basic field presence, while the MCP server handles parameter validation according to its schema
+
+These guidelines ensure clean parameter passing and proper separation of concerns between the Inspector client and MCP servers.

--- a/client/src/utils/__tests__/paramUtils.test.ts
+++ b/client/src/utils/__tests__/paramUtils.test.ts
@@ -205,4 +205,76 @@ describe("cleanParams", () => {
       // optionalField omitted entirely
     });
   });
+
+  it("should preserve null values when field has default: null", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      required: [],
+      properties: {
+        optionalFieldWithNullDefault: { type: "string", default: null },
+        optionalFieldWithoutDefault: { type: "string" },
+      },
+    };
+
+    const params = {
+      optionalFieldWithNullDefault: null,
+      optionalFieldWithoutDefault: null,
+    };
+
+    const cleaned = cleanParams(params, schema);
+
+    expect(cleaned).toEqual({
+      optionalFieldWithNullDefault: null, // preserved because default: null
+      // optionalFieldWithoutDefault omitted
+    });
+  });
+
+  it("should preserve default values that match current value", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      required: [],
+      properties: {
+        fieldWithDefaultString: { type: "string", default: "defaultValue" },
+        fieldWithDefaultNumber: { type: "number", default: 42 },
+        fieldWithDefaultNull: { type: "string", default: null },
+        fieldWithDefaultBoolean: { type: "boolean", default: false },
+      },
+    };
+
+    const params = {
+      fieldWithDefaultString: "defaultValue",
+      fieldWithDefaultNumber: 42,
+      fieldWithDefaultNull: null,
+      fieldWithDefaultBoolean: false,
+    };
+
+    const cleaned = cleanParams(params, schema);
+
+    expect(cleaned).toEqual({
+      fieldWithDefaultString: "defaultValue",
+      fieldWithDefaultNumber: 42,
+      fieldWithDefaultNull: null,
+      fieldWithDefaultBoolean: false,
+    });
+  });
+
+  it("should omit values that do not match their default", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      required: [],
+      properties: {
+        fieldWithDefault: { type: "string", default: "defaultValue" },
+      },
+    };
+
+    const params = {
+      fieldWithDefault: null, // doesn't match default
+    };
+
+    const cleaned = cleanParams(params, schema);
+
+    expect(cleaned).toEqual({
+      // fieldWithDefault omitted because value (null) doesn't match default ("defaultValue")
+    });
+  });
 });

--- a/client/src/utils/paramUtils.ts
+++ b/client/src/utils/paramUtils.ts
@@ -2,7 +2,7 @@ import type { JsonSchemaType } from "./jsonUtils";
 
 /**
  * Cleans parameters by removing undefined, null, and empty string values for optional fields
- * while preserving all values for required fields.
+ * while preserving all values for required fields and fields with explicit default values.
  *
  * @param params - The parameters object to clean
  * @param schema - The JSON schema defining which fields are required
@@ -14,12 +14,22 @@ export function cleanParams(
 ): Record<string, unknown> {
   const cleaned: Record<string, unknown> = {};
   const required = schema.required || [];
+  const properties = schema.properties || {};
 
   for (const [key, value] of Object.entries(params)) {
     const isFieldRequired = required.includes(key);
+    const fieldSchema = properties[key] as JsonSchemaType | undefined;
+
+    // Check if the field has an explicit default value
+    const hasDefault = fieldSchema && "default" in fieldSchema;
+    const defaultValue = hasDefault ? fieldSchema.default : undefined;
 
     if (isFieldRequired) {
       // Required fields: always include, even if empty string or falsy
+      cleaned[key] = value;
+    } else if (hasDefault && value === defaultValue) {
+      // Field has a default value and current value matches it - preserve it
+      // This is important for cases like default: null
       cleaned[key] = value;
     } else {
       // Optional fields: only include if they have meaningful values


### PR DESCRIPTION
The cleanParams function added in 0.17.0 was overly zealous and removes nulls being set by the tool schema as defaults.

Since there are a few opinionated ways to handle validation for tools I also added the established guidelines to the agent instructions, to make it clearer where and when validation should happen and what Inspector vs the server should handle in these scenarios.

## Motivation and Context

Fixes https://github.com/modelcontextprotocol/inspector/issues/846

## How Has This Been Tested?

I followed these test cases using a set of tools created for testing regression scenarios: `mcp-maintainer-toolkit@latest`

### Test 1: Union Type Test Tool (Primary Regression Test)

Tool: `unionTypeTest`

#### Test 1a: Default null values are preserved and sent in `tools/call`
- Run the `unionTypeTest` tool without changing any values
- In 0.17.0 this would remove all null arguments from the `tools/call` in the History pane
- In this branch, null defaults are preserved in the `tools/call` params

#### Test 1b: Default null values are sent if input is cleared
- Clear the optionalString field and run the tool again
- Expected: Tool receives null for optionalString

#### Test 1c: Null values are sent when user manually enters them
- Manually type null in the optionalString field
- Click "Run Tool"
- Expected: Tool receives null for optionalString

#### Test 1d: Non-null values override defaults
- Enter "hello" in optionalString
- Enter "42" in optionalNumber
- Check the optionalBoolean checkbox
- Click "Run Tool"
- Expected: Message shows "Optional parameters provided: optionalString: "hello", optionalNumber: 42, optionalBoolean: true"

### Test 2: Other Default Values

Tool: formatData

#### Test 2a: String default value preserved
- Select the formatData tool
- Verify format field shows "json" as default
- Click "Copy Input"
- Expected: JSON contains "format": "json"
- Leave format as "json", add {} to data field
- Click "Run Tool"
- Expected: Data formatted as JSON

#### Test 2b: Enum default value preserved

Tool: enumDropdownTest

- Select the enumDropdownTest tool
- Verify priority defaults to "medium"
- Verify colorScheme defaults to "auto"
- Click "Copy Input"
- Expected: JSON contains both default values
- Run tool without changing defaults
- Expected: Tool receives default values


### Test 3: Optional Fields Without Defaults (Backward Compatibility)

Tool: getCurrentTime

#### Test 3a: Empty optional field is omitted
- Select the getCurrentTime tool
- Leave timezone field empty
- Click "Copy Input"
- Expected: JSON should NOT contain timezone field (omitted entirely)
- Click "Run Tool"
- Expected: Success with "(local timezone)" in response

#### Test 3b: Optional field with value is included
- Enter "America/New_York" in timezone
- Click "Copy Input"
- Expected: JSON contains "timezone": "America/New_York"
- Click "Run Tool"
- Expected: Success with "(America/New_York)" in response

### Test 4: Required fields preserve empty values for validation

- Select the `strictTypeValidation` tool
- Leave all fields empty
- Click "Run Tool"
- Expected: Server validation error (not Inspector error)
- Expected: Error explains which required fields are missing/invalid

### Test 5: Automated Tests

cd client
npm test -- paramUtils.test.ts
- Expected: All 12 tests pass
- Specifically verify these new tests pass:
  - "should preserve null values when field has default: null"
  - "should preserve default values that match current value"
  - "should omit values that do not match their default"

## Breaking Changes

No - this part of the behavior is unintentional.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
