### PR TITLE
scripts: avoid execSync

### DIFF
--- a/cli/scripts/make-executable.js
+++ b/cli/scripts/make-executable.js
@@ -3,7 +3,7 @@
  */
 import { promises as fs } from "fs";
 import { platform } from "os";
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 import path from "path";
 
 const TARGET_FILE = path.resolve("build/cli.js");
@@ -12,7 +12,10 @@ async function makeExecutable() {
   try {
     // On Unix-like systems (Linux, macOS), use chmod
     if (platform() !== "win32") {
-      execSync(`chmod +x "${TARGET_FILE}"`);
+      const r = spawnSync("chmod", ["+x", TARGET_FILE], { stdio: "inherit" });
+      if (r.error) throw r.error;
+      if (r.status !== 0)
+        throw new Error(`chmod failed with exit code ${r.status}`);
       console.log("Made file executable with chmod");
     } else {
       // On Windows, no need to make files "executable" in the Unix sense

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -2,7 +2,7 @@
 
 import fs from "fs";
 import path from "path";
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -84,7 +84,11 @@ console.log(`Updated ${updatedFiles.length} files to version ${newVersion}`);
 // Update package-lock.json
 console.log("\n🔒 Updating package-lock.json...");
 try {
-  execSync("npm install", { stdio: "inherit" });
+  const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+  const r = spawnSync(npmCmd, ["install"], { stdio: "inherit" });
+  if (r.error) throw r.error;
+  if (r.status !== 0)
+    throw new Error(`npm install failed with exit code ${r.status}`);
   console.log("✅ package-lock.json updated successfully");
 } catch (error) {
   console.error("❌ Failed to update package-lock.json:", error.message);


### PR DESCRIPTION
Replace shell-based `execSync` calls with `spawnSync` (no shell) in release/build helper scripts.\n\nThis reduces the risk of accidental shell injection and aligns with the MCP hardening guidance to avoid shell execution when possible.