### PR TITLE
fix: UI not using full window width (remove place-items:center)

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -28,7 +28,6 @@ a:hover {
 
 body {
   margin: 0;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
Fixes #876. Removed place-items: center from body to restore full-width layout.