### PR TITLE
fix: exclude x-custom-auth-headers from direct connections

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -558,8 +558,11 @@ export function useConnection({
         }
       });
 
-      // Add custom header names as a special request header for server processing
-      if (customHeaderNames.length > 0) {
+      // Add custom header names as a special request header for proxy server processing.
+      // Only include this meta-header for proxied connections — direct connections send
+      // headers straight to the MCP server, which won't include x-custom-auth-headers
+      // in its Access-Control-Allow-Headers, breaking CORS preflight checks.
+      if (customHeaderNames.length > 0 && connectionType !== "direct") {
         headers["x-custom-auth-headers"] = JSON.stringify(customHeaderNames);
       }
 


### PR DESCRIPTION
## Problem

When using direct connections (not proxied), the inspector sends `x-custom-auth-headers` to the MCP server. This meta-header is a proxy implementation detail — MCP servers don't expect it and won't list it in `Access-Control-Allow-Headers`, causing the browser to block the request during CORS preflight.

## Fix

Only add the `x-custom-auth-headers` meta-header when using proxied connections (`connectionType !== "direct"`). Custom headers themselves are still sent normally in both modes — only the metadata header used by the proxy server is excluded.

## Testing

Added a test verifying that direct connections with custom headers:
- ✅ Send the actual custom headers (e.g., `X-Tenant-ID`)
- ✅ Do NOT send the `x-custom-auth-headers` meta-header

Fixes #1100