### PR TITLE
fix: pre-flight port check and graceful shutdown to prevent EADDRINUSE

### DIFF
--- a/client/bin/client.js
+++ b/client/bin/client.js
@@ -5,9 +5,39 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import handler from "serve-handler";
 import http from "http";
+import net from "net";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const distPath = join(__dirname, "../dist");
+
+const port = parseInt(process.env.CLIENT_PORT || "6274", 10);
+const host = process.env.HOST || "localhost";
+
+// Check port availability before attempting to bind.
+// Prevents confusing EADDRINUSE errors from stale processes.
+function checkPort(targetHost, targetPort) {
+  return new Promise((resolve) => {
+    const tester = net.createServer();
+    tester.once("error", (err) => {
+      resolve(false);
+    });
+    tester.once("listening", () => {
+      tester.close(() => resolve(true));
+    });
+    tester.listen(targetPort, targetHost);
+  });
+}
+
+const portFree = await checkPort(host, port);
+if (!portFree) {
+  console.error(
+    `❌  MCP Inspector PORT IS IN USE at http://${host}:${port} ❌ `,
+  );
+  console.error(
+    `💡 To fix: run "lsof -ti:${port} | xargs kill -9" to free the port, or set CLIENT_PORT to use a different port.`,
+  );
+  process.exit(1);
+}
 
 const server = http.createServer((request, response) => {
   const handlerOptions = {
@@ -40,8 +70,6 @@ const server = http.createServer((request, response) => {
   return handler(request, response, handlerOptions);
 });
 
-const port = parseInt(process.env.CLIENT_PORT || "6274", 10);
-const host = process.env.HOST || "localhost";
 server.on("listening", () => {
   const url = process.env.INSPECTOR_URL || `http://${host}:${port}`;
   console.log(`\n🚀 MCP Inspector is up and running at:\n   ${url}\n`);
@@ -58,5 +86,20 @@ server.on("error", (err) => {
   } else {
     throw err;
   }
+  process.exit(1);
 });
+
+// Graceful shutdown: properly close the HTTP server so the port is
+// released immediately instead of lingering in CLOSE_WAIT state.
+function shutdown() {
+  server.close(() => {
+    process.exit(0);
+  });
+  // Force exit if close takes too long (e.g. hanging connections)
+  setTimeout(() => process.exit(0), 3000);
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
 server.listen(port, host);


### PR DESCRIPTION
## Summary

Fixes a race condition where the MCP Inspector reports "PORT IS IN USE" even when ports are confirmed free, and leaves ports in CLOSE_WAIT state after Ctrl+C — causing the error to persist across restarts.

**Three bugs identified and fixed:**

1. **No pre-flight port availability check** — Both the client (`client/bin/client.js`) and proxy server (`server/src/index.ts`) attempted to bind directly via `server.listen()` without first verifying the port was free. When a stale process held the port, users received a confusing `EADDRINUSE` error with no actionable guidance.

2. **Missing `process.exit(1)` in client EADDRINUSE handler** — The client's error handler logged the error but never called `process.exit(1)`, leaving the process hanging indefinitely. Users had to manually kill the process.

3. **No SIGINT/SIGTERM graceful shutdown** — Neither the client nor server registered signal handlers, so `Ctrl+C` left TCP sockets in `CLOSE_WAIT` state. The OS wouldn't release the port, causing the next launch to fail with `EADDRINUSE` — even though `lsof` showed no process on the port.

## Changes

### `client/bin/client.js`
- Added `import net from "net"`
- Added `checkPort()` function that attempts a test bind before the real `server.listen()`
- Moved `port` and `host` declarations above the check so they're available for the pre-flight test
- Added `process.exit(1)` to the existing EADDRINUSE error handler
- Added SIGINT/SIGTERM handlers with `server.close()` for graceful shutdown (3s force-exit timeout)
- Added actionable `lsof`/`kill` instructions in error messages

### `server/src/index.ts`
- Added `import net from "net"` with other imports at the top of the file
- Added typed `checkPort()` function (`Promise<boolean>`) before `app.listen()`
- Added SIGINT/SIGTERM handlers with `server.close()` for graceful shutdown (3s force-exit timeout)

## How to test

1. Start the Inspector: `npx @modelcontextprotocol/inspector`
2. Ctrl+C to stop — port should be released immediately
3. Restart immediately — should start cleanly without EADDRINUSE
4. Start Inspector, then in another terminal start a second instance on the same port — should get a clear error with `lsof`/`kill` fix instructions and exit cleanly

## Test plan

- [ ] Verify Inspector starts normally on default ports (6274/6277)
- [ ] Verify Ctrl+C releases ports immediately (no CLOSE_WAIT)
- [ ] Verify immediate restart after Ctrl+C works without EADDRINUSE
- [ ] Verify clear error + exit when port is genuinely in use
- [ ] Verify `CLIENT_PORT` / `SERVER_PORT` env var overrides still work
- [ ] Verify Windows compatibility (no platform-specific APIs used)

Resolves #1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)