### PR TITLE
fix: prevent long unbreakable words in alert messages from overflowing

### DIFF
--- a/client/src/components/PromptsTab.tsx
+++ b/client/src/components/PromptsTab.tsx
@@ -131,7 +131,9 @@ const PromptsTab = ({
               <Alert variant="destructive">
                 <AlertCircle className="h-4 w-4" />
                 <AlertTitle>Error</AlertTitle>
-                <AlertDescription>{error}</AlertDescription>
+                <AlertDescription className="break-all">
+                  {error}
+                </AlertDescription>
               </Alert>
             ) : selectedPrompt ? (
               <div className="space-y-4">

--- a/client/src/components/ResourcesTab.tsx
+++ b/client/src/components/ResourcesTab.tsx
@@ -225,7 +225,9 @@ const ResourcesTab = ({
               <Alert variant="destructive">
                 <AlertCircle className="h-4 w-4" />
                 <AlertTitle>Error</AlertTitle>
-                <AlertDescription>{error}</AlertDescription>
+                <AlertDescription className="break-all">
+                  {error}
+                </AlertDescription>
               </Alert>
             ) : selectedResource ? (
               <JsonView

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -137,7 +137,9 @@ const ToolsTab = ({
                   <Alert variant="destructive">
                     <AlertCircle className="h-4 w-4" />
                     <AlertTitle>Error</AlertTitle>
-                    <AlertDescription>{error}</AlertDescription>
+                    <AlertDescription className="break-all">
+                      {error}
+                    </AlertDescription>
                   </Alert>
                 )}
                 <p className="text-sm text-gray-600 dark:text-gray-400">


### PR DESCRIPTION
## Summary
Fixes the issue where long, non-breakable words in alert messages would overflow the container.

## Motivation and Context
Previously, if an alert contained a long string without spaces, it would extend outside the container, breaking the UI. This change ensures proper word wrapping or breaking to keep the alert content inside the container.

## How Has This Been Tested?
- Tested alerts with normal messages.
- Tested alerts with long, unbroken strings.
- Verified UI remains intact across different screen sizes.

## Breaking Changes
No breaking changes. Existing alert functionality remains the same.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This fix is proactive; no issue was reported. It improves alert component resilience against unexpected input.


Screenshots: 
Before:
<img width="869" height="548" alt="image" src="https://github.com/user-attachments/assets/a56eedf3-232b-449b-9bf4-a8e3f06d1af7" />

After:
<img width="885" height="517" alt="image" src="https://github.com/user-attachments/assets/b223b3a1-db94-4df2-bc11-71e2c3b451db" />