### PR TITLE
feat: add theme property to Icon and Prompt types

### DIFF
--- a/client/src/components/IconDisplay.tsx
+++ b/client/src/components/IconDisplay.tsx
@@ -3,6 +3,7 @@ interface Icon {
   src: string;
   mimeType?: string;
   sizes?: string[];
+  theme?: "light" | "dark";
 }
 
 // Helper type for objects that may have icons

--- a/client/src/components/PromptsTab.tsx
+++ b/client/src/components/PromptsTab.tsx
@@ -24,7 +24,12 @@ export type Prompt = {
     description?: string;
     required?: boolean;
   }[];
-  icons?: { src: string; mimeType?: string; sizes?: string[] }[];
+  icons?: {
+    src: string;
+    mimeType?: string;
+    sizes?: string[];
+    theme?: "light" | "dark";
+  }[];
 };
 
 const PromptsTab = ({


### PR DESCRIPTION
**Summary**

This PR adds support for the theme property in MCP icons, aligning the Inspector with the official Model Context Protocol icon specification.

**What’s Updated**

Extended the Icon type to include theme?: string as defined in the MCP Icons spec.

Updated components (PromptsTab, IconDisplay, and others) to correctly preserve and pass the theme field through the UI.

**Why**

The MCP spec includes the theme field in the icon schema, but the Inspector previously omitted it, causing theming data to be dropped.
This update ensures full spec compliance and prepares the Inspector for any future UI features that rely on icon theming.

**Related Issue**

Closes #965