### PR TITLE
fix: omit x-custom-auth-headers in direct connections to prevent CORS failures

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -559,7 +559,9 @@ export function useConnection({
       });
 
       // Add custom header names as a special request header for server processing
-      if (customHeaderNames.length > 0) {
+      // Only add when using proxy connection — this is a proxy implementation detail
+      // that would break CORS on direct connections (see #1100)
+      if (customHeaderNames.length > 0 && connectionType !== "direct") {
         headers["x-custom-auth-headers"] = JSON.stringify(customHeaderNames);
       }
 


### PR DESCRIPTION
## Problem

`x-custom-auth-headers` is a proxy implementation detail — the inspector server uses it to know which custom headers to forward to the MCP server. However, this header is currently added unconditionally to all requests, including **direct connections** that bypass the proxy.

When connecting directly, the MCP server receives `x-custom-auth-headers` but doesn't recognize it and doesn't include it in `Access-Control-Allow-Headers`. The browser's CORS preflight check then fails, blocking the entire connection.

Fixes #1100

## Solution

Only add `x-custom-auth-headers` when `connectionType !== "direct"` — i.e., when the request goes through the inspector proxy, which is the only place that header is consumed.

## Changes

- `client/src/lib/hooks/useConnection.ts`: Conditionally add `x-custom-auth-headers` only for proxy connections
- `client/src/lib/hooks/__tests__/useConnection.test.tsx`: Added test verifying `x-custom-auth-headers` is omitted in direct connections