### PR TITLE
fix: detect 401 errors from StreamableHTTP transport for OAuth flow

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -17,7 +17,10 @@ import {
   StdioClientTransport,
   getDefaultEnvironment,
 } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
@@ -43,6 +46,22 @@ const { values } = parseArgs({
     "server-url": { type: "string", default: "" },
   },
 });
+
+/**
+ * Helper function to detect 401 Unauthorized errors from various transport types.
+ * StreamableHTTPClientTransport throws a generic Error with "HTTP 401" in the message
+ * when there's no authProvider configured, while SSEClientTransport throws SseError.
+ */
+const is401Error = (error: unknown): boolean => {
+  if (error instanceof SseError && error.code === 401) return true;
+  if (error instanceof StreamableHTTPError && error.code === 401) return true;
+  if (
+    error instanceof Error &&
+    (error.message.includes("HTTP 401") || error.message.includes("(401)"))
+  )
+    return true;
+  return false;
+};
 
 // Function to get HTTP headers.
 const getHttpHeaders = (req: express.Request): Record<string, string> => {
@@ -508,10 +527,10 @@ app.post(
           req.body,
         );
       } catch (error) {
-        if (error instanceof SseError && error.code === 401) {
+        if (is401Error(error)) {
           console.error(
             "Received 401 Unauthorized from MCP server:",
-            error.message,
+            error instanceof Error ? error.message : error,
           );
           res.status(401).json(error);
           return;
@@ -649,7 +668,7 @@ app.get(
         transportToServer: serverTransport,
       });
     } catch (error) {
-      if (error instanceof SseError && error.code === 401) {
+      if (is401Error(error)) {
         console.error(
           "Received 401 Unauthorized from MCP server. Authentication failure.",
         );
@@ -695,7 +714,7 @@ app.get(
         transportToServer: serverTransport,
       });
     } catch (error) {
-      if (error instanceof SseError && error.code === 401) {
+      if (is401Error(error)) {
         console.error(
           "Received 401 Unauthorized from MCP server. Authentication failure.",
         );


### PR DESCRIPTION
## Summary

Fix for Streamable HTTP WWW-Authenticate challenge not triggering OAuth flow in version 0.17.5.

When an OAuth-protected MCP server returns a 401 `WWW-Authenticate` challenge via Streamable HTTP transport, the proxy was returning 500 instead of 401 to the client. This prevented the client-side OAuth discovery and redirect flow from triggering.

> **Note:** Inspector V2 is under development to address architectural and UX improvements. During this time, V1 contributions should focus on **bug fixes and MCP spec compliance**. See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

The server-side error handling only checked for `SseError` instances when detecting 401 responses from MCP servers. However, `StreamableHTTPClientTransport` throws a different error type (generic `Error` with "HTTP 401" in the message) when there's no `authProvider` configured on the server-side transport.

**Changes:**
1. Imported `StreamableHTTPError` from the SDK
2. Added `is401Error()` helper function that detects 401 errors from:
   - `SseError` with code 401 (existing behavior)
   - `StreamableHTTPError` with code 401 (new)
   - Generic `Error` with "HTTP 401" or "(401)" in message (fallback)
3. Updated error handling in `/mcp`, `/stdio`, and `/sse` routes to use the new helper

## Related Issues

Fixes #960

## Testing

- [ ] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [ ] Added/updated automated tests
- [ ] Manual testing performed

### Test Results and/or Instructions

**How to test this fix:**
1. Set up an MCP server with OAuth protection that returns a `WWW-Authenticate` header on 401
2. Start the Inspector and select "Streamable HTTP" transport
3. Enter the OAuth-protected MCP server URL
4. Click Connect
5. **Expected (with fix):** OAuth flow is triggered - user is redirected to authorization page
6. **Before fix:** Shows "Connection Error - Check if your MCP server is running and proxy token is correct"

**Note:** The server package currently lacks test infrastructure. The `is401Error()` helper is a simple pure function. Automated tests could be added when server-side test infrastructure is established.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None

## Additional Context

**Root Cause Analysis:**

The SDK's `StreamableHTTPClientTransport.send()` method handles 401 responses differently depending on whether an `authProvider` is configured:
- With `authProvider`: Attempts OAuth flow internally
- Without `authProvider`: Throws `Error('Error POSTing to endpoint (HTTP 401): ...')`

The Inspector's proxy server creates transports without an `authProvider` (the OAuth flow is handled client-side), so it receives the generic Error. The existing error handler only checked for `SseError`, causing the 401 to be returned as a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)