### PR TITLE
fix: remove Content-Type header from OAuth metadata discovery GET requests

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -582,16 +582,22 @@ export function useConnection({
         switch (transportType) {
           case "sse":
             requestHeaders["Accept"] = "text/event-stream";
-            requestHeaders["content-type"] = "application/json";
             transportOptions = {
               authProvider: serverAuthProvider,
               fetch: async (
                 url: string | URL | globalThis.Request,
                 init?: RequestInit,
               ) => {
+                const mergedHeaders = { ...requestHeaders };
+                // Only set Content-Type on requests with a body (e.g. POST).
+                // GET requests (such as OAuth metadata discovery) must not
+                // include Content-Type, as some servers reject it with 415.
+                if (init?.body) {
+                  mergedHeaders["content-type"] = "application/json";
+                }
                 const response = await fetch(url, {
                   ...init,
-                  headers: requestHeaders,
+                  headers: mergedHeaders,
                 });
 
                 // Capture protocol-related headers from response
@@ -611,11 +617,16 @@ export function useConnection({
                 url: string | URL | globalThis.Request,
                 init?: RequestInit,
               ) => {
-                requestHeaders["Accept"] =
-                  "text/event-stream, application/json";
-                requestHeaders["Content-Type"] = "application/json";
+                const mergedHeaders = { ...requestHeaders };
+                mergedHeaders["Accept"] = "text/event-stream, application/json";
+                // Only set Content-Type on requests with a body (e.g. POST).
+                // GET requests (such as OAuth metadata discovery) must not
+                // include Content-Type, as some servers reject it with 415.
+                if (init?.body) {
+                  mergedHeaders["Content-Type"] = "application/json";
+                }
                 const response = await fetch(url, {
-                  headers: requestHeaders,
+                  headers: mergedHeaders,
                   ...init,
                 });
 


### PR DESCRIPTION
## Summary

Fixes #1143

The custom `fetch` wrappers in both the SSE and Streamable HTTP direct-connection paths unconditionally set `Content-Type: application/json` on every outgoing request. This includes GET requests made during OAuth metadata discovery (e.g. `GET /.well-known/oauth-authorization-server`), which violates HTTP semantics — GET requests should not carry a `Content-Type` header.

Some authorization servers (notably Keycloak) enforce this and respond with **415 Unsupported Media Type**, breaking the entire OAuth flow.

## Changes

- **SSE transport**: Moved `content-type: application/json` from the shared `requestHeaders` object into the `fetch` wrapper, only applying it when the request has a body (`init?.body`).
- **Streamable HTTP transport**: Same approach — `Content-Type` is now set conditionally inside the `fetch` wrapper rather than unconditionally before every request.

Both changes use a shallow copy (`mergedHeaders`) so the base `requestHeaders` object is not mutated across calls.

## Test plan

- Connect to an MCP server behind an OAuth authorization server (e.g. Keycloak) using direct Streamable HTTP or SSE transport
- Verify that OAuth metadata discovery (`GET /.well-known/oauth-authorization-server`) no longer returns 415
- Verify that POST requests (JSON-RPC messages) still include `Content-Type: application/json`