### PR TITLE
Fixed TUI list selection bug

### DIFF
--- a/clients/tui/src/components/PromptsTab.tsx
+++ b/clients/tui/src/components/PromptsTab.tsx
@@ -35,7 +35,7 @@ export function PromptsTab({
   const { selectedIndex, firstVisible, setSelection } = useSelectableList(
     prompts.length,
     visibleCount,
-    { resetWhen: [prompts] },
+    { resetWhen: prompts },
   );
   const [error, setError] = useState<string | null>(null);
   const scrollViewRef = useRef<ScrollViewRef>(null);

--- a/clients/tui/src/components/ResourcesTab.tsx
+++ b/clients/tui/src/components/ResourcesTab.tsx
@@ -69,7 +69,7 @@ export function ResourcesTab({
   const { selectedIndex, firstVisible, setSelection } = useSelectableList(
     totalCount,
     visibleCount,
-    { resetWhen: [resources] },
+    { resetWhen: resources },
   );
   const selectedItem = useMemo(
     () => allItems[selectedIndex] || null,

--- a/clients/tui/src/components/ToolsTab.tsx
+++ b/clients/tui/src/components/ToolsTab.tsx
@@ -30,7 +30,7 @@ export function ToolsTab({
   const { selectedIndex, firstVisible, setSelection } = useSelectableList(
     tools.length,
     visibleCount,
-    { resetWhen: [tools] },
+    { resetWhen: tools },
   );
   const [error] = useState<string | null>(null);
   const scrollViewRef = useRef<ScrollViewRef>(null);

--- a/clients/tui/src/hooks/useSelectableList.ts
+++ b/clients/tui/src/hooks/useSelectableList.ts
@@ -11,8 +11,8 @@ function clampFirstVisible(
 }
 
 export interface UseSelectableListOptions {
-  /** When these change, reset selection to 0 (e.g. [tools] when switching servers) */
-  resetWhen?: unknown[];
+  /** When this reference changes, reset selection to 0 (e.g. tools list when switching servers) */
+  resetWhen?: unknown;
 }
 
 /**
@@ -38,15 +38,13 @@ export function useSelectableList(
     [visibleCount],
   );
 
-  // Reset when deps change (e.g. different server). Depend on list contents
-  // so we don't reset on every render (options.resetWhen is a new array each time).
-  const resetDeps = options?.resetWhen ?? [];
+  // Reset when the list reference changes (e.g. different server).
   useEffect(() => {
-    if (resetDeps.length > 0) {
+    if (options?.resetWhen !== undefined) {
       setSelectedIndex(0);
       setFirstVisible(0);
     }
-  }, [resetDeps.length, ...resetDeps]);
+  }, [options?.resetWhen]);
 
   // Clamp when list shrinks
   useEffect(() => {

--- a/clients/tui/src/hooks/useSelectableList.ts
+++ b/clients/tui/src/hooks/useSelectableList.ts
@@ -38,13 +38,15 @@ export function useSelectableList(
     [visibleCount],
   );
 
-  // Reset when deps change (e.g. different server)
+  // Reset when deps change (e.g. different server). Depend on list contents
+  // so we don't reset on every render (options.resetWhen is a new array each time).
+  const resetDeps = options?.resetWhen ?? [];
   useEffect(() => {
-    if (options?.resetWhen) {
+    if (resetDeps.length > 0) {
       setSelectedIndex(0);
       setFirstVisible(0);
     }
-  }, [options?.resetWhen]);
+  }, [resetDeps.length, ...resetDeps]);
 
   // Clamp when list shrinks
   useEffect(() => {


### PR DESCRIPTION
## Summary

The TUI has a list selection bug for Resources, Prompts, and Tools that made it impossible to navigate the lists (continually reselected first item).

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)

## Changes Made

Fixed hook to only reselect first item when server changes

## Testing

- [X] Tested in UI mode
- [X] Tested with STDIO transport
- [X] Tested with Streamable HTTP transport
- [X] Manual testing performed

## Checklist

- [X] Code follows the style guidelines (ran `npm run prettier-fix`)
- [X] Self-review completed

## Breaking Changes

None