### PR TITLE
Fix duplicate OAuth redirect URIs

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -121,10 +121,16 @@ export class InspectorOAuthClientProvider implements OAuthClientProvider {
     return window.location.origin + "/oauth/callback/debug";
   }
 
+  get redirect_uris() {
+    // Normally register both redirect URIs to support both normal and debug flows
+    // In debug subclass, redirectUrl may be the same as debugRedirectUrl, so remove duplicates
+    // See: https://github.com/modelcontextprotocol/inspector/issues/825
+    return [...new Set([this.redirectUrl, this.debugRedirectUrl])];
+  }
+
   get clientMetadata(): OAuthClientMetadata {
-    // Register both redirect URIs to support both normal and debug flows
     return {
-      redirect_uris: [this.redirectUrl, this.debugRedirectUrl],
+      redirect_uris: this.redirect_uris,
       token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],


### PR DESCRIPTION
## Description
* In auth.ts
  - add getter for redirect_uris which returns redirectUrl and debugRedirectUrl but de-duped
  - included comments that explains the problem and link to issue
  - in clientMetadata getter,
    - replace hardcoded array value with this..redirect_uris, so it will never contain duplicate uris

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
* The `InspectorOAuthClientProvider` has getters for `redirectUrl` and `debugRedirectUrl` which contain distinctly different URLs.
* The `clientMetadata` getter returns an object with `redirectUris` set to an array that contains references to both those getters. Seems fine execpt...
* The `DebugInspectorOAuthClientProvider` subclass has an overridden `redirectUrl` getter that returns `this.debugRedirectUrl`. 
* As a result when using the subclass, you get two copies of the `debugRedirectUrl` in an array, leading to an error "Duplicate redirectURIs" as reported in #825
* This PR addresses that situation by adding a `redirect_uris` getter to `InspectorOAuthClientProvider` which returns an array of `redirectUrl` and `debugRedirectUrl` but de-duped. So if you are using the subclass, you will only have the `debugRedirectUrl` in that array, otherwise both.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Against https://example-server.modelcontextprotocol.io/mcp using the OAuth debugger

## Before
<img width="862" height="371" alt="Screenshot 2025-10-11 at 2 57 28 PM" src="https://github.com/user-attachments/assets/45f4ba88-5e11-405c-a9aa-e203d7cf8b23" />

## After
<img width="862" height="369" alt="Screenshot 2025-10-11 at 2 55 08 PM" src="https://github.com/user-attachments/assets/e30733c4-04ff-4c02-8397-ca6038a622f6" />


## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Fixes #825