### PR TITLE
Fix resource metadata discovery URL construction to comply with MCP spec for subpath deployments

### DIFF
--- a/client/src/components/OAuthFlowProgress.tsx
+++ b/client/src/components/OAuthFlowProgress.tsx
@@ -6,7 +6,10 @@ import { useEffect, useMemo, useState } from "react";
 import { OAuthClientInformation } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { validateRedirectUrl } from "@/utils/urlValidation";
 import { useToast } from "@/lib/hooks/useToast";
-import { getAuthorizationServerMetadataDiscoveryUrl } from "@/utils/oauthUtils";
+import {
+  getAuthorizationServerMetadataDiscoveryUrl,
+  getResourceMetadataDiscoveryUrl,
+} from "@/utils/oauthUtils";
 
 interface OAuthStepProps {
   label: string;
@@ -90,6 +93,11 @@ export const OAuthFlowProgress = ({
     return getAuthorizationServerMetadataDiscoveryUrl(authState.authServerUrl);
   }, [authState.authServerUrl]);
 
+  const resourceMetadataDiscoveryUrl = useMemo(
+    () => getResourceMetadataDiscoveryUrl(serverUrl),
+    [serverUrl],
+  );
+
   const currentStepIdx = steps.findIndex((s) => s === authState.oauthStep);
 
   useEffect(() => {
@@ -150,13 +158,7 @@ export const OAuthFlowProgress = ({
                 <div className="mt-2">
                   <p className="font-medium">Resource Metadata:</p>
                   <p className="text-xs text-muted-foreground">
-                    From{" "}
-                    {
-                      new URL(
-                        "/.well-known/oauth-protected-resource",
-                        serverUrl,
-                      ).href
-                    }
+                    From {resourceMetadataDiscoveryUrl}
                   </p>
                   <pre className="mt-2 p-2 bg-muted rounded-md overflow-auto max-h-[300px]">
                     {JSON.stringify(authState.resourceMetadata, null, 2)}
@@ -169,22 +171,12 @@ export const OAuthFlowProgress = ({
                   <p className="text-sm font-medium text-blue-700">
                     ℹ️ Problem with resource metadata from{" "}
                     <a
-                      href={
-                        new URL(
-                          "/.well-known/oauth-protected-resource",
-                          serverUrl,
-                        ).href
-                      }
+                      href={resourceMetadataDiscoveryUrl}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-blue-500 hover:text-blue-700"
                     >
-                      {
-                        new URL(
-                          "/.well-known/oauth-protected-resource",
-                          serverUrl,
-                        ).href
-                      }
+                      {resourceMetadataDiscoveryUrl}
                     </a>
                   </p>
                   <p className="text-xs text-blue-600 mt-1">

--- a/client/src/utils/__tests__/oauthUtils.test.ts
+++ b/client/src/utils/__tests__/oauthUtils.test.ts
@@ -3,6 +3,7 @@ import {
   parseOAuthCallbackParams,
   generateOAuthState,
   getAuthorizationServerMetadataDiscoveryUrl,
+  getResourceMetadataDiscoveryUrl,
 } from "@/utils/oauthUtils.ts";
 
 describe("parseOAuthCallbackParams", () => {
@@ -83,6 +84,54 @@ describe("generateOAuthErrorDescription", () => {
       expect(generateOAuthState()).toBeDefined();
       expect(generateOAuthState()).toHaveLength(64);
     });
+  });
+});
+
+describe("getResourceMetadataDiscoveryUrl", () => {
+  it("appends single-segment resource path after well-known prefix", () => {
+    expect(
+      getResourceMetadataDiscoveryUrl("https://example.com/resource"),
+    ).toBe("https://example.com/.well-known/oauth-protected-resource/resource");
+  });
+
+  it("appends full subpath resource path after well-known prefix", () => {
+    expect(
+      getResourceMetadataDiscoveryUrl("https://example.com/public/mcp"),
+    ).toBe(
+      "https://example.com/.well-known/oauth-protected-resource/public/mcp",
+    );
+  });
+
+  it("appends deeply nested resource path after well-known prefix", () => {
+    expect(
+      getResourceMetadataDiscoveryUrl("https://example.com/foo/bar/resource"),
+    ).toBe(
+      "https://example.com/.well-known/oauth-protected-resource/foo/bar/resource",
+    );
+  });
+
+  it("strips trailing slash before appending resource path", () => {
+    expect(
+      getResourceMetadataDiscoveryUrl("https://example.com/public/mcp/"),
+    ).toBe(
+      "https://example.com/.well-known/oauth-protected-resource/public/mcp",
+    );
+  });
+
+  it("returns bare well-known URL when resource URL has no path", () => {
+    expect(getResourceMetadataDiscoveryUrl("https://example.com")).toBe(
+      "https://example.com/.well-known/oauth-protected-resource",
+    );
+  });
+
+  it("accepts a URL object as input", () => {
+    expect(
+      getResourceMetadataDiscoveryUrl(
+        new URL("https://example.com/public/mcp"),
+      ),
+    ).toBe(
+      "https://example.com/.well-known/oauth-protected-resource/public/mcp",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `getResourceMetadataDiscoveryUrl()` utility in `oauthUtils.ts` that correctly constructs the protected resource metadata discovery URL per RFC 9728 §3 and the MCP spec
- Replaces all three inline `new URL("/.well-known/oauth-protected-resource", serverUrl)` usages in `OAuthFlowProgress.tsx` with the new utility via a memoized `resourceMetadataDiscoveryUrl` variable
- Adds 6 unit tests covering: single-segment path, subpath, deep path, trailing slash, no path, and URL object input

## Problem

The previous code used:
```js
new URL("/.well-known/oauth-protected-resource", serverUrl)
```
This always resolves to the **host root**, ignoring the resource endpoint path entirely. For subpath-deployed MCP servers (e.g. `https://host/public/mcp`), the metadata URL was incorrectly constructed as `https://host/.well-known/oauth-protected-resource` instead of `https://host/.well-known/oauth-protected-resource/public/mcp`.

Fixes #1008.

## Spec Compliance

Per [RFC 9728 §3](https://www.rfc-editor.org/rfc/rfc9728#section-3) and the [MCP spec §authorization#protected-resource-metadata-discovery-requirements](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#protected-resource-metadata-discovery-requirements), the well-known URL is formed by inserting `/.well-known/oauth-protected-resource` at the origin root and appending the full resource path after it:

| Resource URL | Correct metadata URL |
|---|---|
| `https://host/public/mcp` | `https://host/.well-known/oauth-protected-resource/public/mcp` |
| `https://host/resource` | `https://host/.well-known/oauth-protected-resource/resource` |
| `https://host` (no path) | `https://host/.well-known/oauth-protected-resource` |

This matches the MCP SDK's own implementation: `` new URL(`/.well-known/oauth-protected-resource${rsPath}`, u) ``.

## Test plan

- [x] All existing unit tests pass (`npm test` in `client/`)
- [x] New tests cover: single-segment path, subpath, deep path, trailing slash, no-path URL, URL object input
- [ ] Manual: connect to a subpath-deployed MCP server and verify the resource metadata URL resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)