### PR TITLE
fix: validate serverInfo.websiteUrl before rendering as link

### DIFF
--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -784,75 +784,72 @@ const Sidebar = ({
               </span>
             </div>
 
-            {connectionStatus === "connected" && serverImplementation && (
-              <div className="bg-gray-50 dark:bg-gray-900 p-3 rounded-lg mb-4">
-                <div className="flex items-center gap-2 mb-1">
-                  {(serverImplementation as WithIcons).icons &&
-                  (serverImplementation as WithIcons).icons!.length > 0 ? (
-                    <IconDisplay
-                      icons={(serverImplementation as WithIcons).icons}
-                      size="sm"
-                    />
-                  ) : (
-                    <Server className="w-4 h-4 text-gray-500" />
-                  )}
-                  {(() => {
-                    const websiteUrl = (
-                      serverImplementation as { websiteUrl?: string }
-                    ).websiteUrl;
-                    if (!websiteUrl) {
-                      return (
+            {connectionStatus === "connected" &&
+              serverImplementation &&
+              (() => {
+                const websiteUrl = (
+                  serverImplementation as { websiteUrl?: string }
+                ).websiteUrl;
+                let isValidWebsiteUrl = false;
+                if (websiteUrl) {
+                  try {
+                    validateRedirectUrl(websiteUrl);
+                    isValidWebsiteUrl = true;
+                  } catch {
+                    isValidWebsiteUrl = false;
+                  }
+                }
+                const serverName = serverImplementation.name || "MCP Server";
+                return (
+                  <div className="bg-gray-50 dark:bg-gray-900 p-3 rounded-lg mb-4">
+                    <div className="flex items-center gap-2 mb-1">
+                      {(serverImplementation as WithIcons).icons &&
+                      (serverImplementation as WithIcons).icons!.length > 0 ? (
+                        <IconDisplay
+                          icons={(serverImplementation as WithIcons).icons}
+                          size="sm"
+                        />
+                      ) : (
+                        <Server className="w-4 h-4 text-gray-500" />
+                      )}
+                      {websiteUrl && isValidWebsiteUrl ? (
+                        <a
+                          href={websiteUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline transition-colors"
+                        >
+                          {serverName}
+                        </a>
+                      ) : (
                         <span className="text-sm font-medium text-gray-800 dark:text-gray-200">
-                          {serverImplementation.name || "MCP Server"}
+                          {serverName}
                         </span>
-                      );
-                    }
-                    let isValidWebsiteUrl = false;
-                    try {
-                      validateRedirectUrl(websiteUrl);
-                      isValidWebsiteUrl = true;
-                    } catch {
-                      isValidWebsiteUrl = false;
-                    }
-                    if (!isValidWebsiteUrl) {
-                      return (
-                        <span className="text-sm font-medium text-gray-800 dark:text-gray-200 flex items-center gap-1">
-                          {serverImplementation.name || "MCP Server"}
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span className="inline-flex items-center gap-1 text-yellow-600 dark:text-yellow-500">
-                                <AlertTriangle className="w-3.5 h-3.5" />
-                                <span className="text-xs font-normal">
-                                  Potentially malicious websiteURL field
-                                </span>
-                              </span>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p className="max-w-xs break-all">{websiteUrl}</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </span>
-                      );
-                    }
-                    return (
-                      <a
-                        href={websiteUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline transition-colors"
-                      >
-                        {serverImplementation.name || "MCP Server"}
-                      </a>
-                    );
-                  })()}
-                </div>
-                {serverImplementation.version && (
-                  <div className="text-xs text-gray-500 dark:text-gray-400">
-                    Version: {serverImplementation.version}
+                      )}
+                    </div>
+                    {websiteUrl && !isValidWebsiteUrl && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="flex items-center gap-1 text-yellow-600 dark:text-yellow-500 mb-1">
+                            <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
+                            <span className="text-xs font-normal">
+                              Potentially malicious websiteURL field
+                            </span>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p className="max-w-xs break-all">{websiteUrl}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                    {serverImplementation.version && (
+                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                        Version: {serverImplementation.version}
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-            )}
+                );
+              })()}
 
             {loggingSupported && connectionStatus === "connected" && (
               <div className="space-y-2">

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Copy,
   CheckCheck,
   Server,
+  AlertTriangle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -42,6 +43,7 @@ import CustomHeaders from "./CustomHeaders";
 import { CustomHeaders as CustomHeadersType } from "@/lib/types/customHeaders";
 import { useToast } from "../lib/hooks/useToast";
 import IconDisplay, { WithIcons } from "./IconDisplay";
+import { validateRedirectUrl } from "@/utils/urlValidation";
 
 interface SidebarProps {
   connectionStatus: ConnectionStatus;
@@ -794,24 +796,55 @@ const Sidebar = ({
                   ) : (
                     <Server className="w-4 h-4 text-gray-500" />
                   )}
-                  {(serverImplementation as { websiteUrl?: string })
-                    .websiteUrl ? (
-                    <a
-                      href={
-                        (serverImplementation as { websiteUrl?: string })
-                          .websiteUrl
-                      }
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline transition-colors"
-                    >
-                      {serverImplementation.name || "MCP Server"}
-                    </a>
-                  ) : (
-                    <span className="text-sm font-medium text-gray-800 dark:text-gray-200">
-                      {serverImplementation.name || "MCP Server"}
-                    </span>
-                  )}
+                  {(() => {
+                    const websiteUrl = (
+                      serverImplementation as { websiteUrl?: string }
+                    ).websiteUrl;
+                    if (!websiteUrl) {
+                      return (
+                        <span className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                          {serverImplementation.name || "MCP Server"}
+                        </span>
+                      );
+                    }
+                    let isValidWebsiteUrl = false;
+                    try {
+                      validateRedirectUrl(websiteUrl);
+                      isValidWebsiteUrl = true;
+                    } catch {
+                      isValidWebsiteUrl = false;
+                    }
+                    if (!isValidWebsiteUrl) {
+                      return (
+                        <span className="text-sm font-medium text-gray-800 dark:text-gray-200 flex items-center gap-1">
+                          {serverImplementation.name || "MCP Server"}
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="inline-flex items-center gap-1 text-yellow-600 dark:text-yellow-500">
+                                <AlertTriangle className="w-3.5 h-3.5" />
+                                <span className="text-xs font-normal">
+                                  Potentially malicious websiteURL field
+                                </span>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p className="max-w-xs break-all">{websiteUrl}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </span>
+                      );
+                    }
+                    return (
+                      <a
+                        href={websiteUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline transition-colors"
+                      >
+                        {serverImplementation.name || "MCP Server"}
+                      </a>
+                    );
+                  })()}
                 </div>
                 {serverImplementation.version && (
                   <div className="text-xs text-gray-500 dark:text-gray-400">

--- a/client/src/components/__tests__/Sidebar.test.tsx
+++ b/client/src/components/__tests__/Sidebar.test.tsx
@@ -1046,4 +1046,68 @@ describe("Sidebar", () => {
       );
     });
   });
+
+  describe("Server Implementation websiteUrl", () => {
+    it("should render a warning instead of a link when websiteUrl uses an unsafe protocol", () => {
+      renderSidebar({
+        connectionStatus: "connected",
+        serverImplementation: {
+          name: "Evil Server",
+          version: "1.0.0",
+          websiteUrl: "javascript:alert('xss')",
+        },
+      });
+
+      // The warning message should be displayed
+      expect(
+        screen.getByText("Potentially malicious websiteURL field"),
+      ).toBeInTheDocument();
+
+      // The server name should still be shown
+      expect(screen.getByText("Evil Server")).toBeInTheDocument();
+
+      // No link should have been rendered for the malicious URL
+      expect(
+        screen.queryByRole("link", { name: "Evil Server" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should render a link when websiteUrl is a valid https URL", () => {
+      renderSidebar({
+        connectionStatus: "connected",
+        serverImplementation: {
+          name: "Good Server",
+          version: "1.0.0",
+          websiteUrl: "https://example.com",
+        },
+      });
+
+      const link = screen.getByRole("link", { name: "Good Server" });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "https://example.com");
+
+      expect(
+        screen.queryByText("Potentially malicious websiteURL field"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should render a link when websiteUrl is a valid http URL", () => {
+      renderSidebar({
+        connectionStatus: "connected",
+        serverImplementation: {
+          name: "Local Server",
+          version: "1.0.0",
+          websiteUrl: "http://localhost:3000",
+        },
+      });
+
+      const link = screen.getByRole("link", { name: "Local Server" });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "http://localhost:3000");
+
+      expect(
+        screen.queryByText("Potentially malicious websiteURL field"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

A connected MCP server's `serverInfo.websiteUrl` was rendered directly as an `<a href>` with no protocol check, allowing a malicious server to supply `javascript:` (or other unsafe) URLs that would execute on click. Run the value through `validateRedirectUrl` and, on failure, show a warning-colored "Potentially malicious websiteURL field" message instead of a link. The offending URL is still surfaced via tooltip for inspection.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

<!-- Describe the changes in detail. Include screenshots/recordings if applicable -->

## Testing

- [x] Tested in UI mode
- [ ] Tested in CLI mode
- [x] Tested with STDIO transport
- [x] Tested with SSE transport
- [x] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

Modified the Everything server briefly to return  `websiteUrl: "javascript:alert('xss')"` in the serverInfo.

### Message shown when validation fails
<img width="314" height="106" alt="Screenshot 2026-04-11 at 4 35 07 PM" src="https://github.com/user-attachments/assets/70156232-6d15-4af3-9121-10b6b6b88fdd" />

### Tooltip shown when hovering over message
<img width="306" height="107" alt="Screenshot 2026-04-11 at 4 36 03 PM" src="https://github.com/user-attachments/assets/7addfc97-6e13-4f14-9637-014435934422" />

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed

## Breaking Changes
Nope.

## Additional Context

Addresses: 
https://github.com/modelcontextprotocol/inspector/security/advisories/GHSA-g7v3-7hjr-rh45