### PR TITLE
fix: clear cached DCR client on Guided OAuth Flow and add clear dialog

### DIFF
--- a/client/src/components/__tests__/AuthDebugger.test.tsx
+++ b/client/src/components/__tests__/AuthDebugger.test.tsx
@@ -64,7 +64,6 @@ jest.mock("@/lib/auth", () => ({
     clear: jest.fn().mockImplementation(() => {
       // Mock the real clear() behavior which removes items from sessionStorage
       sessionStorage.removeItem("[https://example.com/mcp] mcp_tokens");
-      sessionStorage.removeItem("[https://example.com/mcp] mcp_client_info");
       sessionStorage.removeItem(
         "[https://example.com/mcp] mcp_server_metadata",
       );

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -245,10 +245,6 @@ export class InspectorOAuthClientProvider implements OAuthClientProvider {
   }
 
   clear() {
-    clearClientInformationFromSessionStorage({
-      serverUrl: this.serverUrl,
-      isPreregistered: false,
-    });
     sessionStorage.removeItem(
       getServerSpecificKey(SESSION_KEYS.TOKENS, this.serverUrl),
     );


### PR DESCRIPTION
## Summary

- **Bug:** Guided OAuth Flow Step 2 was displaying cached `client_id` from sessionStorage without making an actual DCR network request. Users saw stale data and couldn't verify that DCR was working correctly.
- **Fix:** Clear the cached DCR client info when starting the Guided OAuth Flow so Step 2 always performs a fresh registration. Quick OAuth Flow is unaffected.
- **UX improvement:** Replace the immediate "Clear OAuth State" button with a confirmation dialog that offers an optional checkbox to also clear the registered DCR client information. This prevents accidental state loss.
- Also fixes a pre-existing test parse error (Babel `as never` in mock factory).

> **Depends on:** #1121 (preserve DCR client info on disconnect). This PR includes that change as its base commit. Please merge #1121 first.

## Test plan

- [x] `npm run build-client` passes
- [x] `cd client && npm run lint` passes
- [x] `cd client && npm test` passes (new and existing tests)
- [ ] Manual test: open Guided OAuth Flow — Step 2 should always make a fresh DCR request
- [ ] Manual test: click "Clear OAuth State" — should show confirmation dialog with DCR checkbox