### PR TITLE
fix: allow empty elicitation form data when all fields are optional

### DIFF
--- a/client/src/utils/__tests__/schemaUtils.test.ts
+++ b/client/src/utils/__tests__/schemaUtils.test.ts
@@ -43,8 +43,8 @@ describe("generateDefaultValue", () => {
     expect(generateDefaultValue({ type: "array" })).toBe(undefined);
   });
 
-  test("generates undefined for optional object", () => {
-    expect(generateDefaultValue({ type: "object" })).toBe(undefined);
+  test("generates empty object for optional root object", () => {
+    expect(generateDefaultValue({ type: "object" })).toEqual({});
   });
 
   test("generates default null for unknown types", () => {

--- a/client/src/utils/schemaUtils.ts
+++ b/client/src/utils/schemaUtils.ts
@@ -100,6 +100,7 @@ export function generateDefaultValue(
     propertyName && parentSchema
       ? isPropertyRequired(propertyName, parentSchema)
       : false;
+  const isRootSchema = propertyName === undefined && parentSchema === undefined;
 
   switch (schema.type) {
     case "string":
@@ -112,7 +113,9 @@ export function generateDefaultValue(
     case "array":
       return isRequired ? [] : undefined;
     case "object": {
-      if (!schema.properties) return isRequired ? {} : undefined;
+      if (!schema.properties) {
+        return isRequired || isRootSchema ? {} : undefined;
+      }
 
       const obj: JsonObject = {};
       // Only include properties that are required according to the schema's required array
@@ -124,7 +127,11 @@ export function generateDefaultValue(
           }
         }
       });
-      return isRequired ? obj : Object.keys(obj).length > 0 ? obj : undefined;
+
+      if (Object.keys(obj).length === 0) {
+        return isRequired || isRootSchema ? {} : undefined;
+      }
+      return obj;
     }
     case "null":
       return null;


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/modelcontextprotocol/inspector/pull/948).
* #926
* __->__ #948