### PR TITLE
Update docker launch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ The server will start up and the UI will be accessible at `http://localhost:6274
 You can also start it in a Docker container with the following command:
 
 ```bash
-docker run --rm --network host -p 6274:6274 -p 6277:6277 ghcr.io/modelcontextprotocol/inspector:latest
+docker run --rm \
+  -p 127.0.0.1:6274:6274 \
+  -p 127.0.0.1:6277:6277 \
+  -e HOST=0.0.0.0 \
+  -e MCP_AUTO_OPEN_ENABLED=false \
+  ghcr.io/modelcontextprotocol/inspector:latest
 ```
 
 ### From an MCP server repository


### PR DESCRIPTION
## Summary
Update the docker launch command in the README.md to

```bash
docker run --rm \
  -p 127.0.0.1:6274:6274 \
  -p 127.0.0.1:6277:6277 \
  -e HOST=0.0.0.0 \
  -e MCP_AUTO_OPEN_ENABLED=false \
  ghcr.io/modelcontextprotocol/inspector:latest
```

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Related Issues

Although the existing command did work at one time, people have been getting "Docker Connection Refused" issues. I researched it and found the appropriate command to use. https://github.com/modelcontextprotocol/inspector/issues/828#issuecomment-3438728404

### Additional Context 
This fixes #828