### PR TITLE
fix: preserve DCR client info on disconnect to avoid re-registration errors

### DIFF
--- a/client/src/components/__tests__/AuthDebugger.test.tsx
+++ b/client/src/components/__tests__/AuthDebugger.test.tsx
@@ -64,7 +64,6 @@ jest.mock("@/lib/auth", () => ({
     clear: jest.fn().mockImplementation(() => {
       // Mock the real clear() behavior which removes items from sessionStorage
       sessionStorage.removeItem("[https://example.com/mcp] mcp_tokens");
-      sessionStorage.removeItem("[https://example.com/mcp] mcp_client_info");
       sessionStorage.removeItem(
         "[https://example.com/mcp] mcp_server_metadata",
       );

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -245,10 +245,6 @@ export class InspectorOAuthClientProvider implements OAuthClientProvider {
   }
 
   clear() {
-    clearClientInformationFromSessionStorage({
-      serverUrl: this.serverUrl,
-      isPreregistered: false,
-    });
     sessionStorage.removeItem(
       getServerSpecificKey(SESSION_KEYS.TOKENS, this.serverUrl),
     );


### PR DESCRIPTION
## Summary

- **Bug:** On disconnect/reconnect, the Inspector clears all OAuth session state including the dynamically registered client information (client_id, client_secret). However, the DCR-obtained client_id remains valid at the IDP, so discarding it forces an unnecessary re-registration that IDPs like Keycloak reject with a conflict error.
- **Root cause:** `clear()` in `auth.ts` was wiping `clientInformation` from sessionStorage along with tokens and code verifier.
- **Fix:** Stop clearing dynamically registered client information in `clear()`. Only tokens and transient OAuth state are cleared, preserving the still-valid DCR client credentials for reconnection.

## Test plan

- [x] `npm run build-client` passes
- [x] `cd client && npm run lint` passes
- [ ] Manual test: disconnect and reconnect to a Keycloak server — should reuse the existing DCR client without re-registration errors