### PR TITLE
fix: prevent dual Content-Type header in OAuth token requests

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -581,7 +581,7 @@ export function useConnection({
         }
         switch (transportType) {
           case "sse":
-            requestHeaders["Accept"] = "text/event-stream";
+            requestHeaders["accept"] = "text/event-stream";
             requestHeaders["content-type"] = "application/json";
             transportOptions = {
               authProvider: serverAuthProvider,
@@ -589,10 +589,7 @@ export function useConnection({
                 url: string | URL | globalThis.Request,
                 init?: RequestInit,
               ) => {
-                const response = await fetch(url, {
-                  ...init,
-                  headers: requestHeaders,
-                });
+                const response = await fetch(url, init);
 
                 // Capture protocol-related headers from response
                 captureResponseHeaders(response);
@@ -605,19 +602,15 @@ export function useConnection({
             break;
 
           case "streamable-http":
+            requestHeaders["accept"] = "text/event-stream, application/json";
+            requestHeaders["content-type"] = "application/json";
             transportOptions = {
               authProvider: serverAuthProvider,
               fetch: async (
                 url: string | URL | globalThis.Request,
                 init?: RequestInit,
               ) => {
-                requestHeaders["Accept"] =
-                  "text/event-stream, application/json";
-                requestHeaders["Content-Type"] = "application/json";
-                const response = await fetch(url, {
-                  headers: requestHeaders,
-                  ...init,
-                });
+                const response = await fetch(url, init);
 
                 // Capture protocol-related headers from response
                 captureResponseHeaders(response);


### PR DESCRIPTION
## Summary

- **Bug:** OAuth token exchange requests sent to authorization servers (e.g. Keycloak) were rejected with `Failed to parse media type application/json, application/x-www-form-urlencoded` when using direct SSE or Streamable HTTP transports.
- **Root cause:** The custom fetch wrappers for direct transports were setting default `Content-Type: application/json` and `Accept: application/json, text/event-stream` headers. When the SDK's OAuth layer issued token requests with `Content-Type: application/x-www-form-urlencoded`, the headers were merged, producing a malformed dual Content-Type value.
- **Fix:** Move default accept/content-type headers out of the fetch wrapper and into `requestInit.headers` with lowercase keys. Simplify the custom fetch to a pass-through. The SDK's `createFetchWithInit` merges defaults with per-request headers (per-request wins), so OAuth token requests now correctly use `application/x-www-form-urlencoded`.

## Test plan

- [x] `npm run build-client` passes
- [x] `cd client && npm run lint` passes
- [ ] Manual test: connect to a Keycloak-protected MCP server using direct SSE or Streamable HTTP — OAuth token exchange should succeed without Content-Type errors