### PR TITLE
feat: handle tools/resources/prompts list_changed notifications

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -404,6 +404,7 @@ const App = () => {
       if (notification.method === "notifications/tools/list_changed") {
         setNextToolCursor(undefined);
         setTools([]);
+        cacheToolOutputSchemas([]);
         void listTools();
       }
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -401,6 +401,27 @@ const App = () => {
     onNotification: (notification) => {
       setNotifications((prev) => [...prev, notification as ServerNotification]);
 
+      if (notification.method === "notifications/tools/list_changed") {
+        setNextToolCursor(undefined);
+        setTools([]);
+        void listTools();
+      }
+
+      if (notification.method === "notifications/resources/list_changed") {
+        setNextResourceCursor(undefined);
+        setNextResourceTemplateCursor(undefined);
+        setResources([]);
+        setResourceTemplates([]);
+        void listResources();
+        void listResourceTemplates();
+      }
+
+      if (notification.method === "notifications/prompts/list_changed") {
+        setNextPromptCursor(undefined);
+        setPrompts([]);
+        void listPrompts();
+      }
+
       if (notification.method === "notifications/tasks/list_changed") {
         void listTasks();
       }

--- a/client/src/__tests__/App.notifications.test.tsx
+++ b/client/src/__tests__/App.notifications.test.tsx
@@ -1,0 +1,218 @@
+import { act, render, waitFor } from "@testing-library/react";
+import App from "../App";
+import { useConnection } from "../lib/hooks/useConnection";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { ServerNotification } from "@modelcontextprotocol/sdk/types.js";
+import { cacheToolOutputSchemas } from "../utils/schemaUtils";
+
+type OnNotificationHandler = (notification: ServerNotification) => void;
+type UseConnectionReturn = ReturnType<typeof useConnection>;
+
+jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("../lib/oauth-state-machine", () => ({
+  OAuthStateMachine: jest.fn(),
+}));
+
+jest.mock("../lib/auth", () => ({
+  InspectorOAuthClientProvider: jest.fn().mockImplementation(() => ({
+    tokens: jest.fn().mockResolvedValue(null),
+    clear: jest.fn(),
+  })),
+  DebugInspectorOAuthClientProvider: jest.fn(),
+}));
+
+jest.mock("../utils/configUtils", () => ({
+  ...jest.requireActual("../utils/configUtils"),
+  getMCPProxyAddress: jest.fn(() => "http://localhost:6277"),
+  getMCPProxyAuthToken: jest.fn(() => ({
+    token: "",
+    header: "X-MCP-Proxy-Auth",
+  })),
+  getInitialTransportType: jest.fn(() => "stdio"),
+  getInitialSseUrl: jest.fn(() => "http://localhost:3001/sse"),
+  getInitialCommand: jest.fn(() => "mcp-server-everything"),
+  getInitialArgs: jest.fn(() => ""),
+  initializeInspectorConfig: jest.fn(() => ({})),
+  saveInspectorConfig: jest.fn(),
+}));
+
+jest.mock("../lib/hooks/useDraggablePane", () => ({
+  useDraggablePane: () => ({
+    height: 300,
+    handleDragStart: jest.fn(),
+  }),
+  useDraggableSidebar: () => ({
+    width: 320,
+    isDragging: false,
+    handleDragStart: jest.fn(),
+  }),
+}));
+
+jest.mock("../components/Sidebar", () => ({
+  __esModule: true,
+  default: () => <div>Sidebar</div>,
+}));
+
+jest.mock("../lib/hooks/useToast", () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+jest.mock("../utils/schemaUtils", () => ({
+  ...jest.requireActual("../utils/schemaUtils"),
+  cacheToolOutputSchemas: jest.fn(),
+}));
+
+global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+
+jest.mock("../lib/hooks/useConnection", () => ({
+  useConnection: jest.fn(),
+}));
+
+describe("App - list_changed notification handling", () => {
+  const mockUseConnection = jest.mocked(useConnection);
+  const mockCacheToolOutputSchemas = jest.mocked(cacheToolOutputSchemas);
+
+  const makeConnectionState = (makeRequest: jest.Mock) => ({
+    connectionStatus: "connected" as const,
+    serverCapabilities: {
+      tools: { listChanged: true },
+      resources: { listChanged: true },
+      prompts: { listChanged: true },
+    },
+    mcpClient: {
+      request: jest.fn(),
+      notification: jest.fn(),
+      close: jest.fn(),
+    } as unknown as Client,
+    requestHistory: [],
+    clearRequestHistory: jest.fn(),
+    makeRequest,
+    sendNotification: jest.fn(),
+    handleCompletion: jest.fn(),
+    completionsSupported: false,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    serverImplementation: null,
+    cancelTask: jest.fn(),
+    listTasks: jest.fn(),
+  });
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    mockCacheToolOutputSchemas.mockClear();
+    window.location.hash = "#tools";
+  });
+
+  const captureOnNotification = (makeRequest: jest.Mock) => {
+    let captured: OnNotificationHandler | undefined;
+    mockUseConnection.mockImplementation((options) => {
+      captured = (options as { onNotification?: OnNotificationHandler })
+        .onNotification;
+      return makeConnectionState(makeRequest) as unknown as UseConnectionReturn;
+    });
+    return () => {
+      if (!captured) {
+        throw new Error("Expected onNotification to be provided");
+      }
+      return captured;
+    };
+  };
+
+  test("notifications/tools/list_changed re-fetches tools and clears cached output schemas", async () => {
+    const makeRequest = jest
+      .fn()
+      .mockResolvedValue({ tools: [], nextCursor: undefined });
+    const getOnNotification = captureOnNotification(makeRequest);
+
+    render(<App />);
+    await waitFor(() => {
+      expect(mockUseConnection).toHaveBeenCalled();
+    });
+
+    act(() => {
+      getOnNotification()({
+        method: "notifications/tools/list_changed",
+      } as ServerNotification);
+    });
+
+    await waitFor(() => {
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "tools/list" }),
+        expect.anything(),
+      );
+    });
+    // Schema cache must be cleared before the refetch kicks off, so any
+    // in-flight validator can't run against a stale compiled schema.
+    expect(mockCacheToolOutputSchemas).toHaveBeenCalledWith([]);
+    const clearCallOrder =
+      mockCacheToolOutputSchemas.mock.invocationCallOrder[0];
+    const toolsListCallOrder = makeRequest.mock.invocationCallOrder.find(
+      (_, i) => makeRequest.mock.calls[i][0].method === "tools/list",
+    );
+    expect(clearCallOrder).toBeLessThan(toolsListCallOrder!);
+  });
+
+  test("notifications/resources/list_changed re-fetches resources and templates", async () => {
+    const makeRequest = jest.fn().mockImplementation((request) => {
+      if (request.method === "resources/list") {
+        return Promise.resolve({ resources: [], nextCursor: undefined });
+      }
+      if (request.method === "resources/templates/list") {
+        return Promise.resolve({
+          resourceTemplates: [],
+          nextCursor: undefined,
+        });
+      }
+      return Promise.resolve({});
+    });
+    const getOnNotification = captureOnNotification(makeRequest);
+
+    render(<App />);
+    await waitFor(() => {
+      expect(mockUseConnection).toHaveBeenCalled();
+    });
+
+    act(() => {
+      getOnNotification()({
+        method: "notifications/resources/list_changed",
+      } as ServerNotification);
+    });
+
+    await waitFor(() => {
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "resources/list" }),
+        expect.anything(),
+      );
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "resources/templates/list" }),
+        expect.anything(),
+      );
+    });
+  });
+
+  test("notifications/prompts/list_changed re-fetches prompts", async () => {
+    const makeRequest = jest.fn().mockResolvedValue({ prompts: [] });
+    const getOnNotification = captureOnNotification(makeRequest);
+
+    render(<App />);
+    await waitFor(() => {
+      expect(mockUseConnection).toHaveBeenCalled();
+    });
+
+    act(() => {
+      getOnNotification()({
+        method: "notifications/prompts/list_changed",
+      } as ServerNotification);
+    });
+
+    await waitFor(() => {
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "prompts/list" }),
+        expect.anything(),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add handling for `notifications/tools/list_changed`, `notifications/resources/list_changed`, and `notifications/prompts/list_changed` in the inspector's notification callback. When a server sends these notifications, the inspector now automatically refreshes the corresponding lists — matching the existing `tasks/list_changed` pattern.

This enables dynamic tool/resource/prompt registration use cases (e.g., gateway MCP servers that load/unload tools at runtime).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

**`client/src/App.tsx`** — Added 3 conditional blocks to the `onNotification` callback:

- `notifications/tools/list_changed` → resets tool cursor, clears tools, re-fetches via `listTools()`
- `notifications/resources/list_changed` → resets resource + template cursors, clears both lists, re-fetches via `listResources()` + `listResourceTemplates()`
- `notifications/prompts/list_changed` → resets prompt cursor, clears prompts, re-fetches via `listPrompts()`

Each handler resets pagination cursors to `undefined` before re-fetching to ensure a clean refresh from page 1 (not a paginated continuation).

The notification schemas (`ToolListChangedNotificationSchema`, `ResourceListChangedNotificationSchema`, `PromptListChangedNotificationSchema`) are already imported and registered on the MCP client in `useConnection.ts` — this PR adds the missing response logic.

## Related Issues

Fixes #832

## Testing

- [x] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [ ] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

1. Connect the inspector to an MCP server that supports dynamic tool registration
2. Add/remove a tool on the server side
3. The server sends a `notifications/tools/list_changed` notification
4. Verify the Tools tab automatically refreshes to show the updated tool list
5. Same flow applies for resources and prompts

The implementation follows the exact same pattern as the existing `notifications/tasks/list_changed` handler (line 424), which is already working in production.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [x] Documentation updated (README, comments, etc.)

## Breaking Changes

None. This is a purely additive change.

## Additional Context

The infrastructure was already 95% complete:
- SDK notification schemas are imported in `useConnection.ts` (lines 29-31)
- Notification handlers are registered on the client (lines 753-755)
- List fetching functions (`listTools`, `listResources`, `listPrompts`) already exist
- State management is in place

The only missing piece was responding to the notifications in the `onNotification` callback, which this PR adds.