### PR TITLE
Fixed CLI tests that depended on specific version of server-everything

### DIFF
--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm run build
 
       - name: Explicitly pre-install test dependencies
-        run: npx -y @modelcontextprotocol/server-everything --help || true
+        run: npx -y @modelcontextprotocol/server-everything@2026.1.14 --help || true
 
       - name: Run tests
         run: npm test

--- a/cli/package.json
+++ b/cli/package.json
@@ -17,10 +17,11 @@
   "scripts": {
     "build": "tsc",
     "postbuild": "node scripts/make-executable.js",
-    "test": "node scripts/cli-tests.js && node scripts/cli-tool-tests.js && node scripts/cli-header-tests.js",
+    "test": "node scripts/cli-tests.js && node scripts/cli-tool-tests.js && node scripts/cli-header-tests.js && node scripts/cli-metadata-tests.js",
     "test:cli": "node scripts/cli-tests.js",
     "test:cli-tools": "node scripts/cli-tool-tests.js",
-    "test:cli-headers": "node scripts/cli-header-tests.js"
+    "test:cli-headers": "node scripts/cli-header-tests.js",
+    "test:cli-metadata": "node scripts/cli-metadata-tests.js"
   },
   "devDependencies": {},
   "dependencies": {

--- a/cli/scripts/cli-metadata-tests.js
+++ b/cli/scripts/cli-metadata-tests.js
@@ -56,7 +56,7 @@ const BUILD_DIR = path.resolve(SCRIPTS_DIR, "../build");
 
 // Define the test server command using npx
 const TEST_CMD = "npx";
-const TEST_ARGS = ["@modelcontextprotocol/server-everything"];
+const TEST_ARGS = ["@modelcontextprotocol/server-everything@2026.1.14"];
 
 // Create output directory for test results
 const OUTPUT_DIR = path.join(SCRIPTS_DIR, "metadata-test-output");
@@ -335,7 +335,7 @@ async function runTests() {
     "--method",
     "resources/read",
     "--uri",
-    "test://static/resource/1",
+    "demo://resource/static/document/architecture.md",
     "--metadata",
     "client=test-client",
   );
@@ -349,7 +349,7 @@ async function runTests() {
     "--method",
     "prompts/get",
     "--prompt-name",
-    "simple_prompt",
+    "simple-prompt",
     "--metadata",
     "client=test-client",
   );
@@ -383,7 +383,7 @@ async function runTests() {
     "--method",
     "tools/call",
     "--tool-name",
-    "add",
+    "get-sum",
     "--tool-arg",
     "a=10",
     "b=20",
@@ -566,7 +566,7 @@ async function runTests() {
     "--method",
     "prompts/get",
     "--prompt-name",
-    "simple_prompt",
+    "simple-prompt",
     "--metadata",
     "prompt_client=test-prompt-client",
   );

--- a/cli/scripts/cli-tests.js
+++ b/cli/scripts/cli-tests.js
@@ -56,8 +56,9 @@ const PROJECT_ROOT = path.join(SCRIPTS_DIR, "../../");
 const BUILD_DIR = path.resolve(SCRIPTS_DIR, "../build");
 
 // Define the test server command using npx
+const EVERYTHING_SERVER = "@modelcontextprotocol/server-everything@2026.1.14";
 const TEST_CMD = "npx";
-const TEST_ARGS = ["@modelcontextprotocol/server-everything"];
+const TEST_ARGS = [EVERYTHING_SERVER];
 
 // Create output directory for test results
 const OUTPUT_DIR = path.join(SCRIPTS_DIR, "test-output");
@@ -163,7 +164,7 @@ fs.writeFileSync(
         "test-stdio": {
           type: "stdio",
           command: "npx",
-          args: ["@modelcontextprotocol/server-everything"],
+          args: [EVERYTHING_SERVER],
           env: {
             TEST_ENV: "test-value",
           },
@@ -184,7 +185,7 @@ fs.writeFileSync(
       mcpServers: {
         "test-legacy": {
           command: "npx",
-          args: ["@modelcontextprotocol/server-everything"],
+          args: [EVERYTHING_SERVER],
           env: {
             LEGACY_ENV: "legacy-value",
           },
@@ -543,7 +544,7 @@ async function runTests() {
     "--method",
     "resources/read",
     "--uri",
-    "test://static/resource/1",
+    "demo://resource/static/document/architecture.md",
   );
 
   // Test 17: CLI mode with resource read but missing URI (should fail)
@@ -569,7 +570,7 @@ async function runTests() {
     "--method",
     "prompts/get",
     "--prompt-name",
-    "simple_prompt",
+    "simple-prompt",
   );
 
   // Test 19: CLI mode with prompt get and args
@@ -581,10 +582,10 @@ async function runTests() {
     "--method",
     "prompts/get",
     "--prompt-name",
-    "complex_prompt",
+    "args-prompt",
     "--prompt-args",
-    "temperature=0.7",
-    "style=concise",
+    "city=New York",
+    "state=NY",
   );
 
   // Test 20: CLI mode with prompt get but missing prompt name (should fail)
@@ -734,7 +735,7 @@ async function runTests() {
         mcpServers: {
           "only-server": {
             command: "npx",
-            args: ["@modelcontextprotocol/server-everything"],
+            args: [EVERYTHING_SERVER],
           },
         },
       },
@@ -755,7 +756,7 @@ async function runTests() {
         mcpServers: {
           "default-server": {
             command: "npx",
-            args: ["@modelcontextprotocol/server-everything"],
+            args: [EVERYTHING_SERVER],
           },
           "other-server": {
             command: "node",
@@ -777,7 +778,7 @@ async function runTests() {
         mcpServers: {
           server1: {
             command: "npx",
-            args: ["@modelcontextprotocol/server-everything"],
+            args: [EVERYTHING_SERVER],
           },
           server2: {
             command: "node",
@@ -827,14 +828,10 @@ async function runTests() {
   console.log(
     `${colors.BLUE}Starting server-everything in streamableHttp mode.${colors.NC}`,
   );
-  const httpServer = spawn(
-    "npx",
-    ["@modelcontextprotocol/server-everything", "streamableHttp"],
-    {
-      detached: true,
-      stdio: "ignore",
-    },
-  );
+  const httpServer = spawn("npx", [EVERYTHING_SERVER, "streamableHttp"], {
+    detached: true,
+    stdio: "ignore",
+  });
   runningServers.push(httpServer);
 
   await new Promise((resolve) => setTimeout(resolve, 3000));


### PR DESCRIPTION
## Summary

CLI tests depended on specific functionality of `server-everything`, which has changed, breaking a number of tests.

This PR:
- Pins server-everything (in CI and tests)
- Fixes all tests to work with current pinned version
- Fixes a problem with undetected failures (isError: true payloads).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [X] Test updates
- [X] Build/CI improvements

## Testing

- [ ] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [X] Added/updated automated tests
- [ ] Manual testing performed

### Test Results and/or Instructions

All tests now pass

## Checklist

- [X] Code follows the style guidelines (ran `npm run prettier-fix`)
- [X] Self-review completed
- [ ] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

No
