### PR TITLE
type: unify boolean code style using type inference

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -73,7 +73,7 @@ async function runWebClient(args: Args): Promise<void> {
   );
 
   const abort = new AbortController();
-  let cancelled: boolean = false;
+  let cancelled = false;
   process.on("SIGINT", () => {
     cancelled = true;
     abort.abort();


### PR DESCRIPTION
It should be consistent with style https://github.com/modelcontextprotocol/inspector/blob/fe393e514a2921fea58f16aa310563b5c5d0ee8e/cli/src/cli.ts#L125

use type inference.