### PR TITLE
fix: detect 401 errors from `StreamableHTTP` transport in client

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -361,11 +361,6 @@ export function useConnection({
       (error instanceof SseError && error.code === 401) ||
       (error instanceof StreamableHTTPError && error.code === 401) ||
       (error instanceof Error && error.message.includes("401")) ||
-  const is401Error = (error: unknown): boolean => {
-    return (
-      (error instanceof SseError && error.code === 401) ||
-      (error instanceof StreamableHTTPError && error.code === 401) ||
-      (error instanceof Error && error.message.includes("401")) ||
       (error instanceof Error && error.message.includes("Unauthorized")) ||
       (error instanceof Error &&
         error.message.includes("Missing Authorization header"))


### PR DESCRIPTION
## Summary

Fix issue OAuth Flow was not triggered when using `StreamableHTTP` with `Direct` connection type.

> **Note:** Inspector V2 is under development to address architectural and UX improvements. During this time, V1 contributions should focus on **bug fixes and MCP spec compliance**. See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

Added `StreamableHTTPError` handling to `is401Error()` so 401 responses from the Streamable HTTP transport now trigger the existing auth-retry flow, keeping OAuth re-auth logic consistent across transport types.

## Related Issues

Fixes #982 and #960

## Testing

<!-- Describe how you tested these changes, where applicable -->

- [X] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [X] Tested with Streamable HTTP transport
- [ ] Added/updated automated tests
- [ ] Manual testing performed

### Test Results and/or Instructions

**How to test this fix:**
1. Set up an MCP server with OAuth protection that returns a WWW-Authenticate header on 401
2. Start the Inspector and select "Streamable HTTP" transport
3. Enter the OAuth-protected MCP server URL
4. Select "Direct" option in Connection Type
5. Click Connect
6. Expected (with fix): OAuth flow is triggered - user is redirected to Authorization page
7. Before fix: Shows "Connection Error - Check if your MCP server is running and proxy token is correct"

## Checklist

- [X] Code follows the style guidelines (ran `npm run prettier-fix`)
- [X] Self-review completed
- [X] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Additional Context

<!-- Add any other context, screenshots, or information about the PR here -->
