### PR TITLE
fix: handle SSE transport send errors in stdio stderr handler

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -608,22 +608,28 @@ app.get(
         if (chunk.toString().includes("MODULE_NOT_FOUND")) {
           // Server command not found, remove transports
           const message = "Command not found, transports removed";
-          webAppTransport.send({
-            jsonrpc: "2.0",
-            method: "notifications/message",
-            params: {
-              level: "emergency",
-              logger: "proxy",
-              data: {
-                message,
+          webAppTransport
+            .send({
+              jsonrpc: "2.0",
+              method: "notifications/message",
+              params: {
+                level: "emergency",
+                logger: "proxy",
+                data: {
+                  message,
+                },
               },
-            },
-          });
-          webAppTransport.close();
-          serverTransport.close();
-          webAppTransports.delete(webAppTransport.sessionId);
-          serverTransports.delete(webAppTransport.sessionId);
-          sessionHeaderHolders.delete(webAppTransport.sessionId);
+            })
+            .catch(() => {
+              // SSE connection already closed, ignore
+            })
+            .finally(() => {
+              webAppTransport.close();
+              serverTransport.close();
+              webAppTransports.delete(webAppTransport.sessionId);
+              serverTransports.delete(webAppTransport.sessionId);
+              sessionHeaderHolders.delete(webAppTransport.sessionId);
+            });
           console.error(message);
         } else {
           // Inspect message and attempt to assign a RFC 5424 Syslog Protocol level
@@ -658,17 +664,21 @@ app.get(
           } else {
             level = "info";
           }
-          webAppTransport.send({
-            jsonrpc: "2.0",
-            method: "notifications/message",
-            params: {
-              level,
-              logger: "stdio",
-              data: {
-                message,
+          webAppTransport
+            .send({
+              jsonrpc: "2.0",
+              method: "notifications/message",
+              params: {
+                level,
+                logger: "stdio",
+                data: {
+                  message,
+                },
               },
-            },
-          });
+            })
+            .catch(() => {
+              // SSE connection already closed, ignore
+            });
         }
       });
 


### PR DESCRIPTION
## Summary

Fixes #1014

When multiple STDIO connection requests are made in quick succession (e.g. an MCP server mounting ~20 proxied servers), the SSE connection can close before stderr data finishes being forwarded. The `webAppTransport.send()` calls in the stderr handler were not catching the returned promise, so a "Not connected" rejection from `SSEServerTransport.send()` would crash the server as an unhandled promise rejection.

- Add `.catch()` to both `send()` call sites in the stderr `data` handler to silently ignore errors from a closed SSE connection
- Move transport cleanup in the `MODULE_NOT_FOUND` branch into `.finally()` so resources are released regardless of whether the notification send succeeded

## Test plan

- [x] `npm run build-server` passes
- [x] Prettier formatting verified (`npx prettier --check server/src/index.ts`)
- [ ] Manual: start inspector with a multi-server MCP setup, rapidly refresh — no more "Not connected" crash