### PR TITLE
Fixed test failures induced by MCP SDK update

### DIFF
--- a/cli/__tests__/helpers/assertions.ts
+++ b/cli/__tests__/helpers/assertions.ts
@@ -1,18 +1,30 @@
 import { expect } from "vitest";
 import type { CliResult } from "./cli-runner.js";
 
+function formatCliOutput(result: CliResult): string {
+  const out = result.stdout?.trim() || "(empty)";
+  const err = result.stderr?.trim() || "(empty)";
+  return `stdout: ${out}\nstderr: ${err}`;
+}
+
 /**
  * Assert that CLI command succeeded (exit code 0)
  */
 export function expectCliSuccess(result: CliResult) {
-  expect(result.exitCode).toBe(0);
+  expect(
+    result.exitCode,
+    `CLI exited with code ${result.exitCode}. ${formatCliOutput(result)}`,
+  ).toBe(0);
 }
 
 /**
  * Assert that CLI command failed (non-zero exit code)
  */
 export function expectCliFailure(result: CliResult) {
-  expect(result.exitCode).not.toBe(0);
+  expect(
+    result.exitCode,
+    `CLI unexpectedly exited with code ${result.exitCode}. ${formatCliOutput(result)}`,
+  ).not.toBe(0);
 }
 
 /**

--- a/cli/__tests__/helpers/fixtures.ts
+++ b/cli/__tests__/helpers/fixtures.ts
@@ -1,7 +1,7 @@
-import fs from "fs";
-import path from "path";
-import os from "os";
-import crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import * as crypto from "crypto";
 import { getTestMcpServerCommand } from "./test-server-stdio.js";
 
 /**


### PR DESCRIPTION
Fixed test failures induced by MCP SDK update (added session id generator to Streamable test server).  Cleanup up some port usage to avoid potential issues (always use port 0 for test servers). Added stdout/stderr to cli status assertion failures to make CLI test failures easier to debug from test output.

## Summary

MCP SDK v1.26.0 had security fix: Security advisory (GHSA-345p-7cg4-v4c7) which broke our StreamableHTTP test server (which lacked session id generation).  This PR fixes that and adds better test failure output and better test server port management.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] Test updates

## Testing

- [ ] Tested in UI mode
- [X] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [X] Added/updated automated tests
- [ ] Manual testing performed

## Checklist

- [X] Code follows the style guidelines (ran `npm run prettier-fix`)
- [X] Self-review completed
- [X] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)


