### PR TITLE
fix: handle null body status in createCustomFetch proxy

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -338,6 +338,28 @@ const createCustomFetch = (headerHolder: { headers: HeadersInit }) => {
     const acceptHeader = finalHeaders.get("Accept");
     const isSSE = acceptHeader?.includes("text/event-stream");
 
+    // Null body statuses (204, 205, 304) must not have a body per the
+    // Fetch spec. node-fetch may still provide a non-null body stream,
+    // but the Web Response constructor rejects a body for these statuses.
+    // Return a proper Web Response with null body so the SDK's
+    // response.body?.cancel() call works correctly.
+    const isNullBodyStatus =
+      response.status === 204 ||
+      response.status === 205 ||
+      response.status === 304;
+
+    if (isNullBodyStatus) {
+      const responseHeaders: Record<string, string> = {};
+      response.headers.forEach((value: string, key: string) => {
+        responseHeaders[key] = value;
+      });
+      return new Response(null, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: responseHeaders,
+      });
+    }
+
     if (isSSE && response.body) {
       // For SSE requests, we need to convert the Node.js stream to a web ReadableStream
       // because the EventSource polyfill expects web-compatible streams


### PR DESCRIPTION
## Summary

- Fix `TypeError: Response constructor: Invalid response status code 204` when disconnecting from MCP servers that return HTTP 204 No Content on DELETE session termination
- Affects all MCP servers using the Streamable HTTP transport (reproducible with the official Go MCP SDK)

## Problem

`createCustomFetch` wraps `node-fetch` responses for the SDK, but fails on [null body statuses](https://fetch.spec.whatwg.org/#null-body-status) (204, 205, 304):

1. **SSE branch crash**: `headerHolder` retains `Accept: text/event-stream` from prior GET/POST requests. When DELETE fires, the stale header makes `isSSE = true`, and `new Response(webStream, {status: 204})` throws because the Web Response constructor rejects a body for null body statuses.
2. **Pass-through branch crash**: Even if the SSE branch is skipped, the raw `node-fetch` response is returned via `as unknown as Response`. The SDK then calls `response.body?.cancel()` which doesn't exist on Node.js Readable streams (node-fetch), causing `TypeError: response.body?.cancel is not a function`.

## Fix

Detect null body statuses before the SSE stream conversion check and return a proper Web `Response` with `null` body:

```typescript
const isNullBodyStatus =
  response.status === 204 ||
  response.status === 205 ||
  response.status === 304;

if (isNullBodyStatus) {
  return new Response(null, { status, statusText, headers });
}
```

> **Note on 101 Switching Protocols**: The Fetch spec also lists 101 as a null body status. It is intentionally excluded here because the body stream carries the upgraded protocol data (e.g., WebSocket), which must not be discarded.

## Known limitations / Follow-up

- The stale `Accept` header leaking from `headerHolder` into unrelated requests (e.g., DELETE) is a separate root cause that could be addressed in a follow-up PR by scoping header merging per request type.
- Path #3 (`return response as unknown as Response`) is a pre-existing issue where non-SSE, non-null-body responses are not properly converted from node-fetch to Web Response. This could cause silent failures for `response.body?.cancel()` on other status codes.

## Test plan

- [x] `npm run prettier-check` passes
- [x] `npm test` passes (487 tests)
- [x] Manual test: connect to MCP server (Go SDK) via Streamable HTTP → disconnect → no errors in proxy log
- [x] Manual test: connect → call tool → disconnect → clean shutdown confirmed