### PR TITLE
Add button to show and hide access token

### DIFF
--- a/client/src/components/AuthDebugger.tsx
+++ b/client/src/components/AuthDebugger.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useMemo, useEffect } from "react";
+import { useCallback, useMemo, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { DebugInspectorOAuthClientProvider } from "../lib/auth";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, Eye, EyeOff } from "lucide-react";
 import { AuthDebuggerState, EMPTY_DEBUGGER_STATE } from "../lib/auth-types";
 import { OAuthFlowProgress } from "./OAuthFlowProgress";
 import { OAuthStateMachine } from "../lib/oauth-state-machine";
@@ -61,6 +61,8 @@ const AuthDebugger = ({
   authState,
   updateAuthState,
 }: AuthDebuggerProps) => {
+  const [showFullToken, setShowFullToken] = useState(false);
+
   // Check for existing tokens on mount
   useEffect(() => {
     if (serverUrl && !authState.oauthTokens) {
@@ -266,9 +268,25 @@ const AuthDebugger = ({
               <div className="space-y-4">
                 {authState.oauthTokens && (
                   <div className="space-y-2">
-                    <p className="text-sm font-medium">Access Token:</p>
-                    <div className="bg-muted p-2 rounded-md text-xs overflow-x-auto">
-                      {authState.oauthTokens.access_token.substring(0, 25)}...
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-medium">Access Token:</p>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setShowFullToken(!showFullToken)}
+                        className="h-6 px-2"
+                      >
+                        {showFullToken ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </div>
+                    <div className="bg-muted p-2 rounded-md text-xs overflow-x-auto break-all">
+                      {showFullToken
+                        ? authState.oauthTokens.access_token
+                        : `${authState.oauthTokens.access_token.substring(0, 25)}...`}
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
Follow up to https://github.com/modelcontextprotocol/inspector/pull/878

Before the change:

<img width="1326" height="1002" alt="image" src="https://github.com/user-attachments/assets/f23c1659-12bc-4439-b51d-5757e207829a" />

After the change:

<img width="1326" height="1002" alt="image" src="https://github.com/user-attachments/assets/0ee8b935-12d8-4a12-8722-5b2197179a05" />

<img width="1326" height="1002" alt="image" src="https://github.com/user-attachments/assets/3185cd88-f086-479a-b468-5a53ad906958" />

## Motivation and Context

Currently, the access_token.substring(0, 25) is shown. However, when the token is longer, showing only a substring is insufficient, as a user needs to navigate to the token response and copy the access token from there.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
