### PR TITLE
oauth: add tenant suffix to oauth flow

### DIFF
--- a/client/src/components/OAuthFlowProgress.tsx
+++ b/client/src/components/OAuthFlowProgress.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { OAuthClientInformation } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { validateRedirectUrl } from "@/utils/urlValidation";
 import { useToast } from "@/lib/hooks/useToast";
+import { getAuthorizationServerMetadataDiscoveryUrl } from "@/utils/oauthUtils";
 
 interface OAuthStepProps {
   label: string;
@@ -81,6 +82,13 @@ export const OAuthFlowProgress = ({
   const [clientInfo, setClientInfo] = useState<OAuthClientInformation | null>(
     null,
   );
+  const authorizationServerMetadataDiscoveryUrl = useMemo(() => {
+    if (!authState.authServerUrl) {
+      return null;
+    }
+
+    return getAuthorizationServerMetadataDiscoveryUrl(authState.authServerUrl);
+  }, [authState.authServerUrl]);
 
   const currentStepIdx = steps.findIndex((s) => s === authState.oauthStep);
 
@@ -197,13 +205,7 @@ export const OAuthFlowProgress = ({
                   <p className="font-medium">Authorization Server Metadata:</p>
                   {authState.authServerUrl && (
                     <p className="text-xs text-muted-foreground">
-                      From{" "}
-                      {
-                        new URL(
-                          "/.well-known/oauth-authorization-server",
-                          authState.authServerUrl,
-                        ).href
-                      }
+                      From {authorizationServerMetadataDiscoveryUrl}
                     </p>
                   )}
                   <pre className="mt-2 p-2 bg-muted rounded-md overflow-auto max-h-[300px]">

--- a/client/src/components/__tests__/AuthDebugger.test.tsx
+++ b/client/src/components/__tests__/AuthDebugger.test.tsx
@@ -681,7 +681,7 @@ describe("AuthDebugger", () => {
       const updateAuthState = jest.fn();
       const mockResourceMetadata = {
         resource: "https://example.com/mcp",
-        authorization_servers: ["https://custom-auth.example.com"],
+        authorization_servers: ["https://custom-auth.example.com/mcp/tenant"],
         bearer_methods_supported: ["header", "body"],
         resource_documentation: "https://example.com/mcp/docs",
         resource_policy_uri: "https://example.com/mcp/policy",
@@ -733,11 +733,17 @@ describe("AuthDebugger", () => {
         expect(updateAuthState).toHaveBeenCalledWith(
           expect.objectContaining({
             resourceMetadata: mockResourceMetadata,
-            authServerUrl: new URL("https://custom-auth.example.com"),
+            authServerUrl: new URL(
+              "https://custom-auth.example.com/mcp/tenant",
+            ),
             oauthStep: "client_registration",
           }),
         );
       });
+
+      expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenCalledWith(
+        new URL("https://custom-auth.example.com/mcp/tenant"),
+      );
     });
 
     it("should handle protected resource metadata fetch failure gracefully", async () => {

--- a/client/src/utils/__tests__/oauthUtils.test.ts
+++ b/client/src/utils/__tests__/oauthUtils.test.ts
@@ -2,6 +2,7 @@ import {
   generateOAuthErrorDescription,
   parseOAuthCallbackParams,
   generateOAuthState,
+  getAuthorizationServerMetadataDiscoveryUrl,
 } from "@/utils/oauthUtils.ts";
 
 describe("parseOAuthCallbackParams", () => {
@@ -82,5 +83,31 @@ describe("generateOAuthErrorDescription", () => {
       expect(generateOAuthState()).toBeDefined();
       expect(generateOAuthState()).toHaveLength(64);
     });
+  });
+});
+
+describe("getAuthorizationServerMetadataDiscoveryUrl", () => {
+  it("uses root discovery URL for root authorization server URL", () => {
+    expect(
+      getAuthorizationServerMetadataDiscoveryUrl("https://example.com"),
+    ).toBe("https://example.com/.well-known/oauth-authorization-server");
+  });
+
+  it("inserts tenant path for non-root authorization server URL", () => {
+    expect(
+      getAuthorizationServerMetadataDiscoveryUrl("https://example.com/tenant1"),
+    ).toBe(
+      "https://example.com/.well-known/oauth-authorization-server/tenant1",
+    );
+  });
+
+  it("strips trailing slash before appending tenant path", () => {
+    expect(
+      getAuthorizationServerMetadataDiscoveryUrl(
+        "https://example.com/tenant1/",
+      ),
+    ).toBe(
+      "https://example.com/.well-known/oauth-authorization-server/tenant1",
+    );
   });
 });

--- a/client/src/utils/oauthUtils.ts
+++ b/client/src/utils/oauthUtils.ts
@@ -87,3 +87,31 @@ export const generateOAuthErrorDescription = (
     .filter(Boolean)
     .join("\n");
 };
+
+/**
+ * Returns the primary OAuth authorization server metadata discovery URL
+ * for a given authorization server URL, including tenant path handling.
+ */
+export const getAuthorizationServerMetadataDiscoveryUrl = (
+  authorizationServerUrl: string | URL,
+): string => {
+  const url =
+    typeof authorizationServerUrl === "string"
+      ? new URL(authorizationServerUrl)
+      : authorizationServerUrl;
+  const hasPath = url.pathname !== "/";
+
+  if (!hasPath) {
+    return new URL("/.well-known/oauth-authorization-server", url.origin).href;
+  }
+
+  // Strip trailing slash to avoid double slashes in tenant-aware discovery URLs.
+  const pathname = url.pathname.endsWith("/")
+    ? url.pathname.slice(0, -1)
+    : url.pathname;
+
+  return new URL(
+    `/.well-known/oauth-authorization-server${pathname}`,
+    url.origin,
+  ).href;
+};


### PR DESCRIPTION
## Summary

Fix https://github.com/modelcontextprotocol/inspector/issues/1095

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

This adds spec compliant Authorization Server Metadata Discovery

## Related Issues

Fix https://github.com/modelcontextprotocol/inspector/issues/1095

<!-- Link to related issues using #issue_number or "Fixes #issue_number" -->

## Testing

<!-- Describe how you tested these changes, where applicable -->

- [x] Tested in UI mode
- [] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [x] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

<!-- Provide steps for reviewers to test your changes -->

Screenshots are encouraged to share your testing results for this change.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [x] Documentation updated (README, comments, etc.)

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Additional Context

<!-- Add any other context, screenshots, or information about the PR here -->
