### PR TITLE
feat(client): add timing information to request history and notifications

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,6 +19,7 @@ import {
   Task,
   GetTaskResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { TimestampedNotification } from "./lib/notificationTypes";
 import { OAuthTokensSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type {
   AnySchema,
@@ -154,7 +155,9 @@ const App = () => {
     },
   );
   const [logLevel, setLogLevel] = useState<LoggingLevel>("debug");
-  const [notifications, setNotifications] = useState<ServerNotification[]>([]);
+  const [notifications, setNotifications] = useState<TimestampedNotification[]>(
+    [],
+  );
   const [roots, setRoots] = useState<Root[]>([]);
   const [env, setEnv] = useState<Record<string, string>>({});
 
@@ -366,7 +369,11 @@ const App = () => {
     config,
     connectionType,
     onNotification: (notification) => {
-      setNotifications((prev) => [...prev, notification as ServerNotification]);
+      const timestamped: TimestampedNotification = {
+        notification: notification as ServerNotification,
+        receivedAt: new Date().toISOString(),
+      };
+      setNotifications((prev) => [...prev, timestamped]);
 
       if (notification.method === "notifications/tasks/list_changed") {
         void listTasks();

--- a/client/src/lib/notificationTypes.ts
+++ b/client/src/lib/notificationTypes.ts
@@ -2,6 +2,7 @@ import {
   NotificationSchema as BaseNotificationSchema,
   ClientNotificationSchema,
   ServerNotificationSchema,
+  ServerNotification,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { SchemaOutput } from "@modelcontextprotocol/sdk/server/zod-compat.js";
 
@@ -10,3 +11,8 @@ export const NotificationSchema = ClientNotificationSchema.or(
 ).or(BaseNotificationSchema);
 
 export type Notification = SchemaOutput<typeof NotificationSchema>;
+
+export interface TimestampedNotification {
+  notification: ServerNotification;
+  receivedAt: string; // ISO timestamp when received
+}

--- a/client/src/lib/types/requestHistory.ts
+++ b/client/src/lib/types/requestHistory.ts
@@ -1,0 +1,7 @@
+export interface RequestHistoryEntry {
+  request: string;
+  response?: string;
+  requestedAt: string; // ISO timestamp when request was sent
+  respondedAt?: string; // ISO timestamp when response received
+  durationMs?: number; // Calculated duration in ms
+}

--- a/client/src/utils/__tests__/timeUtils.test.ts
+++ b/client/src/utils/__tests__/timeUtils.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  formatDuration,
+  formatTimestamp,
+  formatTimestampFull,
+} from "../timeUtils";
+
+describe("timeUtils", () => {
+  describe("formatDuration", () => {
+    it("formats milliseconds for values under 1 second", () => {
+      expect(formatDuration(0)).toBe("0ms");
+      expect(formatDuration(1)).toBe("1ms");
+      expect(formatDuration(245)).toBe("245ms");
+      expect(formatDuration(999)).toBe("999ms");
+    });
+
+    it("formats seconds with one decimal for values under 10 seconds", () => {
+      expect(formatDuration(1000)).toBe("1.0s");
+      expect(formatDuration(1500)).toBe("1.5s");
+      expect(formatDuration(2400)).toBe("2.4s");
+      expect(formatDuration(9999)).toBe("10.0s");
+    });
+
+    it("formats seconds as integers for values 10 seconds and above", () => {
+      expect(formatDuration(10000)).toBe("10s");
+      expect(formatDuration(15000)).toBe("15s");
+      expect(formatDuration(59999)).toBe("60s");
+    });
+
+    it("formats minutes and seconds for values 1 minute and above", () => {
+      expect(formatDuration(60000)).toBe("1m");
+      expect(formatDuration(90000)).toBe("1m 30s");
+      expect(formatDuration(120000)).toBe("2m");
+      expect(formatDuration(150000)).toBe("2m 30s");
+    });
+
+    it("handles edge cases", () => {
+      expect(formatDuration(60001)).toBe("1m");
+      expect(formatDuration(61000)).toBe("1m 1s");
+    });
+  });
+
+  describe("formatTimestamp", () => {
+    it("formats ISO timestamp to time-only string", () => {
+      // Using a fixed date to ensure consistent output
+      const isoString = "2026-01-15T14:34:56.000Z";
+      const result = formatTimestamp(isoString);
+
+      // The exact output depends on locale, but it should contain time components
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe("string");
+    });
+  });
+
+  describe("formatTimestampFull", () => {
+    it("formats ISO timestamp to full date/time string", () => {
+      const isoString = "2026-01-15T14:34:56.000Z";
+      const result = formatTimestampFull(isoString);
+
+      // The exact output depends on locale, but it should contain date and time
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe("string");
+    });
+  });
+});

--- a/client/src/utils/timeUtils.ts
+++ b/client/src/utils/timeUtils.ts
@@ -1,0 +1,43 @@
+/**
+ * Format a duration in milliseconds to a human-readable string.
+ * Examples: "245ms", "2.4s", "1m 30s"
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+
+  if (ms < 60000) {
+    const seconds = ms / 1000;
+    // Show one decimal place for values under 10s
+    if (seconds < 10) {
+      return `${seconds.toFixed(1)}s`;
+    }
+    return `${Math.round(seconds)}s`;
+  }
+
+  const minutes = Math.floor(ms / 60000);
+  const seconds = Math.round((ms % 60000) / 1000);
+
+  if (seconds === 0) {
+    return `${minutes}m`;
+  }
+
+  return `${minutes}m ${seconds}s`;
+}
+
+/**
+ * Format an ISO timestamp to a time-only string (e.g., "2:34:56 PM").
+ */
+export function formatTimestamp(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleTimeString();
+}
+
+/**
+ * Format an ISO timestamp to a full date/time string (e.g., "1/15/2026, 2:34:56 PM").
+ */
+export function formatTimestampFull(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleString();
+}


### PR DESCRIPTION
## Summary

- Add request-to-response duration display (e.g., "245ms", "2.4s", "1m 30s") as blue badge next to method names
- Show timestamps for requests and server notifications in collapsed view
- Display full timing details (requested/responded timestamps with duration) in expanded view
- Add `TimestampedNotification` wrapper for server notifications with receive timestamps
- Add `RequestHistoryEntry` type with timing fields for request history

<img width="1604" height="1039" alt="image" src="https://github.com/user-attachments/assets/b5c5616d-c239-465f-8eb8-d781a319f7f1" />

<img width="571" height="293" alt="image" src="https://github.com/user-attachments/assets/ef9fec2b-a6b3-41e2-a159-5bb6a15cd91e" />


## Note on V2

This feature aligns with V2's existing design - the `HistoryEntry` type in `v2/core` already includes a `duration` field, and the V2 UX spec shows timing display. However, V2's timing capture isn't wired up yet. This PR provides the functionality for V1 users in the interim.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes  
- [x] All 459 unit tests pass
- [x] E2E tests pass (Chromium)
- [x] Manual testing: connect to MCP server, make requests, verify duration badges appear
- [x] Manual testing: expand history items and verify full timing details show
- [x] Manual testing: verify notification timestamps appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)