### PR TITLE
feat: add MCP_SERVER_ENDPOINT env var with transport auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,13 +241,14 @@ ALLOWED_ORIGINS=http://localhost:6274,http://localhost:8000 npm start
 
 The MCP Inspector supports the following configuration settings. To change them, click on the `Configuration` button in the MCP Inspector UI:
 
-| Setting                                 | Description                                                                                                                                         | Default |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `MCP_SERVER_REQUEST_TIMEOUT`            | Client-side timeout (ms) - Inspector will cancel the request if no response is received within this time. Note: servers may have their own timeouts | 300000  |
-| `MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS` | Reset timeout on progress notifications                                                                                                             | true    |
-| `MCP_REQUEST_MAX_TOTAL_TIMEOUT`         | Maximum total timeout for requests sent to the MCP server (ms) (Use with progress notifications)                                                    | 60000   |
-| `MCP_PROXY_FULL_ADDRESS`                | Set this if you are running the MCP Inspector Proxy on a non-default address. Example: http://10.1.1.22:5577                                        | ""      |
-| `MCP_AUTO_OPEN_ENABLED`                 | Enable automatic browser opening when inspector starts (works with authentication enabled). Only as environment var, not configurable in browser.   | true    |
+| Setting                                 | Description                                                                                                                                                                    | Default |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `MCP_SERVER_REQUEST_TIMEOUT`            | Client-side timeout (ms) - Inspector will cancel the request if no response is received within this time. Note: servers may have their own timeouts                            | 300000  |
+| `MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS` | Reset timeout on progress notifications                                                                                                                                        | true    |
+| `MCP_REQUEST_MAX_TOTAL_TIMEOUT`         | Maximum total timeout for requests sent to the MCP server (ms) (Use with progress notifications)                                                                               | 60000   |
+| `MCP_PROXY_FULL_ADDRESS`                | Set this if you are running the MCP Inspector Proxy on a non-default address. Example: http://10.1.1.22:5577                                                                   | ""      |
+| `MCP_AUTO_OPEN_ENABLED`                 | Enable automatic browser opening when inspector starts (works with authentication enabled). Only as environment var, not configurable in browser.                              | true    |
+| `MCP_SERVER_ENDPOINT`                   | Default MCP server endpoint to connect to on startup. Transport type is auto-detected from path (`/sse` → SSE, `/mcp` → Streamable HTTP). Example: `http://localhost:8080/sse` | ""      |
 
 **Note on Timeouts:** The timeout settings above control when the Inspector (as an MCP client) will cancel requests. These are independent of any server-side timeouts. For example, if a server tool has a 10-minute timeout but the Inspector's timeout is set to 30 seconds, the Inspector will cancel the request after 30 seconds. Conversely, if the Inspector's timeout is 10 minutes but the server times out after 30 seconds, you'll receive the server's timeout error. For tools that require user interaction (like elicitation) or long-running operations, ensure the Inspector's timeout is set appropriately.
 


### PR DESCRIPTION
## Summary

modelcontextprotocol/inspector is a great tool, that I use regularly to test my own MCP servers. In my environment the server endpoint of the mcp server changes (e.g. running multiple instances, port already occupied etc.) to address this I use either dotnet aspire or docker compose which will start the mcp server along with the inspector. I would like to pass the currently used mcp server endpoint as environment variable.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

`server/src/index.ts`:
  - Added detectTransportFromEndpoint() function to auto-detect transport type from URL path
  - Added MCP_SERVER_ENDPOINT environment variable support
  - Updated /config endpoint to return effective server URL and auto-detected transport
  - CLI args (--server-url, --transport) take precedence over env var

 `README.md`:
  - Added MCP_SERVER_ENDPOINT to the configuration table with description

### Usage example:
#### SSE transport (auto-detected from /sse path)
```bash
MCP_SERVER_ENDPOINT=http://localhost:8080/sse npx @modelcontextprotocol/inspector
```
#### Streamable HTTP transport (auto-detected from /mcp path)
```bash
MCP_SERVER_ENDPOINT=http://localhost:8080/mcp npx @modelcontextprotocol/inspector
```

## Related Issues

* original PR #288, I addressed the feedback given there in this PR

## Testing

<!-- Describe how you tested these changes, where applicable -->

- [x] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [x] Tested with SSE transport
- [x] Tested with Streamable HTTP transport
- [ ] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

```pwsh
$env:MCP_SERVER_ENDPOINT='http://localhost:1234/sse'
npm run start
```
<img width="584" height="752" alt="image" src="https://github.com/user-attachments/assets/d3ac2dfb-c791-42b4-8673-a997aa24cf28" />

```pwsh
$env:MCP_SERVER_ENDPOINT='http://localhost:5678/mcp'
npm run start
```
<img width="462" height="735" alt="image" src="https://github.com/user-attachments/assets/96667189-51ec-4b0e-8039-b1f3e5481700" />


## Checklist

- [ ] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [x] Documentation updated (README, comments, etc.)

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Additional Context

As this is a relatively small change, I hope it can get merged before V2 (architecture changes) are done, even if it is not a bugfix.
