### PR TITLE
feat: show item count in list pane header

### DIFF
--- a/client/src/components/ListPane.tsx
+++ b/client/src/components/ListPane.tsx
@@ -61,6 +61,11 @@ const ListPane = <T extends object>({
         <div className="flex items-center justify-between gap-4">
           <h3 className="font-semibold dark:text-white flex-shrink-0">
             {title}
+            {items.length > 0 && (
+              <span className="ml-2 text-xs font-medium text-muted-foreground">
+                ({items.length})
+              </span>
+            )}
           </h3>
           <div className="flex items-center justify-end min-w-0 flex-1">
             {!isSearchExpanded ? (

--- a/client/src/components/__tests__/ListPane.test.tsx
+++ b/client/src/components/__tests__/ListPane.test.tsx
@@ -53,6 +53,18 @@ describe("ListPane", () => {
       expect(screen.getByText("Another Tool")).toBeInTheDocument();
     });
 
+    it("should show item count when items are present", () => {
+      renderListPane();
+
+      expect(screen.getByText("(3)")).toBeInTheDocument();
+    });
+
+    it("should not show item count when no items", () => {
+      renderListPane({ items: [] });
+
+      expect(screen.queryByText("(0)")).not.toBeInTheDocument();
+    });
+
     it("should render empty state when no items", () => {
       renderListPane({ items: [] });
 


### PR DESCRIPTION
## Summary
- Displays the total number of items next to the list pane title (e.g. "Tools (5)") when items have been loaded
- The count is shown in the shared `ListPane` component, so it applies to Tools, Resources, Prompts, Tasks, and Apps tabs
- Count is hidden when no items are present

Closes #1171

## Test plan
- [x] Existing `ListPane` tests pass
- [x] Existing `ToolsTab` tests pass
- [x] Added tests for count visibility (shown when items present, hidden when empty)