### PR TITLE
Show description for anyOf fields in JSON editor

### DIFF
--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -757,6 +757,7 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
               debouncedUpdateParent(newValue);
             }}
             error={jsonError}
+            placeholder={schema.description}
           />
         ) : // If schema type is object but value is not an object or is empty, and we have actual JSON data,
         // render a simple representation of the JSON data

--- a/client/src/components/JsonEditor.tsx
+++ b/client/src/components/JsonEditor.tsx
@@ -8,12 +8,14 @@ interface JsonEditorProps {
   value: string;
   onChange: (value: string) => void;
   error?: string;
+  placeholder?: string;
 }
 
 const JsonEditor = ({
   value,
   onChange,
   error: externalError,
+  placeholder,
 }: JsonEditorProps) => {
   const [editorContent, setEditorContent] = useState(value || "");
   const [internalError, setInternalError] = useState<string | undefined>(
@@ -48,6 +50,7 @@ const JsonEditor = ({
             Prism.highlight(code, Prism.languages.json, "json")
           }
           padding={10}
+          placeholder={placeholder}
           style={{
             fontFamily: '"Fira code", "Fira Mono", monospace',
             fontSize: 14,


### PR DESCRIPTION
## Summary

This fixes the issue where tool parameters with `anyOf` schemas didn't show any description text, which left users without guidance on acceptable values. This PR adds placeholder description text to make it consistent with the fields of other types.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

Adds `placeholder` prop support to JsonEditor component and passes schema description as placeholder to JsonEditor.

## Related Issues

Only addresses the issue of missing description for `anyOf` fields in #915.

## Testing

<!-- Describe how you tested these changes, where applicable -->

- [x] Tested in UI mode
- [ ] Tested in CLI mode
- [x] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [ ] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

<!-- Provide steps for reviewers to test your changes -->

Tested with the following tool with `anyOf` input schemas:

```json
{
  "name": "test_anyof",
  "description": "Test tool with anyOf string|integer parameter",
  "inputSchema": {
    "type": "object",
    "properties": {
      "factor": {
        "anyOf": [
          {
            "type": "string"
          },
          {
            "minimum": 1,
            "type": "integer"
          }
        ],
        "default": 1,
        "description": "Either a string or positive integer"
      }
    }
  },
  "outputSchema": {
    "type": "object",
    "properties": {
      "result": {
        "type": "string"
      }
    },
    "required": [
      "result"
    ],
    "x-fastmcp-wrap-result": true
  },
  "_meta": {
    "_fastmcp": {
      "tags": []
    }
  }
}
```

Before|After
-|-
<img width="1890" height="1926" alt="2025-12-14 at 19 18 26" src="https://github.com/user-attachments/assets/d927920d-14c3-4d82-ad0a-b453296e7259" />|<img width="1890" height="1932" alt="2025-12-14 at 19 16 58" src="https://github.com/user-attachments/assets/424888be-0555-49be-b715-c444a6a498b7" />


## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None. This is a pure UI enhancement that adds missing information.

## Additional Context

<!-- Add any other context, screenshots, or information about the PR here -->
