### PR TITLE
Manage display of "Run as Task" checkbox on Tools Tab

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1526,6 +1526,9 @@ const App = () => {
                       error={errors.prompts}
                     />
                     <ToolsTab
+                      serverSupportsTaskRequests={
+                        !!serverCapabilities?.tasks?.requests?.tools?.call
+                      }
                       tools={tools}
                       listTools={() => {
                         clearError("tools");

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -177,6 +177,7 @@ const ToolsTab = ({
   error,
   resourceContent,
   onReadResource,
+  serverSupportsTaskRequests,
 }: {
   tools: Tool[];
   listTools: () => void;
@@ -195,6 +196,7 @@ const ToolsTab = ({
   error: string | null;
   resourceContent: Record<string, string>;
   onReadResource?: (uri: string) => void;
+  serverSupportsTaskRequests: boolean;
 }) => {
   const [params, setParams] = useState<Record<string, unknown>>({});
   const [runAsTask, setRunAsTask] = useState(false);
@@ -239,15 +241,17 @@ const ToolsTab = ({
       ];
     });
     setParams(Object.fromEntries(params));
-    const taskSupport = getTaskSupport(selectedTool);
-    setRunAsTask(taskSupport === "required");
+    const toolTaskSupport = serverSupportsTaskRequests
+      ? getTaskSupport(selectedTool)
+      : "forbidden";
+    setRunAsTask(toolTaskSupport === "required");
 
     // Reset validation errors when switching tools
     setHasValidationErrors(false);
 
     // Clear form refs for the previous tool
     formRefs.current = {};
-  }, [selectedTool]);
+  }, [selectedTool, serverSupportsTaskRequests]);
 
   const hasReservedMetadataEntry = metadataEntries.some(({ key }) => {
     const trimmedKey = key.trim();
@@ -264,7 +268,9 @@ const ToolsTab = ({
     return trimmedKey !== "" && !hasValidMetaName(trimmedKey);
   });
 
-  const taskSupport = getTaskSupport(selectedTool);
+  const taskSupport = serverSupportsTaskRequests
+    ? getTaskSupport(selectedTool)
+    : "forbidden";
 
   return (
     <TabsContent value="tools">

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -73,6 +73,7 @@ describe("ToolsTab", () => {
     error: null,
     resourceContent: {},
     onReadResource: jest.fn(),
+    serverSupportsTaskRequests: true,
   };
 
   const renderToolsTab = (props = {}) => {
@@ -153,6 +154,38 @@ describe("ToolsTab", () => {
     expect(requiredCheckbox).toBeInTheDocument();
     expect(requiredCheckbox.getAttribute("aria-checked")).toBe("true");
     expect(requiredCheckbox).toBeDisabled();
+  });
+
+  it("should hide run-as-task checkbox when serverSupportsTaskRequests is false even for required/optional tools", async () => {
+    const requiredTool: ExtendedTool = {
+      ...mockTools[0],
+      name: "requiredTool",
+      execution: { taskSupport: "required" },
+    };
+    const optionalTool: ExtendedTool = {
+      ...mockTools[0],
+      name: "optionalTool",
+      execution: { taskSupport: "optional" },
+    };
+
+    const { rerender } = renderToolsTab({
+      selectedTool: requiredTool,
+      serverSupportsTaskRequests: false,
+    });
+
+    expect(screen.queryByLabelText(/run as task/i)).not.toBeInTheDocument();
+
+    rerender(
+      <Tabs defaultValue="tools">
+        <ToolsTab
+          {...defaultProps}
+          selectedTool={optionalTool}
+          serverSupportsTaskRequests={false}
+        />
+      </Tabs>,
+    );
+
+    expect(screen.queryByLabelText(/run as task/i)).not.toBeInTheDocument();
   });
 
   it("should handle integer type inputs", async () => {


### PR DESCRIPTION
## Summary
The "Run as Task" button is always available on the Tools Tab. But if a tool that cannot be run as a task has this checkbox checked when you run it, you get an error. This is confusing, because the availability of the "Run as Task" checkbox would indicate to a user that this tool could be run as a task.

* "Run as Task" is hidden for tools whose `execution.taskSupport` setting is `forbidden`. 
* "Run as Task" is shown, enabled, and unchecked for tools whose `execution.taskSupport` setting is `optional`.
* "Run as Task" is shown, disabled, and checked for tools whose `execution.taskSupport` setting is `required`. 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made
* In ToolsTab.tsx
  - define ExtendedTool interface for augmenting with execution, meta, icons
  - in hasMeta function,
    - cast tool as ExtendedTool
  - add getTaskSupport function
    - returns forbidden if input is not a tool
    - returns the setting of execution.taskSupport if set and valid
    - returns optional otherwise
    - in useEffect map callback
      - set runAsTask to true if getTaskSupport returns "required", else false
    - in IconDisplay instances cast tool as ExtendedTool instead of as WithIcons
    - hide "Run as Task" checkbox if getTaskSupport returns "forbidden" for the selected tool
    - disable the "Run as Task" checkbox if getTaskSupport returns "required"
* In ToolsTab.test.tsx
  - added unit test
    - "should show/hide/disable run-as-task checkbox based on taskSupport"
      - tests checkbox checked and disabled states for "forbidden", "required", and "optional" states

## Related Issues
* Fixes https://github.com/modelcontextprotocol/inspector/issues/1071

## Testing
- [x] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [x] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

1. Run the Everything server `npx @modelcontextprotocol/server-everything@latest streamableHttp`
2. Run the Inspector: `npx @modelcontextprotocol/inspector@latest`
3. Click Connect
4. Click List Tools
5. Click "Echo" tool in list _(this tool's `execution.taskSupport` setting is "forbidden")_
7. See "Run as Task" checkbox is not available.
8. Click "Simulate Research Query" tool in list
9. See "Run as Task" checkbox is available, checked, and disabled _(this tool's `execution.taskSupport` setting is "required")_
NOTE: We don't have a tool that has an `execution.taskSupport` setting of "optional", but it's unit tested.

### `taskSupport == "forbidden"`
<img width="795" height="416" alt="Screenshot 2026-02-06 at 4 31 41 PM" src="https://github.com/user-attachments/assets/97ae146a-fb72-4de7-b8d9-1ca1bb373003" />

### `taskSupport == "required"`
<img width="795" height="554" alt="Screenshot 2026-02-06 at 4 32 58 PM" src="https://github.com/user-attachments/assets/9c521f10-eef0-4dd8-b085-0ba757ff7e92" />

## Checklist

- [x ] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [] Documentation updated (README, comments, etc.)

## Breaking Changes
Nope.
