### PR TITLE
Fix: OAuth CORS errors when Connection Type is 'Via Proxy'

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -622,9 +622,14 @@ const App = () => {
         };
 
         try {
-          const stateMachine = new OAuthStateMachine(sseUrl, (updates) => {
-            currentState = { ...currentState, ...updates };
-          });
+          const stateMachine = new OAuthStateMachine(
+            sseUrl,
+            (updates) => {
+              currentState = { ...currentState, ...updates };
+            },
+            connectionType,
+            config,
+          );
 
           while (
             currentState.oauthStep !== "complete" &&
@@ -1264,6 +1269,8 @@ const App = () => {
         onBack={() => setIsAuthDebuggerVisible(false)}
         authState={authState}
         updateAuthState={updateAuthState}
+        connectionType={connectionType}
+        config={config}
       />
     </TabsContent>
   );

--- a/client/src/lib/__tests__/auth.test.ts
+++ b/client/src/lib/__tests__/auth.test.ts
@@ -1,5 +1,6 @@
 import { discoverScopes } from "../auth";
 import { discoverAuthorizationServerMetadata } from "@modelcontextprotocol/sdk/client/auth.js";
+import { InspectorConfig } from "../configurationTypes";
 
 jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
   discoverAuthorizationServerMetadata: jest.fn(),
@@ -9,6 +10,39 @@ const mockDiscoverAuth =
   discoverAuthorizationServerMetadata as jest.MockedFunction<
     typeof discoverAuthorizationServerMetadata
   >;
+
+const mockConfig: InspectorConfig = {
+  MCP_SERVER_REQUEST_TIMEOUT: {
+    label: "Request Timeout",
+    description: "Timeout for MCP requests",
+    value: 30000,
+    is_session_item: false,
+  },
+  MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS: {
+    label: "Reset Timeout on Progress",
+    description: "Reset timeout on progress notifications",
+    value: true,
+    is_session_item: false,
+  },
+  MCP_REQUEST_MAX_TOTAL_TIMEOUT: {
+    label: "Max Total Timeout",
+    description: "Maximum total timeout",
+    value: 300000,
+    is_session_item: false,
+  },
+  MCP_PROXY_FULL_ADDRESS: {
+    label: "Proxy Address",
+    description: "Full address of the MCP proxy",
+    value: "http://localhost:6277",
+    is_session_item: false,
+  },
+  MCP_PROXY_AUTH_TOKEN: {
+    label: "Proxy Auth Token",
+    description: "Authentication token for the proxy",
+    value: "",
+    is_session_item: false,
+  },
+};
 
 const baseMetadata = {
   issuer: "https://test.com",
@@ -129,7 +163,12 @@ describe("discoverScopes", () => {
     }) => {
       mockDiscoverAuth.mockResolvedValue(mockResolves);
 
-      const result = await discoverScopes(serverUrl, resourceMetadata);
+      const result = await discoverScopes(
+        serverUrl,
+        "direct",
+        mockConfig,
+        resourceMetadata,
+      );
 
       expect(result).toBe(expected);
       if (expectedCallUrl) {
@@ -147,7 +186,12 @@ describe("discoverScopes", () => {
         mockDiscoverAuth.mockResolvedValue(mockResolves);
       }
 
-      const result = await discoverScopes(serverUrl, resourceMetadata);
+      const result = await discoverScopes(
+        serverUrl,
+        "direct",
+        mockConfig,
+        resourceMetadata,
+      );
 
       expect(result).toBeUndefined();
     },

--- a/client/src/lib/__tests__/oauth-proxy.test.ts
+++ b/client/src/lib/__tests__/oauth-proxy.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for OAuth Proxy Utilities
+ */
+
+import {
+  discoverAuthorizationServerMetadataViaProxy,
+  discoverOAuthProtectedResourceMetadataViaProxy,
+  registerClientViaProxy,
+  exchangeAuthorizationViaProxy,
+} from "../oauth-proxy";
+import { InspectorConfig } from "../configurationTypes";
+
+// Mock the config utils
+jest.mock("@/utils/configUtils", () => ({
+  getMCPProxyAddress: jest.fn(() => "http://localhost:6277"),
+  getMCPProxyAuthToken: jest.fn(() => ({
+    token: "test-token",
+    header: "x-mcp-proxy-auth",
+  })),
+}));
+
+// Mock global fetch
+global.fetch = jest.fn();
+
+const mockConfig: InspectorConfig = {
+  MCP_SERVER_REQUEST_TIMEOUT: {
+    label: "Request Timeout",
+    description: "Timeout for MCP requests",
+    value: 30000,
+    is_session_item: false,
+  },
+  MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS: {
+    label: "Reset Timeout on Progress",
+    description: "Reset timeout on progress notifications",
+    value: true,
+    is_session_item: false,
+  },
+  MCP_REQUEST_MAX_TOTAL_TIMEOUT: {
+    label: "Max Total Timeout",
+    description: "Maximum total timeout",
+    value: 300000,
+    is_session_item: false,
+  },
+  MCP_PROXY_FULL_ADDRESS: {
+    label: "Proxy Address",
+    description: "Full address of the MCP proxy",
+    value: "http://localhost:6277",
+    is_session_item: false,
+  },
+  MCP_PROXY_AUTH_TOKEN: {
+    label: "Proxy Auth Token",
+    description: "Authentication token for the proxy",
+    value: "test-token",
+    is_session_item: false,
+  },
+};
+
+describe("OAuth Proxy Utilities", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("discoverAuthorizationServerMetadataViaProxy", () => {
+    it("should successfully fetch metadata through proxy", async () => {
+      const mockMetadata = {
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code"],
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMetadata,
+      });
+
+      const result = await discoverAuthorizationServerMetadataViaProxy(
+        new URL("https://auth.example.com"),
+        mockConfig,
+      );
+
+      expect(result).toEqual(mockMetadata);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:6277/oauth/metadata?url=https%3A%2F%2Fauth.example.com%2F.well-known%2Foauth-authorization-server",
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            "x-mcp-proxy-auth": "Bearer test-token",
+          },
+        },
+      );
+    });
+
+    it("should handle network errors", async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(
+        new Error("Network error"),
+      );
+
+      await expect(
+        discoverAuthorizationServerMetadataViaProxy(
+          new URL("https://auth.example.com"),
+          mockConfig,
+        ),
+      ).rejects.toThrow("Network error");
+    });
+
+    it("should handle non-ok responses", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        json: async () => ({ error: "Metadata not found" }),
+      });
+
+      await expect(
+        discoverAuthorizationServerMetadataViaProxy(
+          new URL("https://auth.example.com"),
+          mockConfig,
+        ),
+      ).rejects.toThrow(
+        "Failed to discover OAuth metadata: Not found: Metadata not found",
+      );
+    });
+
+    it("should handle responses without error details", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        json: async () => {
+          throw new Error("Invalid JSON");
+        },
+      });
+
+      await expect(
+        discoverAuthorizationServerMetadataViaProxy(
+          new URL("https://auth.example.com"),
+          mockConfig,
+        ),
+      ).rejects.toThrow(
+        "Failed to discover OAuth metadata: Server error (500): Internal Server Error",
+      );
+    });
+  });
+
+  describe("discoverOAuthProtectedResourceMetadataViaProxy", () => {
+    it("should successfully fetch resource metadata through proxy", async () => {
+      const mockMetadata = {
+        resource: "https://api.example.com",
+        authorization_servers: ["https://auth.example.com"],
+        scopes_supported: ["read", "write"],
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMetadata,
+      });
+
+      const result = await discoverOAuthProtectedResourceMetadataViaProxy(
+        "https://api.example.com",
+        mockConfig,
+      );
+
+      expect(result).toEqual(mockMetadata);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:6277/oauth/resource-metadata?url=https%3A%2F%2Fapi.example.com%2F.well-known%2Foauth-protected-resource",
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            "x-mcp-proxy-auth": "Bearer test-token",
+          },
+        },
+      );
+    });
+
+    it("should handle errors", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        json: async () => ({ error: "Resource metadata not found" }),
+      });
+
+      await expect(
+        discoverOAuthProtectedResourceMetadataViaProxy(
+          "https://api.example.com",
+          mockConfig,
+        ),
+      ).rejects.toThrow(
+        "Failed to discover resource metadata: Not found: Resource metadata not found",
+      );
+    });
+  });
+
+  describe("registerClientViaProxy", () => {
+    it("should successfully register client through proxy", async () => {
+      const clientMetadata = {
+        client_name: "Test Client",
+        redirect_uris: ["http://localhost:6274/oauth/callback"],
+        grant_types: ["authorization_code"],
+      };
+
+      const mockClientInformation = {
+        client_id: "test-client-id",
+        client_secret: "test-client-secret",
+        ...clientMetadata,
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockClientInformation,
+      });
+
+      const result = await registerClientViaProxy(
+        "https://auth.example.com/register",
+        clientMetadata,
+        mockConfig,
+      );
+
+      expect(result).toEqual(mockClientInformation);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:6277/oauth/register",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-mcp-proxy-auth": "Bearer test-token",
+          },
+          body: JSON.stringify({
+            registrationEndpoint: "https://auth.example.com/register",
+            clientMetadata,
+          }),
+        },
+      );
+    });
+
+    it("should handle registration errors", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        json: async () => ({ error: "Invalid client metadata" }),
+      });
+
+      await expect(
+        registerClientViaProxy(
+          "https://auth.example.com/register",
+          {
+            client_name: "Test",
+            redirect_uris: ["http://localhost:6274/oauth/callback"],
+          },
+          mockConfig,
+        ),
+      ).rejects.toThrow(
+        "Failed to register client: Bad Request: Invalid client metadata",
+      );
+    });
+  });
+
+  describe("exchangeAuthorizationViaProxy", () => {
+    it("should successfully exchange authorization code through proxy", async () => {
+      const params = {
+        grant_type: "authorization_code",
+        code: "test-auth-code",
+        redirect_uri: "http://localhost:6274/oauth/callback",
+        code_verifier: "test-verifier",
+        client_id: "test-client-id",
+      };
+
+      const mockTokens = {
+        access_token: "test-access-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTokens,
+      });
+
+      const result = await exchangeAuthorizationViaProxy(
+        "https://auth.example.com/token",
+        params,
+        mockConfig,
+      );
+
+      expect(result).toEqual(mockTokens);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:6277/oauth/token",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-mcp-proxy-auth": "Bearer test-token",
+          },
+          body: JSON.stringify({
+            tokenEndpoint: "https://auth.example.com/token",
+            params,
+          }),
+        },
+      );
+    });
+
+    it("should handle token exchange errors", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: async () => ({ error: "invalid_grant" }),
+      });
+
+      await expect(
+        exchangeAuthorizationViaProxy(
+          "https://auth.example.com/token",
+          { grant_type: "authorization_code", code: "invalid" },
+          mockConfig,
+        ),
+      ).rejects.toThrow(
+        "Failed to exchange authorization code: Authentication failed: invalid_grant",
+      );
+    });
+
+    it("should handle network failures", async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(
+        new Error("Connection refused"),
+      );
+
+      await expect(
+        exchangeAuthorizationViaProxy(
+          "https://auth.example.com/token",
+          { grant_type: "authorization_code", code: "test" },
+          mockConfig,
+        ),
+      ).rejects.toThrow("Connection refused");
+    });
+  });
+});

--- a/client/src/lib/__tests__/oauth-proxy.test.ts
+++ b/client/src/lib/__tests__/oauth-proxy.test.ts
@@ -120,7 +120,51 @@ describe("OAuth Proxy Utilities", () => {
           mockConfig,
         ),
       ).rejects.toThrow(
-        "Failed to discover OAuth metadata: Not found: Metadata not found",
+        "Not found: Metadata not found. The OAuth endpoint may not exist or be misconfigured.",
+      );
+    });
+
+    it("should fall back to root well-known URL for non-root paths", async () => {
+      const mockMetadata = {
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code"],
+      };
+
+      // First call (path-aware) fails with 404
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        json: async () => ({ error: "Not found" }),
+      });
+
+      // Second call (root fallback) succeeds
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMetadata,
+      });
+
+      const result = await discoverAuthorizationServerMetadataViaProxy(
+        new URL("https://auth.example.com/tenant"),
+        mockConfig,
+      );
+
+      expect(result).toEqual(mockMetadata);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      // First attempt: path-aware URL
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        1,
+        "http://localhost:6277/oauth/metadata?url=https%3A%2F%2Fauth.example.com%2F.well-known%2Foauth-authorization-server%2Ftenant",
+        expect.any(Object),
+      );
+      // Second attempt: root fallback URL
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        "http://localhost:6277/oauth/metadata?url=https%3A%2F%2Fauth.example.com%2F.well-known%2Foauth-authorization-server",
+        expect.any(Object),
       );
     });
 
@@ -139,9 +183,7 @@ describe("OAuth Proxy Utilities", () => {
           new URL("https://auth.example.com"),
           mockConfig,
         ),
-      ).rejects.toThrow(
-        "Failed to discover OAuth metadata: Server error (500): Internal Server Error",
-      );
+      ).rejects.toThrow("Server error (500): Internal Server Error");
     });
   });
 
@@ -190,7 +232,49 @@ describe("OAuth Proxy Utilities", () => {
           mockConfig,
         ),
       ).rejects.toThrow(
-        "Failed to discover resource metadata: Not found: Resource metadata not found",
+        "Not found: Resource metadata not found. The OAuth endpoint may not exist or be misconfigured.",
+      );
+    });
+
+    it("should fall back to root well-known URL for non-root paths", async () => {
+      const mockMetadata = {
+        resource: "https://api.example.com/mcp",
+        authorization_servers: ["https://auth.example.com"],
+        scopes_supported: ["read", "write"],
+      };
+
+      // First call (path-aware) fails with 404
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        json: async () => ({ error: "Not found" }),
+      });
+
+      // Second call (root fallback) succeeds
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMetadata,
+      });
+
+      const result = await discoverOAuthProtectedResourceMetadataViaProxy(
+        "https://api.example.com/mcp",
+        mockConfig,
+      );
+
+      expect(result).toEqual(mockMetadata);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      // First attempt: path-aware URL
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        1,
+        "http://localhost:6277/oauth/resource-metadata?url=https%3A%2F%2Fapi.example.com%2F.well-known%2Foauth-protected-resource%2Fmcp",
+        expect.any(Object),
+      );
+      // Second attempt: root fallback URL
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        "http://localhost:6277/oauth/resource-metadata?url=https%3A%2F%2Fapi.example.com%2F.well-known%2Foauth-protected-resource",
+        expect.any(Object),
       );
     });
   });

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -1513,6 +1513,8 @@ describe("useConnection", () => {
         if (expectScopeCall) {
           expect(mockDiscoverScopes).toHaveBeenCalledWith(
             defaultProps.sseUrl,
+            "proxy",
+            defaultProps.config,
             undefined,
           );
         } else {
@@ -1537,6 +1539,8 @@ describe("useConnection", () => {
 
       expect(mockDiscoverScopes).toHaveBeenCalledWith(
         defaultProps.sseUrl,
+        "proxy",
+        defaultProps.config,
         undefined,
       );
       expect(mockAuth).toHaveBeenCalledWith(expect.any(Object), {

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -64,6 +64,7 @@ import {
   clearScopeFromSessionStorage,
   discoverScopes,
 } from "../auth";
+import { discoverOAuthProtectedResourceMetadataViaProxy } from "../oauth-proxy";
 import {
   getMCPProxyAddress,
   getMCPTaskTtl,
@@ -404,13 +405,26 @@ export function useConnection({
         // Only discover resource metadata when we need to discover scopes
         let resourceMetadata;
         try {
-          resourceMetadata = await discoverOAuthProtectedResourceMetadata(
-            new URL("/", sseUrl),
-          );
+          if (connectionType === "proxy") {
+            resourceMetadata =
+              await discoverOAuthProtectedResourceMetadataViaProxy(
+                sseUrl,
+                config,
+              );
+          } else {
+            resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+              new URL("/", sseUrl),
+            );
+          }
         } catch {
           // Resource metadata is optional, continue without it
         }
-        scope = await discoverScopes(sseUrl, resourceMetadata);
+        scope = await discoverScopes(
+          sseUrl,
+          connectionType,
+          config,
+          resourceMetadata,
+        );
       }
 
       saveScopeToSessionStorage(sseUrl, scope);

--- a/client/src/lib/oauth-proxy.ts
+++ b/client/src/lib/oauth-proxy.ts
@@ -1,0 +1,238 @@
+/**
+ * OAuth Proxy Utilities
+ *
+ * These functions route OAuth requests through the MCP Inspector proxy server
+ * to avoid CORS issues when connectionType is "proxy".
+ */
+
+import {
+  OAuthMetadata,
+  OAuthProtectedResourceMetadata,
+  OAuthClientInformation,
+  OAuthTokens,
+  OAuthClientMetadata,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { getMCPProxyAddress, getMCPProxyAuthToken } from "@/utils/configUtils";
+import { InspectorConfig } from "./configurationTypes";
+
+/**
+ * Get proxy headers for authentication
+ * @param config - Inspector configuration containing proxy authentication settings
+ * @returns Headers object with Content-Type and optional Bearer token
+ */
+function getProxyHeaders(config: InspectorConfig): Record<string, string> {
+  const { token, header } = getMCPProxyAuthToken(config);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (token) {
+    headers[header] = `Bearer ${token}`;
+  }
+
+  return headers;
+}
+
+/**
+ * Common helper for proxying fetch requests
+ * @param endpoint - The API endpoint path (e.g., "/oauth/metadata")
+ * @param method - HTTP method (GET or POST)
+ * @param config - Inspector configuration containing proxy settings
+ * @param body - Optional request body object
+ * @param queryParams - Optional query parameters to append to URL
+ * @returns Promise resolving to the typed response
+ * @throws Error if the request fails or returns non-ok status
+ */
+async function proxyFetch<T>(
+  endpoint: string,
+  method: "GET" | "POST",
+  config: InspectorConfig,
+  body?: object,
+  queryParams?: Record<string, string>,
+): Promise<T> {
+  const proxyAddress = getMCPProxyAddress(config);
+  const url = new URL(endpoint, proxyAddress);
+
+  if (queryParams) {
+    Object.entries(queryParams).forEach(([key, value]) => {
+      url.searchParams.set(key, value);
+    });
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url.toString(), {
+      method,
+      headers: getProxyHeaders(config),
+      ...(body && { body: JSON.stringify(body) }),
+    });
+  } catch (error) {
+    // Network errors (connection refused, timeout, etc.)
+    throw new Error(
+      `Network error: ${error instanceof Error ? error.message : "Failed to connect to proxy server"}`,
+    );
+  }
+
+  if (!response.ok) {
+    // Try to get detailed error from response body
+    const errorData = await response
+      .json()
+      .catch(() => ({ error: response.statusText }));
+    const errorMessage = errorData.error || response.statusText;
+    const errorDetails = errorData.details ? ` - ${errorData.details}` : "";
+
+    // Provide specific error messages based on status code
+    switch (response.status) {
+      case 400:
+        throw new Error(`Bad Request: ${errorMessage}${errorDetails}`);
+      case 401:
+        throw new Error(
+          `Authentication failed: ${errorMessage}. Check your proxy authentication token.`,
+        );
+      case 403:
+        throw new Error(
+          `Access forbidden: ${errorMessage}. You may not have permission to access this resource.`,
+        );
+      case 404:
+        throw new Error(
+          `Not found: ${errorMessage}. The OAuth endpoint may not exist or be misconfigured.`,
+        );
+      case 500:
+      case 502:
+      case 503:
+      case 504:
+        throw new Error(
+          `Server error (${response.status}): ${errorMessage}${errorDetails}`,
+        );
+      default:
+        throw new Error(
+          `Request failed (${response.status}): ${errorMessage}${errorDetails}`,
+        );
+    }
+  }
+
+  return await response.json();
+}
+
+/**
+ * Discover OAuth Authorization Server Metadata via proxy
+ * @param authServerUrl - The OAuth authorization server URL
+ * @param config - Inspector configuration containing proxy settings
+ * @returns Promise resolving to OAuth metadata
+ * @throws Error if metadata discovery fails
+ */
+export async function discoverAuthorizationServerMetadataViaProxy(
+  authServerUrl: URL,
+  config: InspectorConfig,
+): Promise<OAuthMetadata> {
+  // Construct the well-known URL per RFC 8414
+  const pathname = authServerUrl.pathname.endsWith("/")
+    ? authServerUrl.pathname.slice(0, -1)
+    : authServerUrl.pathname;
+  const wellKnownUrl = new URL(
+    `/.well-known/oauth-authorization-server${pathname}`,
+    authServerUrl,
+  );
+
+  try {
+    return await proxyFetch<OAuthMetadata>(
+      "/oauth/metadata",
+      "GET",
+      config,
+      undefined,
+      { url: wellKnownUrl.toString() },
+    );
+  } catch (error) {
+    throw new Error(
+      `Failed to discover OAuth metadata: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Discover OAuth Protected Resource Metadata via proxy
+ * @param serverUrl - The MCP server URL
+ * @param config - Inspector configuration containing proxy settings
+ * @returns Promise resolving to OAuth protected resource metadata
+ * @throws Error if resource metadata discovery fails
+ */
+export async function discoverOAuthProtectedResourceMetadataViaProxy(
+  serverUrl: string,
+  config: InspectorConfig,
+): Promise<OAuthProtectedResourceMetadata> {
+  // Construct the well-known URL per RFC 9728
+  const url = new URL(serverUrl);
+  const pathname = url.pathname.endsWith("/")
+    ? url.pathname.slice(0, -1)
+    : url.pathname;
+  const wellKnownUrl = new URL(
+    `/.well-known/oauth-protected-resource${pathname}`,
+    url,
+  );
+
+  try {
+    return await proxyFetch<OAuthProtectedResourceMetadata>(
+      "/oauth/resource-metadata",
+      "GET",
+      config,
+      undefined,
+      { url: wellKnownUrl.toString() },
+    );
+  } catch (error) {
+    throw new Error(
+      `Failed to discover resource metadata: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Register OAuth client via proxy (Dynamic Client Registration)
+ * @param registrationEndpoint - The OAuth client registration endpoint URL
+ * @param clientMetadata - OAuth client metadata for registration
+ * @param config - Inspector configuration containing proxy settings
+ * @returns Promise resolving to OAuth client information
+ * @throws Error if client registration fails
+ */
+export async function registerClientViaProxy(
+  registrationEndpoint: string,
+  clientMetadata: OAuthClientMetadata,
+  config: InspectorConfig,
+): Promise<OAuthClientInformation> {
+  try {
+    return await proxyFetch<OAuthClientInformation>(
+      "/oauth/register",
+      "POST",
+      config,
+      { registrationEndpoint, clientMetadata },
+    );
+  } catch (error) {
+    throw new Error(
+      `Failed to register client: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Exchange authorization code for tokens via proxy
+ * @param tokenEndpoint - The OAuth token endpoint URL
+ * @param params - Token exchange parameters (code, client_id, etc.)
+ * @param config - Inspector configuration containing proxy settings
+ * @returns Promise resolving to OAuth tokens
+ * @throws Error if token exchange fails
+ */
+export async function exchangeAuthorizationViaProxy(
+  tokenEndpoint: string,
+  params: Record<string, string>,
+  config: InspectorConfig,
+): Promise<OAuthTokens> {
+  try {
+    return await proxyFetch<OAuthTokens>("/oauth/token", "POST", config, {
+      tokenEndpoint,
+      params,
+    });
+  } catch (error) {
+    throw new Error(
+      `Failed to exchange authorization code: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/client/src/lib/oauth-proxy.ts
+++ b/client/src/lib/oauth-proxy.ts
@@ -125,7 +125,7 @@ export async function discoverAuthorizationServerMetadataViaProxy(
   authServerUrl: URL,
   config: InspectorConfig,
 ): Promise<OAuthMetadata> {
-  // Construct the well-known URL per RFC 8414
+  // Construct the path-aware well-known URL per RFC 8414
   const pathname = authServerUrl.pathname.endsWith("/")
     ? authServerUrl.pathname.slice(0, -1)
     : authServerUrl.pathname;
@@ -143,9 +143,21 @@ export async function discoverAuthorizationServerMetadataViaProxy(
       { url: wellKnownUrl.toString() },
     );
   } catch (error) {
-    throw new Error(
-      `Failed to discover OAuth metadata: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    // If path-aware discovery fails and we have a non-root path, fall back to root discovery
+    if (pathname && pathname !== "/") {
+      const rootWellKnownUrl = new URL(
+        `/.well-known/oauth-authorization-server`,
+        authServerUrl,
+      );
+      return await proxyFetch<OAuthMetadata>(
+        "/oauth/metadata",
+        "GET",
+        config,
+        undefined,
+        { url: rootWellKnownUrl.toString() },
+      );
+    }
+    throw error;
   }
 }
 
@@ -179,9 +191,21 @@ export async function discoverOAuthProtectedResourceMetadataViaProxy(
       { url: wellKnownUrl.toString() },
     );
   } catch (error) {
-    throw new Error(
-      `Failed to discover resource metadata: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    // If path-aware discovery fails and we have a non-root path, fall back to root discovery
+    if (pathname && pathname !== "/") {
+      const rootWellKnownUrl = new URL(
+        `/.well-known/oauth-protected-resource`,
+        url,
+      );
+      return await proxyFetch<OAuthProtectedResourceMetadata>(
+        "/oauth/resource-metadata",
+        "GET",
+        config,
+        undefined,
+        { url: rootWellKnownUrl.toString() },
+      );
+    }
+    throw error;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "jest-fixed-jsdom": "^0.0.9",
         "lint-staged": "^16.1.5",
         "playwright": "^1.56.1",
-        "prettier": "^3.7.1",
+        "prettier": "^3.7.4",
         "rimraf": "^6.0.1",
         "typescript": "^5.4.2"
       },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "jest-fixed-jsdom": "^0.0.9",
     "lint-staged": "^16.1.5",
     "playwright": "^1.56.1",
-    "prettier": "^3.7.1",
+    "prettier": "^3.7.4",
     "rimraf": "^6.0.1",
     "typescript": "^5.4.2"
   },


### PR DESCRIPTION
## Problem

When users select "Via Proxy" as the Connection Type, OAuth authentication fails with CORS errors because OAuth operations bypass the proxy and execute directly from the browser.

Fixes #995

## Solution

Route all OAuth operations through the Express proxy server when connectionType is "proxy", following the same pattern as MCP server connections.

## Changes

### Server-Side (`server/src/index.ts`)
Added 4 OAuth proxy endpoints:
- `GET /oauth/metadata` - Authorization server metadata discovery
- `GET /oauth/resource-metadata` - Protected resource metadata discovery
- `POST /oauth/register` - Dynamic Client Registration (DCR)
- `POST /oauth/token` - Token exchange

### Client-Side
- **`client/src/lib/oauth-proxy.ts`** (new) - Proxy utility functions
- **`client/src/lib/oauth-state-machine.ts`** - Conditional routing based on connectionType
- **`client/src/components/AuthDebugger.tsx`** - Accepts connectionType/config props
- **`client/src/App.tsx`** - Provides connectionType and config
- **`client/src/lib/auth.ts`** - Fix scope to be optional per RFC 7591

## Testing

Tested successfully with Keycloak OAuth server. All OAuth operations work without CORS errors in proxy mode. Direct mode still functions for servers with proper CORS configuration.

## Backward Compatibility

No breaking changes. Direct connections work as before. Proxy mode is opt-in via existing "Connection Type" selector.

## Next Steps

Based on your feedback to this PR, I will add polish, tests, and documentation accordingly.