### PR TITLE
feat(stdio): working directory support with validation and UX gating

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -141,6 +141,10 @@ const App = () => {
     return localStorage.getItem("lastOauthScope") || "";
   });
 
+  const [workingDir, setWorkingDir] = useState<string>(() => {
+    return localStorage.getItem("lastWorkingDir") || "";
+  });
+
   const [oauthClientSecret, setOauthClientSecret] = useState<string>(() => {
     return localStorage.getItem("lastOauthClientSecret") || "";
   });
@@ -264,6 +268,7 @@ const App = () => {
     args,
     sseUrl,
     env,
+    workingDir,
     customHeaders,
     oauthClientId,
     oauthClientSecret,
@@ -398,6 +403,10 @@ const App = () => {
   useEffect(() => {
     localStorage.setItem("lastOauthScope", oauthScope);
   }, [oauthScope]);
+
+  useEffect(() => {
+    localStorage.setItem("lastWorkingDir", workingDir);
+  }, [workingDir]);
 
   useEffect(() => {
     localStorage.setItem("lastOauthClientSecret", oauthClientSecret);
@@ -918,6 +927,8 @@ const App = () => {
           logLevel={logLevel}
           sendLogLevelRequest={sendLogLevelRequest}
           loggingSupported={!!serverCapabilities?.logging || false}
+          workingDir={workingDir}
+          setWorkingDir={setWorkingDir}
           connectionType={connectionType}
           setConnectionType={setConnectionType}
         />

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -127,6 +127,7 @@ describe("useConnection", () => {
     args: "",
     sseUrl: "http://localhost:8080",
     env: {},
+    workingDir: "",
     config: DEFAULT_INSPECTOR_CONFIG,
   };
 
@@ -1256,6 +1257,52 @@ describe("useConnection", () => {
       expect(
         mockSSETransport.url?.searchParams.get("proxyFullAddress"),
       ).toBeNull();
+    });
+
+    test("sends working directory query parameter for stdio transport when provided", async () => {
+      const propsWithWorkingDir = {
+        ...defaultProps,
+        transportType: "stdio" as const,
+        command: "test-command",
+        args: "test-args",
+        env: {},
+        workingDir: "/path/to/project",
+        config: DEFAULT_INSPECTOR_CONFIG,
+      };
+
+      const { result } = renderHook(() => useConnection(propsWithWorkingDir));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Check that the URL contains the working directory parameter
+      expect(mockSSETransport.url?.searchParams.get("workingDir")).toBe(
+        "/path/to/project",
+      );
+    });
+
+    test("does not send working directory parameter when not provided", async () => {
+      const propsWithoutWorkingDir = {
+        ...defaultProps,
+        transportType: "stdio" as const,
+        command: "test-command",
+        args: "test-args",
+        env: {},
+        workingDir: "",
+        config: DEFAULT_INSPECTOR_CONFIG,
+      };
+
+      const { result } = renderHook(() =>
+        useConnection(propsWithoutWorkingDir),
+      );
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      // Check that the URL does not contain the working directory parameter
+      expect(mockSSETransport.url?.searchParams.get("workingDir")).toBeNull();
     });
 
     test("does not send proxyFullAddress parameter for streamable-http transport", async () => {

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -64,6 +64,7 @@ interface UseConnectionOptions {
   args: string;
   sseUrl: string;
   env: Record<string, string>;
+  workingDir?: string;
   // Custom headers support
   customHeaders?: CustomHeaders;
   oauthClientId?: string;
@@ -88,6 +89,7 @@ export function useConnection({
   args,
   sseUrl,
   env,
+  workingDir,
   customHeaders,
   oauthClientId,
   oauthClientSecret,
@@ -560,6 +562,9 @@ export function useConnection({
             mcpProxyServerUrl.searchParams.append("command", command);
             mcpProxyServerUrl.searchParams.append("args", args);
             mcpProxyServerUrl.searchParams.append("env", JSON.stringify(env));
+            if (workingDir) {
+              mcpProxyServerUrl.searchParams.append("workingDir", workingDir);
+            }
 
             const proxyFullAddress = config.MCP_PROXY_FULL_ADDRESS
               .value as string;

--- a/client/src/lib/hooks/useWorkingDirValidation.ts
+++ b/client/src/lib/hooks/useWorkingDirValidation.ts
@@ -1,0 +1,51 @@
+import { useCallback, useState } from "react";
+import { InspectorConfig } from "@/lib/configurationTypes";
+import { getMCPProxyAddress, getMCPProxyAuthToken } from "@/utils/configUtils";
+
+export function useWorkingDirValidation(
+  workingDir: string,
+  config: InspectorConfig,
+) {
+  const [workingDirError, setWorkingDirError] = useState<string | null>(null);
+  const [isValidating, setIsValidating] = useState(false);
+
+  const validateNow = useCallback(async (): Promise<boolean> => {
+    if (!workingDir) {
+      setWorkingDirError(null);
+      return true;
+    }
+    setIsValidating(true);
+    try {
+      const base = getMCPProxyAddress(config);
+      const url = new URL(`${base}/validate/working-dir`);
+      url.searchParams.set("path", workingDir);
+
+      const { token, header } = getMCPProxyAuthToken(config);
+      const resp = await fetch(url.toString(), {
+        headers: token ? { [header]: `Bearer ${token}` } : undefined,
+      });
+      const data: { valid: boolean; error?: string } = await resp.json();
+      setWorkingDirError(
+        data.valid ? null : data.error || "Invalid working directory",
+      );
+      return !!data.valid;
+    } catch {
+      setWorkingDirError("Unable to validate working directory");
+      return false;
+    } finally {
+      setIsValidating(false);
+    }
+  }, [config, workingDir]);
+
+  const validateOnBlur = useCallback(async () => {
+    await validateNow();
+  }, [validateNow]);
+
+  return {
+    workingDirError,
+    setWorkingDirError,
+    validateOnBlur,
+    validateNow,
+    isValidating,
+  } as const;
+}

--- a/server/src/__tests__/validationUtils.spec.ts
+++ b/server/src/__tests__/validationUtils.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "@jest/globals";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { validateWorkingDirectoryAbsolute } from "../validationUtils.js";
+
+describe("validateWorkingDirectoryAbsolute", () => {
+  it("returns error for missing path", async () => {
+    const res = await validateWorkingDirectoryAbsolute("");
+    expect(res.valid).toBe(false);
+    expect(res.error).toBe("Missing path");
+  });
+
+  it("returns error for non-absolute path", async () => {
+    const res = await validateWorkingDirectoryAbsolute("./rel");
+    expect(res.valid).toBe(false);
+    expect(res.error).toBe("Path must be absolute");
+  });
+
+  it("returns valid for existing readable directory", async () => {
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "mcpv-"));
+    try {
+      const res = await validateWorkingDirectoryAbsolute(dir);
+      expect(res.valid).toBe(true);
+      expect(res.error).toBeUndefined();
+    } finally {
+      await fs.promises.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns error when path does not exist", async () => {
+    const nonExistent = path.join(os.tmpdir(), `nope-${Date.now()}`);
+    const res = await validateWorkingDirectoryAbsolute(nonExistent);
+    expect(res.valid).toBe(false);
+    expect(res.error).toContain("Directory does not exist");
+  });
+
+  it("returns error when path is a file", async () => {
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "mcpf-"));
+    const file = path.join(dir, "f.txt");
+    await fs.promises.writeFile(file, "x");
+    try {
+      const res = await validateWorkingDirectoryAbsolute(file);
+      expect(res.valid).toBe(false);
+      expect(res.error).toBe("Not a directory");
+    } finally {
+      await fs.promises.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/validationUtils.ts
+++ b/server/src/validationUtils.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type WorkingDirValidationResult = {
+  valid: boolean;
+  error?: string;
+};
+
+export async function validateWorkingDirectoryAbsolute(
+  directoryPath: string,
+): Promise<WorkingDirValidationResult> {
+  if (!directoryPath) {
+    return { valid: false, error: "Missing path" };
+  }
+  if (!path.isAbsolute(directoryPath)) {
+    return { valid: false, error: "Path must be absolute" };
+  }
+  try {
+    const stat = await fs.promises.stat(directoryPath);
+    if (!stat.isDirectory()) {
+      return { valid: false, error: "Not a directory" };
+    }
+    await fs.promises.access(directoryPath, fs.constants.R_OK);
+    return { valid: true };
+  } catch {
+    return {
+      valid: false,
+      error: "Directory does not exist or is not accessible",
+    };
+  }
+}


### PR DESCRIPTION

<!-- Provide a brief summary of your changes -->
- Add end-to-end workingDir support for stdio transport (client ↔ proxy)
- Server: /validate/working-dir endpoint and shared validator with unit tests
- Client: workingDir input, persisted state, copied config integration
- Client: useWorkingDirValidation hook; Connect awaits validation; disable while invalid/validating
- Tests: updated Sidebar jest, added server validator tests; unit suite passing; code formatted
- e2e note: no Playwright for workingDir yet due to proxy auth complexity

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
solves the issue (https://github.com/modelcontextprotocol/inspector/issues/718)

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes, connected to haiven-mcp-server using cwd

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ X] My code follows the repository's style guidelines
- [ X] New and existing tests pass locally
- [ X] I have added appropriate error handling
- [ X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
