### PR TITLE
fix: resolve $ref references in tool input schema properties

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -18,6 +18,7 @@ import {
   generateDefaultValue,
   isPropertyRequired,
   normalizeUnionType,
+  resolveRef,
 } from "@/utils/schemaUtils";
 import {
   CompatibilityCallToolResult,
@@ -90,14 +91,21 @@ const ToolsTab = ({
   useEffect(() => {
     const params = Object.entries(
       selectedTool?.inputSchema.properties ?? [],
-    ).map(([key, value]) => [
-      key,
-      generateDefaultValue(
+    ).map(([key, value]) => {
+      // First resolve any $ref references
+      const resolvedValue = resolveRef(
         value as JsonSchemaType,
-        key,
         selectedTool?.inputSchema as JsonSchemaType,
-      ),
-    ]);
+      );
+      return [
+        key,
+        generateDefaultValue(
+          resolvedValue,
+          key,
+          selectedTool?.inputSchema as JsonSchemaType,
+        ),
+      ];
+    });
     setParams(Object.fromEntries(params));
 
     // Reset validation errors when switching tools
@@ -154,7 +162,12 @@ const ToolsTab = ({
                 </p>
                 {Object.entries(selectedTool.inputSchema.properties ?? []).map(
                   ([key, value]) => {
-                    const prop = normalizeUnionType(value as JsonSchemaType);
+                    // First resolve any $ref references
+                    const resolvedValue = resolveRef(
+                      value as JsonSchemaType,
+                      selectedTool.inputSchema as JsonSchemaType,
+                    );
+                    const prop = normalizeUnionType(resolvedValue);
                     const inputSchema =
                       selectedTool.inputSchema as JsonSchemaType;
                     const required = isPropertyRequired(key, inputSchema);

--- a/client/src/utils/jsonUtils.ts
+++ b/client/src/utils/jsonUtils.ts
@@ -48,6 +48,7 @@ export type JsonSchemaType = {
   const?: JsonValue;
   oneOf?: (JsonSchemaType | JsonSchemaConst)[];
   anyOf?: (JsonSchemaType | JsonSchemaConst)[];
+  $ref?: string;
 };
 
 export type JsonObject = { [key: string]: JsonValue };


### PR DESCRIPTION
## Motivation and Context

Previously, when a tool's input schema contained $ref references (e.g., 
"$ref": "#/properties/source"), the ToolsTab component would incorrectly 
render the referenced property as an object type instead of resolving 
the reference to the actual schema definition.

This caused issues where properties that should inherit from other 
properties (like string types with validation rules) were rendered as 
complex object forms instead of simple input fields.
before:
  <img width="1055" height="476" alt="image" src="https://github.com/user-attachments/assets/7e180936-98c3-4261-aae7-048658142610" />

after:
  <img width="895" height="305" alt="image" src="https://github.com/user-attachments/assets/5f34202a-6713-4a63-8dce-096f9879a8bc" />

image
## How Has This Been Tested?

Tested with MCP tools that use $ref references in their input schemas.
For example, a schema with:
```json
{
  "properties": {
    "source": {
      "type": "string",
      "minLength": 1,
      "description": "test"
    },
    "target": {
      "$ref": "#/properties/source"
    }
  }
}
```

Now correctly renders both `source` and `target` as string input fields 
with the same validation rules, instead of rendering `target` as an 
object form.

## Breaking Changes

No breaking changes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally