### PR TITLE
fix: register both OAuth redirect URIs to avoid DCR conflict

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -146,10 +146,12 @@ export class InspectorOAuthClientProvider implements OAuthClientProvider {
   }
 
   get redirect_uris() {
-    // Normally register both redirect URIs to support both normal and debug flows
-    // In debug subclass, redirectUrl may be the same as debugRedirectUrl, so remove duplicates
-    // See: https://github.com/modelcontextprotocol/inspector/issues/825
-    return [...new Set([this.redirectUrl, this.debugRedirectUrl])];
+    // Always register both redirect URIs regardless of which subclass is used,
+    // so that a single client registration works for both normal and debug flows.
+    return [
+      window.location.origin + "/oauth/callback",
+      window.location.origin + "/oauth/callback/debug",
+    ];
   }
 
   get clientMetadata(): OAuthClientMetadata {


### PR DESCRIPTION
## Summary

- **Bug:** When the Auth Debugger performs OAuth Dynamic Client Registration (DCR) first, the client is registered with only the debug redirect URI (`/oauth/callback/debug`). The normal "Connect" flow then fails because `/oauth/callback` is not a registered redirect URI.
- **Root cause:** `redirect_uris` getter used `this.redirectUrl`, which `DebugInspectorOAuthClientProvider` overrides to return the debug URL. The `Set` deduplication collapsed both entries into just the debug URI.
- **Fix:** Hardcode both redirect URIs in the `redirect_uris` getter so they are always registered regardless of which subclass is used.

## Test plan

- [x] `npm run build-client` passes
- [x] `cd client && npm run lint` passes
- [ ] Manual test: use Auth Debugger first, then try normal Connect — both should work with the same registered client