### PR TITLE
fix: prevent SSE transport crash on concurrent STDIO connections

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -596,7 +596,6 @@ app.get(
       const endpoint = `${prefix}/message`;
 
       const webAppTransport = new SSEServerTransport(endpoint, res);
-      webAppTransports.set(webAppTransport.sessionId, webAppTransport);
       console.log("Created client transport");
 
       serverTransports.set(webAppTransport.sessionId, serverTransport);
@@ -604,23 +603,27 @@ app.get(
 
       await webAppTransport.start();
 
+      webAppTransports.set(webAppTransport.sessionId, webAppTransport);
+
       (serverTransport as StdioClientTransport).stderr!.on("data", (chunk) => {
         if (chunk.toString().includes("MODULE_NOT_FOUND")) {
           // Server command not found, remove transports
           const message = "Command not found, transports removed";
-          webAppTransport.send({
-            jsonrpc: "2.0",
-            method: "notifications/message",
-            params: {
-              level: "emergency",
-              logger: "proxy",
-              data: {
-                message,
+          webAppTransport
+            .send({
+              jsonrpc: "2.0",
+              method: "notifications/message",
+              params: {
+                level: "emergency",
+                logger: "proxy",
+                data: {
+                  message,
+                },
               },
-            },
-          });
-          webAppTransport.close();
-          serverTransport.close();
+            })
+            .catch(() => {});
+          webAppTransport.close().catch(() => {});
+          serverTransport.close().catch(() => {});
           webAppTransports.delete(webAppTransport.sessionId);
           serverTransports.delete(webAppTransport.sessionId);
           sessionHeaderHolders.delete(webAppTransport.sessionId);
@@ -658,17 +661,19 @@ app.get(
           } else {
             level = "info";
           }
-          webAppTransport.send({
-            jsonrpc: "2.0",
-            method: "notifications/message",
-            params: {
-              level,
-              logger: "stdio",
-              data: {
-                message,
+          webAppTransport
+            .send({
+              jsonrpc: "2.0",
+              method: "notifications/message",
+              params: {
+                level,
+                logger: "stdio",
+                data: {
+                  message,
+                },
               },
-            },
-          });
+            })
+            .catch(() => {});
         }
       });
 
@@ -707,7 +712,6 @@ app.get(
       const endpoint = `${prefix}/message`;
 
       const webAppTransport = new SSEServerTransport(endpoint, res);
-      webAppTransports.set(webAppTransport.sessionId, webAppTransport);
       console.log("Created client transport");
 
       serverTransports.set(webAppTransport.sessionId, serverTransport!); // eslint-disable-line @typescript-eslint/no-non-null-assertion
@@ -717,6 +721,8 @@ app.get(
       console.log("Created server transport");
 
       await webAppTransport.start();
+
+      webAppTransports.set(webAppTransport.sessionId, webAppTransport);
 
       mcpProxy({
         transportToClient: webAppTransport,


### PR DESCRIPTION
## Summary

Fixes #1014

When multiple STDIO connection requests arrive in quick succession (e.g. an MCP server mounting ~20 proxied servers), the SSE transport crashes with a "Not connected" error.

**Root cause:** `SSEServerTransport` was registered in the `webAppTransports` map *before* `await transport.start()` completed. This allowed the `/message` endpoint to look up and use a transport that wasn't fully connected yet, causing `send()` to throw.

**Changes:**
- Move `webAppTransports.set()` to **after** `await webAppTransport.start()` in both `/stdio` and `/sse` endpoints, so only fully-connected transports are discoverable
- Add `.catch()` handlers to `send()` and `close()` calls in the stderr forwarding handler to prevent unhandled promise rejections when the SSE connection drops while the server process is still running

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] All 486 tests pass (`npm test`)
- [ ] Manual: create MCP server with ~20 proxied servers, run `fastmcp dev server.py`, open inspector — no crash