### PR TITLE
Add implicit default origin in case of port 80

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -170,10 +170,12 @@ const originValidationMiddleware = (
 
   // Default origins based on CLIENT_PORT or use environment variable
   const clientPort = process.env.CLIENT_PORT || "6274";
-  const defaultOrigin = `http://localhost:${clientPort}`;
-  const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(",") || [
-    defaultOrigin,
-  ];
+  const defaultOrigins = [`http://localhost:${clientPort}`];
+  if (clientPort === "80") {
+    defaultOrigins.push("http://localhost");
+  }
+  const allowedOrigins =
+    process.env.ALLOWED_ORIGINS?.split(",") || defaultOrigins;
 
   if (origin && !allowedOrigins.includes(origin)) {
     console.error(`Invalid origin: ${origin}`);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
In case of client port 80, origin `http://localhost` without explicit port should be accepted by default.

## How Has This Been Tested?
Tested locally.

## Breaking Changes
I would guess that nobody relies on that behavior.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None.
