### PR TITLE
fix: skip output schema validation when tool result isError

### DIFF
--- a/client/src/components/ToolResults.tsx
+++ b/client/src/components/ToolResults.tsx
@@ -115,7 +115,7 @@ const ToolResults = ({
           error:
             "Tool has an output schema but did not return structured content",
         };
-      } else if (structuredResult.structuredContent) {
+      } else if (structuredResult.structuredContent && !isError) {
         validationResult = validateToolOutput(
           selectedTool.name,
           structuredResult.structuredContent,

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -483,6 +483,32 @@ describe("ToolsTab", () => {
       ).toBeInTheDocument();
     });
 
+    it("should not validate structuredContent against output schema when isError is true", () => {
+      const errorResult = {
+        content: [
+          {
+            type: "text",
+            text: "Something went wrong",
+          },
+        ],
+        structuredContent: {
+          errorCode: "NOT_FOUND",
+        },
+        isError: true,
+      };
+
+      renderToolsTab({
+        tools: [toolWithOutputSchema],
+        selectedTool: toolWithOutputSchema,
+        toolResult: errorResult,
+      });
+
+      // Should display structured content
+      expect(screen.getByText("Structured Content:")).toBeInTheDocument();
+      // Should NOT show a validation error
+      expect(screen.queryByText(/Validation Error:/)).not.toBeInTheDocument();
+    });
+
     it("should show unstructured content title when both structured and unstructured exist", () => {
       const resultWithBoth = {
         content: [{ type: "text", text: '{"temperature": 25}' }],


### PR DESCRIPTION
## Summary

When a tool returns `isError: true`, its `structuredContent` is not required to conform to the tool's `outputSchema`. The Inspector UI was still validating it, showing a spurious "Validation Error" that obscured the actual server-provided error message.

This is the Inspector-side counterpart to [modelcontextprotocol/typescript-sdk#1428](https://github.com/modelcontextprotocol/typescript-sdk/pull/1428), which fixes the same validation skip in the SDK's `callTool()` client method.

## Type of Change

- [x] Bug fix
- [x] Test updates

## Changes Made

- `client/src/components/ToolResults.tsx` — added `&& !isError` guard before calling `validateToolOutput`, matching the SDK behavior
- `client/src/components/__tests__/ToolsTab.test.tsx` — added test case confirming error results with non-conforming `structuredContent` do not  trigger validation errors

## Related Issues

Depends on [modelcontextprotocol/typescript-sdk#1428](https://github.com/modelcontextprotocol/typescript-sdk/pull/1428) for the SDK / CLI-level fix.

## Testing

- [x] Tested in UI mode
- [x] Tested with SSE transport
- [x] Added/updated automated tests

### Test Results and/or Instructions

1. Connect to an MCP server that has a tool with an `outputSchema`
2. Call the tool in a way that triggers an `isError: true` response with  `structuredContent` that doesn't match the schema
3. Verify the UI shows the server's error content without a "Validation Error" banner

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed

## Breaking Changes

None.

## Additional Context

Reproduced against IntelliJ's MCP server (`get_repositories` tool) which returns `isError: true` with `structuredContent` containing `projects` instead of the schema-required `roots`.

Before:
<img width="1727" height="685" alt="errors" src="https://github.com/user-attachments/assets/3b90d57f-96f2-4d9b-b75c-b17a95635885" />

After:
<img width="1703" height="777" alt="Screenshot 2026-02-02 at 5 00 18 PM" src="https://github.com/user-attachments/assets/85af3185-f065-4d00-a78a-59f85e8e439a" />

