### PR TITLE
fix: suppress RFC 8707 `resource` parameter in OAuth authorization requests

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -142,19 +142,25 @@ export class InspectorOAuthClientProvider implements OAuthClientProvider {
    *
    * The MCP TypeScript SDK reads the `resource` field from RFC 9728 Protected
    * Resource Metadata (PRM) and by default forwards it as a `resource` query
-   * parameter on the /authorize URL. Authorization servers that do not support
-   * the RFC 8707 `resource` parameter — notably Azure Entra ID v2.0, which
-   * treats it as a v1.0-only concept — reject the request with an error such
-   * as AADSTS9010010 ("The resource parameter … doesn't match … the requested
-   * scopes"), even when the PRM `resource` value is a perfectly valid
-   * RFC 9728-compliant server URL.
+   * parameter on the /authorize URL. However, RFC 8707 defines the `resource`
+   * parameter as OPTIONAL — authorization servers are not required to support
+   * it. Some servers actively reject the parameter:  specifically, Azure Entra
+   * ID v2.0 returns AADSTS9010010 ("The resource parameter … doesn't match …
+   * the requested scopes") when `resource` is present, even when the PRM
+   * `resource` value is a valid RFC 9728-compliant server URL.
    *
    * By implementing this hook and returning `undefined`, we tell the SDK to
    * omit the `resource` parameter entirely. The authorization server identity
    * and supported scopes are still fully discovered from PRM via the
    * `authorization_servers` and `scopes_supported` fields, so discovery is
-   * unaffected. Only the redundant (and potentially incompatible) `resource`
-   * query parameter is dropped from the authorize URL.
+   * unaffected.
+   *
+   * Trade-off: In multi-resource environments (one authorization server
+   * protecting several resource servers), the `resource` parameter helps
+   * audience-restrict tokens to a specific resource. For the Inspector — a
+   * single-connection developer tool where the scope already encodes the
+   * target resource — omitting it is safe and compatible with all major
+   * authorization servers (Keycloak, Auth0, Okta, PingFederate, Entra ID).
    */
   validateResourceURL(
     _serverUrl: URL,

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -137,6 +137,32 @@ export class InspectorOAuthClientProvider implements OAuthClientProvider {
     return getScopeFromSessionStorage(this.serverUrl);
   }
 
+  /**
+   * Suppress the RFC 8707 `resource` parameter in authorization requests.
+   *
+   * The MCP TypeScript SDK reads the `resource` field from RFC 9728 Protected
+   * Resource Metadata (PRM) and by default forwards it as a `resource` query
+   * parameter on the /authorize URL. Authorization servers that do not support
+   * the RFC 8707 `resource` parameter — notably Azure Entra ID v2.0, which
+   * treats it as a v1.0-only concept — reject the request with an error such
+   * as AADSTS9010010 ("The resource parameter … doesn't match … the requested
+   * scopes"), even when the PRM `resource` value is a perfectly valid
+   * RFC 9728-compliant server URL.
+   *
+   * By implementing this hook and returning `undefined`, we tell the SDK to
+   * omit the `resource` parameter entirely. The authorization server identity
+   * and supported scopes are still fully discovered from PRM via the
+   * `authorization_servers` and `scopes_supported` fields, so discovery is
+   * unaffected. Only the redundant (and potentially incompatible) `resource`
+   * query parameter is dropped from the authorize URL.
+   */
+  validateResourceURL(
+    _serverUrl: URL,
+    _resourceMetadataUrl?: string,
+  ): Promise<URL | undefined> {
+    return Promise.resolve(undefined);
+  }
+
   get redirectUrl() {
     return window.location.origin + "/oauth/callback";
   }


### PR DESCRIPTION
## Problem

When connecting the MCP Inspector to an MCP server that implements [RFC 9728 Protected Resource Metadata (PRM)](https://datatracker.ietf.org/doc/html/rfc9728), the TypeScript SDK reads the `resource` field from the PRM document and appends it as a `resource` query parameter on the `/authorize` URL (per [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707)).

Authorization servers that **do not support RFC 8707** reject this parameter. Specifically, **Azure Entra ID v2.0** returns:

> `AADSTS9010010: The resource parameter provided in the request doesn't match with the requested scopes.`

This blocks the OAuth authorization code flow entirely for any MCP server deployed behind Azure Entra ID (and potentially other authorization servers that don't implement RFC 8707).

### Root Cause

The SDK's `startAuthorization()` calls `selectResourceURL()`, which returns `new URL(resourceMetadata.resource)` when PRM is present. This URL is then added as `resource=<server-url>` to the authorize endpoint. Azure Entra ID v2.0 only uses the `scope` parameter for audience resolution and treats `resource` as a v1.0-only concept — any request including it is rejected.

The `resource` field in RFC 9728 PRM is intended for **resource discovery** (identifying the protected resource), not necessarily for inclusion as a query parameter in authorization requests to all authorization servers.

## Fix

Implements `validateResourceURL()` on `InspectorOAuthClientProvider`, returning `undefined`. This is the SDK's intended escape hatch — when this hook is present, the SDK delegates to it instead of using the raw PRM `resource` field. Returning `undefined` tells the SDK to omit the `resource` parameter from the authorize URL entirely.

**What still works:**
- PRM discovery of `authorization_servers` (used to find the correct authorization endpoint)
- PRM discovery of `scopes_supported` (used to request the correct scopes)
- PKCE flow (`code_challenge` / `code_verifier`)

**What changes:**
- The `resource=<server-url>` query parameter is no longer appended to the `/authorize` URL

Since `DebugInspectorOAuthClientProvider` extends `InspectorOAuthClientProvider`, the fix applies to both normal and debug OAuth flows automatically.

## How to Reproduce

1. Deploy any MCP server with RFC 9728 PRM behind **Azure Entra ID v2.0** as the authorization server
2. Configure the PRM document with:
   - `resource`: the server URL
   - `authorization_servers`: pointing to the Entra ID v2.0 issuer
   - `scopes_supported`: e.g. `["api://<app-id>/.default"]`
3. Open MCP Inspector, enter the server URL, and initiate the OAuth flow
4. The browser redirects to the Entra `/authorize` endpoint with `resource=https://<server-url>/` in the query string
5. Entra rejects with `AADSTS9010010`

## Change

- **File:** `client/src/lib/auth.ts`
- **Class:** `InspectorOAuthClientProvider`
- **Method added:** `validateResourceURL()` — returns `Promise.resolve(undefined)`
- **Lines changed:** +26 insertions