### PR TITLE
feat(elicitation): Add URL elicitation support. SEP-1036

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -341,7 +341,10 @@ const App = () => {
           request: {
             id: nextRequestId.current,
             message: request.params.message,
+            mode: request.params.mode,
             requestedSchema: request.params.requestedSchema,
+            url: request.params.url,
+            elicitationId: request.params.elicitationId,
           },
           originatingTab: currentTab,
           resolve,

--- a/client/src/components/ElicitationFormRequest.tsx
+++ b/client/src/components/ElicitationFormRequest.tsx
@@ -6,19 +6,22 @@ import { JsonSchemaType, JsonValue } from "@/utils/jsonUtils";
 import { generateDefaultValue } from "@/utils/schemaUtils";
 import {
   PendingElicitationRequest,
+  FormElicitationRequestData,
   ElicitationResponse,
 } from "./ElicitationTab";
 import Ajv from "ajv";
 
-export type ElicitationRequestProps = {
-  request: PendingElicitationRequest;
+export type ElicitationFormRequestProps = {
+  request: PendingElicitationRequest & {
+    request: FormElicitationRequestData;
+  };
   onResolve: (id: number, response: ElicitationResponse) => void;
 };
 
-const ElicitationRequest = ({
+const ElicitationFormRequest = ({
   request,
   onResolve,
-}: ElicitationRequestProps) => {
+}: ElicitationFormRequestProps) => {
   const [formData, setFormData] = useState<JsonValue>({});
   const [validationError, setValidationError] = useState<string | null>(null);
 
@@ -170,4 +173,4 @@ const ElicitationRequest = ({
   );
 };
 
-export default ElicitationRequest;
+export default ElicitationFormRequest;

--- a/client/src/components/ElicitationTab.tsx
+++ b/client/src/components/ElicitationTab.tsx
@@ -1,13 +1,28 @@
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { TabsContent } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
 import { JsonSchemaType } from "@/utils/jsonUtils";
-import ElicitationRequest from "./ElicitationRequest";
+import ElicitationFormRequest from "@/components/ElicitationFormRequest.tsx";
+import ElicitationUrlRequest from "@/components/ElicitationUrlRequest.tsx";
 
-export interface ElicitationRequestData {
+export type FormElicitationRequestData = {
+  mode?: "form";
   id: number;
   message: string;
   requestedSchema: JsonSchemaType;
-}
+};
+
+export type UrlElicitationRequestData = {
+  mode: "url";
+  id: number;
+  message: string;
+  url: string;
+  elicitationId: string;
+};
+
+export type ElicitationRequestData =
+  | FormElicitationRequestData
+  | UrlElicitationRequestData;
 
 export interface ElicitationResponse {
   action: "accept" | "decline" | "cancel";
@@ -25,6 +40,23 @@ export type Props = {
   onResolve: (id: number, response: ElicitationResponse) => void;
 };
 
+const isFormRequest = (
+  req: PendingElicitationRequest,
+): req is PendingElicitationRequest & {
+  request: FormElicitationRequestData;
+} => {
+  const mode = req.request.mode;
+  return mode === undefined || mode === null || mode === "form";
+};
+
+const isUrlElicitationRequest = (
+  req: PendingElicitationRequest,
+): req is PendingElicitationRequest & {
+  request: UrlElicitationRequestData;
+} => {
+  return req.request.mode === "url";
+};
+
 const ElicitationTab = ({ pendingRequests, onResolve }: Props) => {
   return (
     <TabsContent value="elicitations">
@@ -37,13 +69,52 @@ const ElicitationTab = ({ pendingRequests, onResolve }: Props) => {
         </Alert>
         <div className="mt-4 space-y-4">
           <h3 className="text-lg font-semibold">Recent Requests</h3>
-          {pendingRequests.map((request) => (
-            <ElicitationRequest
-              key={request.id}
-              request={request}
-              onResolve={onResolve}
-            />
-          ))}
+          {pendingRequests.map((request) => {
+            if (isFormRequest(request)) {
+              return (
+                <ElicitationFormRequest
+                  key={request.id}
+                  request={request}
+                  onResolve={onResolve}
+                />
+              );
+            } else if (isUrlElicitationRequest(request)) {
+              return (
+                <ElicitationUrlRequest
+                  key={request.id}
+                  request={request}
+                  onResolve={onResolve}
+                />
+              );
+            }
+            return (
+              <div
+                key={request.id}
+                className="flex flex-col gap-3 p-4 border rounded-lg"
+              >
+                <p className="text-sm">
+                  Unsupported elicitation mode. You can decline or cancel this
+                  request.
+                </p>
+                <div className="flex space-x-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => onResolve(request.id, { action: "decline" })}
+                  >
+                    Decline
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => onResolve(request.id, { action: "cancel" })}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
           {pendingRequests.length === 0 && (
             <p className="text-gray-500">No pending requests</p>
           )}

--- a/client/src/components/ElicitationUrlRequest.tsx
+++ b/client/src/components/ElicitationUrlRequest.tsx
@@ -136,6 +136,7 @@ const ElicitationUrlRequest = ({
             Cancel
           </Button>
           <Button
+            type="button"
             onClick={async () => {
               try {
                 await navigator.clipboard.writeText(request.request.url);

--- a/client/src/components/ElicitationUrlRequest.tsx
+++ b/client/src/components/ElicitationUrlRequest.tsx
@@ -1,0 +1,167 @@
+import {
+  ElicitationResponse,
+  PendingElicitationRequest,
+  UrlElicitationRequestData,
+} from "@/components/ElicitationTab.tsx";
+import JsonView from "@/components/JsonView.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { CheckCheck, Copy } from "lucide-react";
+import useCopy from "@/lib/hooks/useCopy.ts";
+import { toast } from "@/lib/hooks/useToast.ts";
+
+export type ElicitationUrlRequestProps = {
+  request: PendingElicitationRequest & {
+    request: UrlElicitationRequestData;
+  };
+  onResolve: (id: number, response: ElicitationResponse) => void;
+};
+
+const ElicitationUrlRequest = ({
+  request,
+  onResolve,
+}: ElicitationUrlRequestProps) => {
+  const { copied, setCopied } = useCopy();
+
+  const parsedUrl = (() => {
+    try {
+      return new URL(request.request.url);
+    } catch {
+      return null;
+    }
+  })();
+
+  const handleAcceptAndOpen = () => {
+    if (!parsedUrl) {
+      return;
+    }
+
+    window.open(parsedUrl.href, "_blank", "noopener,noreferrer");
+
+    onResolve(request.id, {
+      action: "accept",
+    });
+  };
+
+  const handleAccept = () => {
+    onResolve(request.id, {
+      action: "accept",
+    });
+  };
+
+  const handleDecline = () => {
+    onResolve(request.id, { action: "decline" });
+  };
+
+  const handleCancel = () => {
+    onResolve(request.id, { action: "cancel" });
+  };
+
+  const warnings = (() => {
+    if (!parsedUrl) {
+      return [];
+    }
+
+    const warnings: string[] = [];
+
+    if (parsedUrl.protocol !== "https:") {
+      warnings.push("Not https protocol");
+    }
+
+    if (parsedUrl.hostname.includes("xn--")) {
+      warnings.push("This URL contains internationalized characters");
+    }
+    if (/[^\u0020-\u007E]/.test(parsedUrl.hostname)) {
+      warnings.push("This URL contains non-Latin characters");
+    }
+    return warnings;
+  })();
+
+  const domain = (() => {
+    if (parsedUrl) {
+      return parsedUrl.hostname;
+    }
+    console.error("Invalid URL in elicitation request.");
+    return "Invalid URL";
+  })();
+
+  return (
+    <div
+      data-testid="elicitation-request"
+      className="flex gap-4 p-4 border rounded-lg space-y-4"
+    >
+      <div className="flex-1 bg-gray-50 dark:bg-gray-800 dark:text-gray-100 p-2 rounded">
+        <div className="space-y-2">
+          <div className="mt-2">
+            <h5 className="text-xs font-medium mb-1">Request Schema:</h5>
+            <JsonView
+              data={JSON.stringify(
+                request.request,
+                ["message", "url", "elicitationId"],
+                2,
+              )}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 space-y-6">
+        <div className="space-y-3">
+          {warnings.length > 0 &&
+            warnings.map((msg, index) => (
+              <div
+                key={index}
+                className="bg-yellow-100 border-l-4 border-yellow-500 p-2 text-xs text-yellow-700"
+              >
+                {msg}
+              </div>
+            ))}
+          <p className="text-sm">{request.request.message}</p>
+          <p className="text-sm font-semibold">Domain: {domain}</p>
+          <p className="text-xs text-gray-600">
+            Full URL: {request.request.url}
+          </p>
+        </div>
+        <div className="flex space-x-2">
+          <Button
+            type="button"
+            onClick={handleAcceptAndOpen}
+            disabled={!parsedUrl}
+          >
+            Accept and open
+          </Button>
+          <Button type="button" onClick={handleAccept}>
+            Accept
+          </Button>
+          <Button type="button" variant="outline" onClick={handleDecline}>
+            Decline
+          </Button>
+          <Button type="button" variant="outline" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(request.request.url);
+                setCopied(true);
+              } catch (error) {
+                toast({
+                  title: "Error",
+                  description: `There was an error copying url to the clipboard: ${error instanceof Error ? error.message : String(error)}`,
+                });
+              }
+            }}
+          >
+            {copied ? (
+              <CheckCheck className="h-4 w-4 mr-2 dark:text-green-700 text-green-600" />
+            ) : (
+              <Copy className="h-4 w-4 mr-2" />
+            )}
+            Copy URL
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ElicitationUrlRequest;

--- a/client/src/components/ElicitationUrlRequest.tsx
+++ b/client/src/components/ElicitationUrlRequest.tsx
@@ -64,11 +64,11 @@ const ElicitationUrlRequest = ({
     const warnings: string[] = [];
 
     if (parsedUrl.protocol !== "https:") {
-      warnings.push("Not https protocol");
+      warnings.push("Not HTTPS protocol");
     }
 
     if (parsedUrl.hostname.includes("xn--")) {
-      warnings.push("This URL contains internationalized characters");
+      warnings.push("This URL contains internationalized (non-ASCII) characters");
     }
     return warnings;
   })();

--- a/client/src/components/ElicitationUrlRequest.tsx
+++ b/client/src/components/ElicitationUrlRequest.tsx
@@ -70,9 +70,6 @@ const ElicitationUrlRequest = ({
     if (parsedUrl.hostname.includes("xn--")) {
       warnings.push("This URL contains internationalized characters");
     }
-    if (/[^\u0020-\u007E]/.test(parsedUrl.hostname)) {
-      warnings.push("This URL contains non-Latin characters");
-    }
     return warnings;
   })();
 

--- a/client/src/components/ElicitationUrlRequest.tsx
+++ b/client/src/components/ElicitationUrlRequest.tsx
@@ -107,7 +107,7 @@ const ElicitationUrlRequest = ({
             warnings.map((msg, index) => (
               <div
                 key={index}
-                className="bg-yellow-100 border-l-4 border-yellow-500 p-2 text-xs text-yellow-700"
+                className="bg-yellow-100 border-l-4 border-yellow-500 p-2 text-xs text-yellow-700 dark:bg-yellow-900 dark:text-yellow-200"
               >
                 {msg}
               </div>

--- a/client/src/components/__tests__/ElicitationFormRequest.test.tsx
+++ b/client/src/components/__tests__/ElicitationFormRequest.test.tsx
@@ -1,8 +1,11 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { describe, it, jest, beforeEach, afterEach } from "@jest/globals";
-import ElicitationRequest from "../ElicitationRequest";
-import { PendingElicitationRequest } from "../ElicitationTab";
+import ElicitationFormRequest from "../ElicitationFormRequest";
+import {
+  FormElicitationRequestData,
+  PendingElicitationRequest,
+} from "../ElicitationTab";
 
 jest.mock("../DynamicJsonForm", () => {
   return function MockDynamicJsonForm({
@@ -38,6 +41,10 @@ jest.mock("../DynamicJsonForm", () => {
 describe("ElicitationRequest", () => {
   const mockOnResolve = jest.fn();
 
+  type FormPendingElicitationRequest = PendingElicitationRequest & {
+    request: FormElicitationRequestData;
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -47,8 +54,8 @@ describe("ElicitationRequest", () => {
   });
 
   const createMockRequest = (
-    overrides: Partial<PendingElicitationRequest> = {},
-  ): PendingElicitationRequest => ({
+    overrides: Partial<FormPendingElicitationRequest> = {},
+  ): FormPendingElicitationRequest => ({
     id: 1,
     request: {
       id: 1,
@@ -66,10 +73,10 @@ describe("ElicitationRequest", () => {
   });
 
   const renderElicitationRequest = (
-    request: PendingElicitationRequest = createMockRequest(),
+    request: FormPendingElicitationRequest = createMockRequest(),
   ) => {
     return render(
-      <ElicitationRequest request={request} onResolve={mockOnResolve} />,
+      <ElicitationFormRequest request={request} onResolve={mockOnResolve} />,
     );
   };
 

--- a/client/src/components/__tests__/ElicitationUrlRequest.test.tsx
+++ b/client/src/components/__tests__/ElicitationUrlRequest.test.tsx
@@ -1,0 +1,688 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, it, jest, beforeEach, afterEach } from "@jest/globals";
+import ElicitationUrlRequest from "../ElicitationUrlRequest";
+import {
+  PendingElicitationRequest,
+  UrlElicitationRequestData,
+} from "../ElicitationTab";
+
+// Mock useCopy hook
+const mockSetCopied = jest.fn();
+let mockCopied = false;
+jest.mock("@/lib/hooks/useCopy.ts", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    copied: mockCopied,
+    setCopied: mockSetCopied,
+  })),
+}));
+
+// Mock toast
+jest.mock("@/lib/hooks/useToast.ts", () => ({
+  toast: jest.fn(),
+}));
+
+// Mock lucide-react icons
+jest.mock("lucide-react", () => ({
+  CheckCheck: ({ className }: { className?: string }) => (
+    <div data-testid="check-check-icon" className={className}>
+      CheckCheck
+    </div>
+  ),
+  Copy: ({ className }: { className?: string }) => (
+    <div data-testid="copy-icon" className={className}>
+      Copy
+    </div>
+  ),
+}));
+
+// Mock JsonView component
+jest.mock("../JsonView", () => {
+  return function MockJsonView({ data }: { data: string }) {
+    return <div data-testid="json-view">{data}</div>;
+  };
+});
+
+// Get the mocked toast function
+const { toast } = jest.requireMock("@/lib/hooks/useToast.ts");
+
+describe("ElicitationUrlRequest", () => {
+  const mockOnResolve = jest.fn();
+  const mockWindowOpen = jest.fn();
+  const mockConsoleError = jest.fn();
+  const mockWriteText = jest.fn();
+  const originalWindowOpen = window.open;
+  const originalConsoleError = console.error;
+  const originalClipboard = navigator.clipboard;
+
+  type UrlPendingElicitationRequest = PendingElicitationRequest & {
+    request: UrlElicitationRequestData;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCopied = false;
+    window.open = mockWindowOpen;
+    console.error = mockConsoleError;
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: mockWriteText,
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockWriteText.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    window.open = originalWindowOpen;
+    console.error = originalConsoleError;
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  const createMockRequest = (
+    overrides: Partial<UrlPendingElicitationRequest> = {},
+  ): UrlPendingElicitationRequest => ({
+    id: 1,
+    request: {
+      mode: "url",
+      id: 1,
+      message: "Please authorize access to your repositories.",
+      url: "https://github.com/login/oauth/authorize?client_id=abc123",
+      elicitationId: "550e8400-e29b-41d4-a716-446655440000",
+    },
+    ...overrides,
+  });
+
+  const renderElicitationUrlRequest = (
+    request: UrlPendingElicitationRequest = createMockRequest(),
+  ) => {
+    return render(
+      <ElicitationUrlRequest request={request} onResolve={mockOnResolve} />,
+    );
+  };
+
+  describe("Rendering", () => {
+    it("should render the component", () => {
+      renderElicitationUrlRequest();
+      expect(screen.getByTestId("elicitation-request")).toBeInTheDocument();
+    });
+
+    it("should display request message", () => {
+      const message = "Please provide your API key to continue.";
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message,
+            url: "https://example.com/api-key",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+      expect(screen.getByText(message)).toBeInTheDocument();
+    });
+
+    it("should display domain extracted from URL", () => {
+      renderElicitationUrlRequest();
+      expect(screen.getByText("Domain: github.com")).toBeInTheDocument();
+    });
+
+    it("should display full URL", () => {
+      const url = "https://example.com/auth?code=xyz";
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test message",
+            url,
+            elicitationId: "test-id",
+          },
+        }),
+      );
+      expect(screen.getByText(/Full URL:/)).toBeInTheDocument();
+      expect(
+        screen.getByText((content, element) => {
+          return element?.textContent === `Full URL: ${url}`;
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("should render all action buttons", () => {
+      renderElicitationUrlRequest();
+      expect(
+        screen.getByRole("button", { name: /^accept and open$/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^accept$/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /decline/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /copy url/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("should render JsonView with request schema", () => {
+      renderElicitationUrlRequest();
+      expect(screen.getByTestId("json-view")).toBeInTheDocument();
+    });
+
+    it("should display request data in JSON format", () => {
+      const request = createMockRequest();
+      renderElicitationUrlRequest(request);
+      const jsonView = screen.getByTestId("json-view");
+      const jsonData = JSON.parse(jsonView.textContent || "{}");
+      expect(jsonData.message).toBe(request.request.message);
+      expect(jsonData.url).toBe(request.request.url);
+      expect(jsonData.elicitationId).toBe(request.request.elicitationId);
+    });
+  });
+
+  describe("User Interactions", () => {
+    it("should call window.open and onResolve with accept action when 'Accept and open' button is clicked", () => {
+      const request = createMockRequest();
+      renderElicitationUrlRequest(request);
+
+      fireEvent.click(screen.getByRole("button", { name: /accept and open/i }));
+
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        request.request.url,
+        "_blank",
+        "noopener,noreferrer",
+      );
+      expect(mockOnResolve).toHaveBeenCalledWith(1, {
+        action: "accept",
+      });
+    });
+
+    it("should call onResolve with decline action when Decline button is clicked", () => {
+      renderElicitationUrlRequest();
+
+      fireEvent.click(screen.getByRole("button", { name: /decline/i }));
+
+      expect(mockOnResolve).toHaveBeenCalledWith(1, { action: "decline" });
+      expect(mockWindowOpen).not.toHaveBeenCalled();
+    });
+
+    it("should call onResolve with cancel action when Cancel button is clicked", () => {
+      renderElicitationUrlRequest();
+
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+      expect(mockOnResolve).toHaveBeenCalledWith(1, { action: "cancel" });
+      expect(mockWindowOpen).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("URL Validation and Warnings", () => {
+    it("should not show protocol warning for HTTPS URLs", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "https://example.com/secure",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(screen.queryByText("Not https protocol")).not.toBeInTheDocument();
+    });
+
+    it("should show protocol warning for HTTP URLs", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "http://example.com/insecure",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(screen.getByText("Not https protocol")).toBeInTheDocument();
+    });
+
+    it("should show warning for Punycode (internationalized) URLs", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "https://xn--nxasmq6b.com/path",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(
+        screen.getByText("This URL contains internationalized characters"),
+      ).toBeInTheDocument();
+    });
+
+    it("should show warning for URLs with non-Latin characters", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "https://xn--r8jz45g.com/path", // Punycode for 見.com
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(
+        screen.getByText("This URL contains internationalized characters"),
+      ).toBeInTheDocument();
+    });
+
+    it("should show multiple warnings when applicable", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "http://xn--nxasmq6b.com/path",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(screen.getByText("Not https protocol")).toBeInTheDocument();
+      expect(
+        screen.getByText("This URL contains internationalized characters"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Invalid URL Handling", () => {
+    it("should display 'Invalid URL' for malformed URLs without crashing", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "not-a-valid-url",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(screen.getByText("Domain: Invalid URL")).toBeInTheDocument();
+      expect(mockConsoleError).toHaveBeenCalled();
+    });
+
+    it("should not show warnings for invalid URLs", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "invalid-url",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(screen.queryByText("Not https protocol")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("This URL contains internationalized characters"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should handle empty URL string", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(screen.getByText("Domain: Invalid URL")).toBeInTheDocument();
+    });
+
+    it("should still allow interaction with buttons when URL is invalid", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "invalid",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /decline/i }));
+      expect(mockOnResolve).toHaveBeenCalledWith(1, { action: "decline" });
+    });
+  });
+
+  describe("Different URL Protocols", () => {
+    it("should handle localhost URLs", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "http://localhost:3000/auth",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(screen.getByText("Domain: localhost")).toBeInTheDocument();
+      expect(screen.getByText("Not https protocol")).toBeInTheDocument();
+    });
+
+    it("should handle URLs with ports", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "https://example.com:8080/path",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(screen.getByText("Domain: example.com")).toBeInTheDocument();
+    });
+
+    it("should handle URLs with query parameters", () => {
+      const url =
+        "https://example.com/auth?client_id=123&redirect_uri=http://localhost";
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url,
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(
+        screen.getByText((content, element) => {
+          return element?.textContent === `Full URL: ${url}`;
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("should handle URLs with hash fragments", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "https://example.com/page#section",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(screen.getByText("Domain: example.com")).toBeInTheDocument();
+    });
+  });
+
+  describe("Request ID Handling", () => {
+    it("should use correct request ID when calling onResolve", () => {
+      const customId = 42;
+      renderElicitationUrlRequest(
+        createMockRequest({
+          id: customId,
+        }),
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /^accept and open$/i }),
+      );
+
+      expect(mockOnResolve).toHaveBeenCalledWith(customId, {
+        action: "accept",
+      });
+    });
+
+    it("should pass different IDs for different actions", () => {
+      const customId = 99;
+      renderElicitationUrlRequest(
+        createMockRequest({
+          id: customId,
+        }),
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      expect(mockOnResolve).toHaveBeenCalledWith(customId, {
+        action: "cancel",
+      });
+    });
+  });
+
+  describe("Copy URL Functionality", () => {
+    it("should copy URL to clipboard when Copy URL button is clicked", async () => {
+      const url = "https://example.com/auth";
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url,
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      const copyButton = screen.getByRole("button", { name: /copy url/i });
+      fireEvent.click(copyButton);
+
+      await waitFor(() => {
+        expect(mockWriteText).toHaveBeenCalledWith(url);
+      });
+    });
+
+    it("should call setCopied when copy succeeds", async () => {
+      renderElicitationUrlRequest();
+
+      const copyButton = screen.getByRole("button", { name: /copy url/i });
+      fireEvent.click(copyButton);
+
+      await waitFor(() => {
+        expect(mockSetCopied).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it("should show Copy icon when not copied", () => {
+      mockCopied = false;
+      renderElicitationUrlRequest();
+
+      expect(screen.getByTestId("copy-icon")).toBeInTheDocument();
+      expect(screen.queryByTestId("check-check-icon")).not.toBeInTheDocument();
+    });
+
+    it("should show CheckCheck icon when copied", () => {
+      mockCopied = true;
+      renderElicitationUrlRequest();
+
+      expect(screen.getByTestId("check-check-icon")).toBeInTheDocument();
+      expect(screen.queryByTestId("copy-icon")).not.toBeInTheDocument();
+    });
+
+    it("should show toast error when clipboard write fails", async () => {
+      const error = new Error("Clipboard access denied");
+      mockWriteText.mockRejectedValue(error);
+
+      renderElicitationUrlRequest();
+
+      const copyButton = screen.getByRole("button", { name: /copy url/i });
+      fireEvent.click(copyButton);
+
+      await waitFor(() => {
+        expect(toast).toHaveBeenCalledWith({
+          title: "Error",
+          description: expect.stringContaining("Clipboard access denied"),
+        });
+      });
+    });
+
+    it("should handle non-Error clipboard failures", async () => {
+      mockWriteText.mockRejectedValue("Unknown error");
+
+      renderElicitationUrlRequest();
+
+      const copyButton = screen.getByRole("button", { name: /copy url/i });
+      fireEvent.click(copyButton);
+
+      await waitFor(() => {
+        expect(toast).toHaveBeenCalledWith({
+          title: "Error",
+          description: expect.stringContaining("Unknown error"),
+        });
+      });
+    });
+  });
+
+  describe("Button Disabled States", () => {
+    it("should disable 'Accept and open' button when URL is invalid", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "not-a-valid-url",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      const acceptAndOpenButton = screen.getByRole("button", {
+        name: /^accept and open$/i,
+      });
+      expect(acceptAndOpenButton).toBeDisabled();
+    });
+
+    it("should enable 'Accept and open' button when URL is valid", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "https://example.com/valid",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      const acceptAndOpenButton = screen.getByRole("button", {
+        name: /^accept and open$/i,
+      });
+      expect(acceptAndOpenButton).not.toBeDisabled();
+    });
+
+    it("should not call window.open when 'Accept and open' is clicked with invalid URL", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "invalid",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      const acceptAndOpenButton = screen.getByRole("button", {
+        name: /^accept and open$/i,
+      });
+
+      // Button is disabled, but try to click anyway
+      fireEvent.click(acceptAndOpenButton);
+
+      expect(mockWindowOpen).not.toHaveBeenCalled();
+    });
+
+    it("should keep other buttons enabled when URL is invalid", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "invalid-url",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      expect(
+        screen.getByRole("button", { name: /^accept$/i }),
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /decline/i }),
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /copy url/i }),
+      ).not.toBeDisabled();
+    });
+
+    it("should disable 'Accept and open' for empty URL", () => {
+      renderElicitationUrlRequest(
+        createMockRequest({
+          request: {
+            mode: "url",
+            id: 1,
+            message: "Test",
+            url: "",
+            elicitationId: "test-id",
+          },
+        }),
+      );
+
+      const acceptAndOpenButton = screen.getByRole("button", {
+        name: /^accept and open$/i,
+      });
+      expect(acceptAndOpenButton).toBeDisabled();
+    });
+  });
+});

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -264,7 +264,10 @@ describe("useConnection", () => {
         }),
         expect.objectContaining({
           capabilities: expect.objectContaining({
-            elicitation: {},
+            elicitation: {
+              form: {},
+              url: {},
+            },
           }),
         }),
       );

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -27,6 +27,7 @@ import {
   ResourceListChangedNotificationSchema,
   ToolListChangedNotificationSchema,
   PromptListChangedNotificationSchema,
+  ElicitationCompleteNotificationSchema,
   Progress,
   LoggingLevel,
   ElicitRequestSchema,
@@ -414,7 +415,10 @@ export function useConnection({
     const clientCapabilities = {
       capabilities: {
         sampling: {},
-        elicitation: {},
+        elicitation: {
+          form: {},
+          url: {},
+        },
         roots: {
           listChanged: true,
         },
@@ -695,6 +699,7 @@ export function useConnection({
           ResourceListChangedNotificationSchema,
           ToolListChangedNotificationSchema,
           PromptListChangedNotificationSchema,
+          ElicitationCompleteNotificationSchema,
         ].forEach((notificationSchema) => {
           client.setNotificationHandler(notificationSchema, onNotification);
         });


### PR DESCRIPTION
## Summary

<!-- Provide a brief description of what this PR does -->
Implemented support of URL Elicitation SEP-1036. This bring next changes:
- change default elicitation capabilities to form and url
- new subtab for url elicitation, with options to: accept and open url, accept, decline, cancel, and copy  url
- show warning if the url is not valid link, has non latin characters or not https protocol 
- save `notifications/elicitation/complete` to notification tab

! This PR does not change behaviour in case URLElicitationRequiredError. The error will only shown in error popup.

Video:

https://github.com/user-attachments/assets/84b380b3-8ef6-4409-be9f-5a6e06dcd3d3


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

<!-- Describe the changes in detail. Include screenshots/recordings if applicable -->

Code changes:
- Added new component `ElicitationUrlRequest`
- Updated types for form and url elicitation request data
- Updated ElicitationTab to handle both form and url elicitation requests

## Related Issues

<!-- Link to related issues using #issue_number or "Fixes #issue_number" -->

Issue: https://github.com/modelcontextprotocol/inspector/issues/929

## Testing

<!-- Describe how you tested these changes, where applicable -->

- [x] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [x] Tested with Streamable HTTP transport
- [ ] Added/updated automated tests
- [x] Manual testing performed

Tested with [python elicitation server](https://github.com/modelcontextprotocol/python-sdk/blob/c7cbfbb3022855a5f77f99c27d594633925d5f8b/examples/snippets/servers/elicitation.py) 

### Test Results and/or Instructions

<!-- Provide steps for reviewers to test your changes -->

Screenshots are encouraged to share your testing results for this change.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Additional Context

<!-- Add any other context, screenshots, or information about the PR here -->
I'm not typescript developer, feel free to close or update PR if needed. This changes was done to test url elicitation for rust sdk. 
