### PR TITLE
fix: include server/static in published package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "client/bin",
     "client/dist",
     "server/build",
+    "server/static",
     "cli/build"
   ],
   "workspaces": [

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "build",
+    "static",
     "LICENSE"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary

The MCP Apps sandbox proxy fails to load when the inspector is installed from npm. The `/sandbox` endpoint returns:

```
MCP Apps sandbox not loaded: Error: ENOENT: no such file or directory, open '.../server/static/sandbox_proxy.html'
```

The `files` arrays in `package.json` and `server/package.json` only include `build/`, so `server/static/` is excluded from the published package. The server resolves the file via `join(__dirname, "..", "static", "sandbox_proxy.html")` — which works from a repo checkout (where `server/static/` exists alongside `server/src/`), but not from the npm package where only `server/build/` is shipped.

This doesn't surface during development because the source directory layout satisfies the path. It only breaks for consumers installing from npm.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

Added `"server/static"` to the root `files` array and `"static"` to `server/package.json` `files` array. No code changes.

## Related Issues

Couldn't find an existing issue — happy to open one if preferred.

## Testing

- [x] Tested in UI mode
- [x] Tested with Streamable HTTP transport
- [x] Manual testing performed

### Test Results and/or Instructions

**Reproduce:** Install the inspector from npm, connect to an MCP server with tools that have `_meta.ui.resourceUri`, open the Apps tab — sandbox fails with ENOENT.

**Verify:** `npm pack --dry-run` should now include `server/static/sandbox_proxy.html` in the tarball. Before this change it only included `server/build/static/sandbox_proxy.html` (which the code never resolves to).

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [x] Documentation updated (README, comments, etc.)

## Breaking Changes

None.
