### PR TITLE
fix: lock get-intrinsic to 1.3.0 to avoid generator-function dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
     "rimraf": "^6.0.1",
     "typescript": "^5.4.2"
   },
+  "overrides": {
+    "get-intrinsic": "1.3.0"
+  },
   "engines": {
     "node": ">=22.7.5"
   },


### PR DESCRIPTION
## Summary
This PR adds an npm override to lock `get-intrinsic` to version 1.3.0, preventing automatic upgrades to 1.3.1 which requires the `generator-function` package.

## Problem
When users run `npx @modelcontextprotocol/inspector`, npm performs fresh dependency resolution and picks the latest version of `get-intrinsic` that satisfies the semver range `^1.2.5`. This currently resolves to version 1.3.1, which was published on September 29, 2025 (after inspector 0.16.8 was published).

`get-intrinsic@1.3.1` introduced new dependencies:
- `generator-function@^2.0.0`
- `async-generator-function@^1.0.0`
- `async-function@^1.0.0`

## Dependency Chain
```
@modelcontextprotocol/inspector-server
  → express@^5.1.0
    → qs@^6.14.0
      → side-channel@^1.1.0
        → side-channel-map@^1.0.1
          → get-intrinsic@^1.2.5 (resolves to 1.3.1 without override)
            → generator-function@^2.0.0 ❌
```

## Solution
Add npm `overrides` field to `package.json` to lock `get-intrinsic` to version 1.3.0, which does not have the problematic dependencies.

## Testing
- ✅ Local install works with override
- ✅ Build completes successfully
- ✅ `npm ls get-intrinsic` shows version 1.3.0 with "overridden" label
- ✅ No `generator-function` dependency in package-lock.json