### PR TITLE
fix(security): add input validation to CLI to prevent command injection

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,15 +1,28 @@
 {
-  "name": "@modelcontextprotocol/inspector-cli",
-  "version": "0.18.0",
-  "description": "CLI for the Model Context Protocol inspector",
+  "name": "@bryan-thompson/inspector-assessment-cli",
+  "version": "1.15.3",
+  "description": "CLI for the Enhanced MCP Inspector with assessment capabilities",
   "license": "MIT",
-  "author": "Anthropic, PBC (https://anthropic.com)",
-  "homepage": "https://modelcontextprotocol.io",
-  "bugs": "https://github.com/modelcontextprotocol/inspector/issues",
+  "author": "Bryan Thompson <bryan@triepod.ai>",
+  "contributors": [
+    "Anthropic, PBC (original MCP Inspector)"
+  ],
+  "homepage": "https://github.com/triepod-ai/inspector-assessment",
+  "bugs": "https://github.com/triepod-ai/inspector-assessment/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/triepod-ai/inspector-assessment.git"
+  },
   "main": "build/cli.js",
   "type": "module",
   "bin": {
-    "mcp-inspector-cli": "build/cli.js"
+    "mcp-inspector-assess-cli": "build/cli.js",
+    "mcp-assess-full": "build/assess-full.js",
+    "mcp-assess-security": "build/assess-security.js",
+    "mcp-validate-testbed": "build/validate-testbed.js"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "files": [
     "build"
@@ -17,15 +30,18 @@
   "scripts": {
     "build": "tsc",
     "postbuild": "node scripts/make-executable.js",
-    "test": "node scripts/cli-tests.js && node scripts/cli-tool-tests.js && node scripts/cli-header-tests.js",
+    "test": "node scripts/cli-tests.js && node scripts/cli-tool-tests.js && node scripts/cli-header-tests.js && node scripts/cli-validation-tests.js",
     "test:cli": "node scripts/cli-tests.js",
     "test:cli-tools": "node scripts/cli-tool-tests.js",
-    "test:cli-headers": "node scripts/cli-header-tests.js"
+    "test:cli-headers": "node scripts/cli-header-tests.js",
+    "test:cli-validation": "node scripts/cli-validation-tests.js"
   },
   "devDependencies": {},
   "dependencies": {
+    "@bryan-thompson/inspector-assessment-client": "^1.5.0",
     "@modelcontextprotocol/sdk": "^1.24.3",
     "commander": "^13.1.0",
-    "spawn-rx": "^5.1.2"
+    "spawn-rx": "^5.1.2",
+    "zod": "^3.25.76"
   }
 }

--- a/cli/scripts/cli-validation-tests.js
+++ b/cli/scripts/cli-validation-tests.js
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+
+/**
+ * CLI Input Validation Tests
+ *
+ * Tests the input validation functions added for security:
+ * - Environment variable name/value validation
+ * - Server URL validation
+ * - Command validation (shell metacharacter rejection)
+ */
+
+import { spawn } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Colors for output
+const colors = {
+  GREEN: "\x1b[32m",
+  YELLOW: "\x1b[33m",
+  RED: "\x1b[31m",
+  BLUE: "\x1b[34m",
+  NC: "\x1b[0m",
+};
+
+// Track test results
+let PASSED_TESTS = 0;
+let FAILED_TESTS = 0;
+let TOTAL_TESTS = 0;
+
+const CLI_PATH = path.join(__dirname, "..", "build", "cli.js");
+
+/**
+ * Run a CLI command and capture output
+ */
+function runCli(args, timeout = 5000) {
+  return new Promise((resolve) => {
+    const proc = spawn("node", [CLI_PATH, ...args], {
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    // Kill process after timeout (CLI may hang waiting for server)
+    const timer = setTimeout(() => {
+      proc.kill("SIGTERM");
+    }, timeout);
+
+    proc.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ code: -1, stdout, stderr: err.message });
+    });
+  });
+}
+
+/**
+ * Test helper
+ */
+function test(name, passed, details = "") {
+  TOTAL_TESTS++;
+  if (passed) {
+    PASSED_TESTS++;
+    console.log(`${colors.GREEN}✓${colors.NC} ${name}`);
+  } else {
+    FAILED_TESTS++;
+    console.log(`${colors.RED}✗${colors.NC} ${name}`);
+    if (details) {
+      console.log(`  ${colors.YELLOW}Details: ${details}${colors.NC}`);
+    }
+  }
+}
+
+async function runTests() {
+  console.log(
+    `\n${colors.YELLOW}=== CLI Input Validation Tests ===${colors.NC}\n`,
+  );
+
+  // Test 1: Valid environment variable should work
+  console.log(
+    `${colors.BLUE}Testing environment variable validation...${colors.NC}`,
+  );
+  {
+    const result = await runCli(
+      ["-e", "VALID_VAR=value", "--", "echo", "test"],
+      3000,
+    );
+    // Should not see "Skipping invalid" warning for valid env var
+    const hasWarning = result.stderr.includes("Skipping invalid environment");
+    test(
+      "Valid env var name (VALID_VAR=value) should not warn",
+      !hasWarning,
+      hasWarning ? `Got warning: ${result.stderr.substring(0, 100)}` : "",
+    );
+  }
+
+  // Test 2: Environment variable starting with underscore should work
+  {
+    const result = await runCli(
+      ["-e", "_PRIVATE=value", "--", "echo", "test"],
+      3000,
+    );
+    const hasWarning = result.stderr.includes("Skipping invalid environment");
+    test(
+      "Env var starting with underscore (_PRIVATE=value) should not warn",
+      !hasWarning,
+      hasWarning ? `Got warning: ${result.stderr.substring(0, 100)}` : "",
+    );
+  }
+
+  // Test 3: Invalid env var name (starts with number) should warn
+  {
+    const result = await runCli(
+      ["-e", "123INVALID=value", "--", "echo", "test"],
+      3000,
+    );
+    const hasWarning = result.stderr.includes(
+      "Skipping invalid environment variable name",
+    );
+    test(
+      "Env var starting with number (123INVALID) should warn and skip",
+      hasWarning,
+      !hasWarning
+        ? `No warning found. stderr: ${result.stderr.substring(0, 100)}`
+        : "",
+    );
+  }
+
+  // Test 4: Invalid env var name (contains special chars) should warn
+  {
+    const result = await runCli(
+      ["-e", "INVALID-VAR=value", "--", "echo", "test"],
+      3000,
+    );
+    const hasWarning = result.stderr.includes(
+      "Skipping invalid environment variable name",
+    );
+    test(
+      "Env var with hyphen (INVALID-VAR) should warn and skip",
+      hasWarning,
+      !hasWarning
+        ? `No warning found. stderr: ${result.stderr.substring(0, 100)}`
+        : "",
+    );
+  }
+
+  // Test 5: Server URL validation - private IP warning
+  console.log(`\n${colors.BLUE}Testing server URL validation...${colors.NC}`);
+  {
+    const result = await runCli(
+      ["--server-url", "http://localhost:3000", "--transport", "http"],
+      3000,
+    );
+    const hasWarning = result.stderr.includes("private/internal address");
+    test(
+      "Private IP URL (localhost) should show warning",
+      hasWarning,
+      !hasWarning
+        ? `No warning found. stderr: ${result.stderr.substring(0, 100)}`
+        : "",
+    );
+  }
+
+  // Test 6: Server URL validation - 127.0.0.1 warning
+  {
+    const result = await runCli(
+      ["--server-url", "http://127.0.0.1:3000", "--transport", "http"],
+      3000,
+    );
+    const hasWarning = result.stderr.includes("private/internal address");
+    test(
+      "Private IP URL (127.0.0.1) should show warning",
+      hasWarning,
+      !hasWarning
+        ? `No warning found. stderr: ${result.stderr.substring(0, 100)}`
+        : "",
+    );
+  }
+
+  // Test 7: Server URL validation - public IP should not warn
+  {
+    const result = await runCli(
+      ["--server-url", "https://example.com/mcp", "--transport", "http"],
+      3000,
+    );
+    const hasWarning = result.stderr.includes("private/internal address");
+    test(
+      "Public URL (example.com) should not show private IP warning",
+      !hasWarning,
+      hasWarning
+        ? `Got unexpected warning: ${result.stderr.substring(0, 100)}`
+        : "",
+    );
+  }
+
+  // Test 8: Command validation - shell metacharacters should error
+  console.log(`\n${colors.BLUE}Testing command validation...${colors.NC}`);
+  {
+    const result = await runCli(["--", "node; rm -rf /"], 3000);
+    const hasError =
+      result.stderr.includes("shell metacharacters") || result.code !== 0;
+    test(
+      "Command with semicolon (node; rm -rf /) should error",
+      hasError,
+      !hasError
+        ? `Expected error. code: ${result.code}, stderr: ${result.stderr.substring(0, 100)}`
+        : "",
+    );
+  }
+
+  // Test 9: Command validation - pipe character should error
+  {
+    const result = await runCli(["--", "cat /etc/passwd | grep root"], 3000);
+    const hasError =
+      result.stderr.includes("shell metacharacters") || result.code !== 0;
+    test(
+      "Command with pipe (cat | grep) should error",
+      hasError,
+      !hasError
+        ? `Expected error. code: ${result.code}, stderr: ${result.stderr.substring(0, 100)}`
+        : "",
+    );
+  }
+
+  // Test 10: Command validation - backticks should error
+  {
+    const result = await runCli(["--", "echo `whoami`"], 3000);
+    const hasError =
+      result.stderr.includes("shell metacharacters") || result.code !== 0;
+    test(
+      "Command with backticks (echo `whoami`) should error",
+      hasError,
+      !hasError
+        ? `Expected error. code: ${result.code}, stderr: ${result.stderr.substring(0, 100)}`
+        : "",
+    );
+  }
+
+  // Test 11: Command validation - valid command should work
+  {
+    const result = await runCli(["--", "node", "--version"], 3000);
+    // Should not error due to metacharacters
+    const hasMetacharError = result.stderr.includes("shell metacharacters");
+    test(
+      "Valid command (node --version) should not error on metacharacters",
+      !hasMetacharError,
+      hasMetacharError
+        ? `Got unexpected error: ${result.stderr.substring(0, 100)}`
+        : "",
+    );
+  }
+
+  // Print summary
+  console.log(`\n${colors.YELLOW}=== Test Summary ===${colors.NC}`);
+  console.log(`Total: ${TOTAL_TESTS}`);
+  console.log(`${colors.GREEN}Passed: ${PASSED_TESTS}${colors.NC}`);
+  console.log(`${colors.RED}Failed: ${FAILED_TESTS}${colors.NC}`);
+
+  if (FAILED_TESTS > 0) {
+    console.log(
+      `\n${colors.RED}Some tests failed. Please review the validation implementation.${colors.NC}`,
+    );
+    process.exit(1);
+  } else {
+    console.log(`\n${colors.GREEN}All validation tests passed!${colors.NC}`);
+    process.exit(0);
+  }
+}
+
+runTests().catch((err) => {
+  console.error(`${colors.RED}Test runner error: ${err.message}${colors.NC}`);
+  process.exit(1);
+});

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,8 +6,126 @@ import path from "node:path";
 import { dirname, resolve } from "path";
 import { spawnPromise } from "spawn-rx";
 import { fileURLToPath } from "url";
+import { execSync } from "node:child_process";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Validate environment variable names
+ * - Must start with letter or underscore
+ * - Can contain letters, numbers, underscores
+ */
+function isValidEnvVarName(name: string): boolean {
+  return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name);
+}
+
+/**
+ * Validate environment variable values
+ * - No null bytes (could truncate strings)
+ */
+function isValidEnvVarValue(value: string): boolean {
+  return !value.includes("\0");
+}
+
+/**
+ * Validate and sanitize environment variables
+ * Returns filtered environment variables with invalid entries removed
+ */
+function validateEnvVars(env: Record<string, string>): Record<string, string> {
+  const validated: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(env)) {
+    if (!isValidEnvVarName(key)) {
+      console.warn(
+        `Warning: Skipping invalid environment variable name: ${key}`,
+      );
+      continue;
+    }
+
+    if (!isValidEnvVarValue(value)) {
+      console.warn(
+        `Warning: Skipping environment variable with invalid value: ${key}`,
+      );
+      continue;
+    }
+
+    validated[key] = value;
+  }
+
+  return validated;
+}
+
+/**
+ * Validate that a URL is safe for connection
+ * - Must be http or https
+ * - Warns about private/internal IPs (potential SSRF)
+ */
+function validateServerUrl(url: string): void {
+  try {
+    const parsed = new URL(url);
+
+    // Must be http or https
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error(
+        `Invalid URL protocol: ${parsed.protocol}. Must be http or https.`,
+      );
+    }
+
+    // Warn about private IPs (potential SSRF attack vector)
+    const hostname = parsed.hostname.toLowerCase();
+    const privatePatterns = [
+      /^localhost$/,
+      /^127\./,
+      /^10\./,
+      /^172\.(1[6-9]|2[0-9]|3[01])\./,
+      /^192\.168\./,
+      /^169\.254\./, // Link-local
+      /^\[::1\]$/, // IPv6 localhost
+      /^\[fe80:/i, // IPv6 link-local
+    ];
+
+    // Only warn for private IPs (don't block - may be intentional for local testing)
+    if (privatePatterns.some((pattern) => pattern.test(hostname))) {
+      console.warn(
+        `Warning: Connecting to private/internal address: ${hostname}`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Invalid URL")) {
+      throw new Error(`Invalid server URL: ${url}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Validate a command exists and is safe to execute
+ */
+function validateCommand(command: string): void {
+  // Check for shell metacharacters
+  const dangerousChars = /[;&|`$(){}[\]<>!]/;
+  if (dangerousChars.test(command)) {
+    throw new Error(
+      `Invalid command: contains shell metacharacters: ${command}`,
+    );
+  }
+
+  // For absolute paths, verify the file exists
+  if (path.isAbsolute(command)) {
+    if (!fs.existsSync(command)) {
+      throw new Error(`Command not found: ${command}`);
+    }
+    return;
+  }
+
+  // For relative commands, verify they exist in PATH
+  try {
+    const whichCmd = process.platform === "win32" ? "where" : "which";
+    execSync(`${whichCmd} "${command}"`, { stdio: "pipe" });
+  } catch {
+    throw new Error(`Command not found in PATH: ${command}`);
+  }
+}
 
 type Args = {
   command: string;
@@ -63,6 +181,17 @@ function delay(ms: number): Promise<void> {
 }
 
 async function runWebClient(args: Args): Promise<void> {
+  // Validate inputs before proceeding
+  const validatedEnvArgs = validateEnvVars(args.envArgs);
+
+  if (args.serverUrl) {
+    validateServerUrl(args.serverUrl);
+  }
+
+  if (args.command) {
+    validateCommand(args.command);
+  }
+
   // Path to the client entry point
   const inspectorClientPath = resolve(
     __dirname,
@@ -82,8 +211,8 @@ async function runWebClient(args: Args): Promise<void> {
   // Build arguments to pass to start.js
   const startArgs: string[] = [];
 
-  // Pass environment variables
-  for (const [key, value] of Object.entries(args.envArgs)) {
+  // Pass validated environment variables
+  for (const [key, value] of Object.entries(validatedEnvArgs)) {
     startArgs.push("-e", `${key}=${value}`);
   }
 
@@ -117,6 +246,21 @@ async function runWebClient(args: Args): Promise<void> {
 }
 
 async function runCli(args: Args): Promise<void> {
+  // Validate inputs before proceeding
+  const validatedEnvArgs = validateEnvVars(args.envArgs);
+
+  if (args.command) {
+    // For CLI mode, command might be a URL - validate appropriately
+    if (
+      args.command.startsWith("http://") ||
+      args.command.startsWith("https://")
+    ) {
+      validateServerUrl(args.command);
+    } else {
+      validateCommand(args.command);
+    }
+  }
+
   const projectRoot = resolve(__dirname, "..");
   const cliPath = resolve(projectRoot, "build", "index.js");
 
@@ -152,7 +296,7 @@ async function runCli(args: Args): Promise<void> {
     }
 
     await spawnPromise("node", cliArgs, {
-      env: { ...process.env, ...args.envArgs },
+      env: { ...process.env, ...validatedEnvArgs },
       signal: abort.signal,
       echoOutput: true,
       // pipe the stdout through here, prevents issues with buffering and


### PR DESCRIPTION
## Summary
Adds input validation to the CLI to prevent potential command injection vulnerabilities.

## Changes
- Add `isValidEnvVarName()` - validates env var names match `[a-zA-Z_][a-zA-Z0-9_]*`
- Add `isValidEnvVarValue()` - rejects values containing null bytes
- Add `validateEnvVars()` - filters invalid env vars with warnings
- Add `validateServerUrl()` - validates URL protocol, warns on private IPs
- Add `validateCommand()` - checks for shell metacharacters, verifies command exists
- Apply validation in `runWebClient()` and `runCli()` functions
- Add 11 integration tests for validation functions

## Security Impact
- Prevents command injection via malicious env var names
- Prevents string truncation via null bytes in values
- Warns users about connecting to internal addresses

## Test plan
- [x] Build passes (`npm run build`)
- [x] CLI validation tests pass (11/11)
- [x] Manual testing of edge cases
- [x] Existing CLI functionality works

🤖 Generated with [Claude Code](https://claude.com/claude-code)