### PR TITLE
Bump Claude Code GitHub Action to v1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -45,9 +45,6 @@ jobs:
           # Trigger when assigned to an issue
           assignee_trigger: "claude"
 
-          # Allow Claude to run bash
-          # This should be safe given the repo is already public
-          allowed_tools: "Bash"
-
-          custom_instructions: |
-            If posting a comment to GitHub, give a concise summary of the comment at the top and put all the details in a <details> block.
+          claude_args: |
+            --allowedTools Bash
+            --system-prompt "If posting a comment to GitHub, give a concise summary of the comment at the top and put all the details in a <details> block."


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/modelcontextprotocol/servers/pull/3018.

This PR bumps Claude Code GitHub Action to v1 from beta. https://github.com/anthropics/claude-code-action/releases/tag/v1

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [x] Build/CI improvements

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [x] Documentation updated (README, comments, etc.)
