### PR TITLE
fix(server): sanitize error responses to prevent stack trace exposure

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -73,12 +73,25 @@ const is401Error = (error: unknown): boolean => {
 };
 
 /**
+ * Sends a sanitized JSON error response to the client without exposing
+ * stack traces or internal error details. The full error is expected to
+ * have already been logged server-side via console.error.
+ */
+const sendErrorResponse = (
+  res: express.Response,
+  status: number,
+  message: string,
+) => {
+  res.status(status).json({ error: message });
+};
+
+/**
  * Prefer forwarding the upstream MCP 401 (WWW-Authenticate + body) so the browser
- * matches direct-mode OAuth behavior. Falls back to JSON-encoding `error` if unknown.
+ * matches direct-mode OAuth behavior. Falls back to a generic 401 JSON response
+ * when no upstream details were captured, to avoid leaking stack traces.
  */
 const sendProxiedUnauthorized = (
   res: express.Response,
-  error: unknown,
   headerHolder?: ProxyHeaderHolder,
 ) => {
   const captured = headerHolder?.lastUpstream401;
@@ -92,7 +105,7 @@ const sendProxiedUnauthorized = (
     delete headerHolder.lastUpstream401;
     return;
   }
-  res.status(401).json(error);
+  sendErrorResponse(res, 401, "Unauthorized");
 };
 
 // Function to get HTTP headers.
@@ -509,7 +522,7 @@ app.get(
       }
     } catch (error) {
       console.error("Error in /mcp route:", error);
-      res.status(500).json(error);
+      sendErrorResponse(res, 500, "Internal server error");
     }
   },
 );
@@ -545,7 +558,7 @@ app.post(
         }
       } catch (error) {
         console.error("Error in /mcp route:", error);
-        res.status(500).json(error);
+        sendErrorResponse(res, 500, "Internal server error");
       }
     } else {
       console.log("New StreamableHttp connection request");
@@ -592,11 +605,11 @@ app.post(
             "Received 401 Unauthorized from MCP server:",
             error instanceof Error ? error.message : error,
           );
-          sendProxiedUnauthorized(res, error, streamableHeaderHolder);
+          sendProxiedUnauthorized(res, streamableHeaderHolder);
           return;
         }
         console.error("Error in /mcp POST route:", error);
-        res.status(500).json(error);
+        sendErrorResponse(res, 500, "Internal server error");
       }
     }
   },
@@ -627,7 +640,7 @@ app.delete(
         res.status(200).end();
       } catch (error) {
         console.error("Error in /mcp route:", error);
-        res.status(500).json(error);
+        sendErrorResponse(res, 500, "Internal server error");
       }
     }
   },
@@ -732,11 +745,11 @@ app.get(
         console.error(
           "Received 401 Unauthorized from MCP server. Authentication failure.",
         );
-        sendProxiedUnauthorized(res, error, undefined);
+        sendProxiedUnauthorized(res, undefined);
         return;
       }
       console.error("Error in /stdio route:", error);
-      res.status(500).json(error);
+      sendErrorResponse(res, 500, "Internal server error");
     }
   },
 );
@@ -781,20 +794,29 @@ app.get(
         console.error(
           "Received 401 Unauthorized from MCP server. Authentication failure.",
         );
-        sendProxiedUnauthorized(res, error, sseHeaderHolder);
+        sendProxiedUnauthorized(res, sseHeaderHolder);
         return;
       } else if (error instanceof SseError && error.code === 404) {
         console.error(
           "Received 404 not found from MCP server. Does the MCP server support SSE?",
         );
-        res.status(404).json(error);
+        sendErrorResponse(
+          res,
+          404,
+          "MCP server returned 404. Does it support SSE?",
+        );
         return;
       } else if (JSON.stringify(error).includes("ECONNREFUSED")) {
         console.error("Connection refused. Is the MCP server running?");
-        res.status(500).json(error);
+        sendErrorResponse(
+          res,
+          500,
+          "Connection refused. Is the MCP server running?",
+        );
+        return;
       }
       console.error("Error in /sse route:", error);
-      res.status(500).json(error);
+      sendErrorResponse(res, 500, "Internal server error");
     }
   },
 );
@@ -824,7 +846,7 @@ app.post(
       await transport.handlePostMessage(req, res);
     } catch (error) {
       console.error("Error in /message route:", error);
-      res.status(500).json(error);
+      sendErrorResponse(res, 500, "Internal server error");
     }
   },
 );
@@ -900,7 +922,7 @@ app.get("/config", originValidationMiddleware, authMiddleware, (req, res) => {
     });
   } catch (error) {
     console.error("Error in /config route:", error);
-    res.status(500).json(error);
+    sendErrorResponse(res, 500, "Internal server error");
   }
 });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -806,7 +806,11 @@ app.get(
           "MCP server returned 404. Does it support SSE?",
         );
         return;
-      } else if (JSON.stringify(error).includes("ECONNREFUSED")) {
+      } else if (
+        error instanceof Error &&
+        (error.message.includes("ECONNREFUSED") ||
+          (error.cause && String(error.cause).includes("ECONNREFUSED")))
+      ) {
         console.error("Connection refused. Is the MCP server running?");
         sendErrorResponse(
           res,
@@ -904,9 +908,8 @@ app.post(
         body: responseBody,
       });
     } catch (error) {
-      res.status(500).json({
-        error: error instanceof Error ? error.message : String(error),
-      });
+      console.error("Error in /fetch route:", error);
+      sendErrorResponse(res, 500, "Internal server error");
     }
   },
 );


### PR DESCRIPTION
## Summary

Resolves the 11 open CodeQL `js/stack-trace-exposure` alerts in `server/src/index.ts`. Each was a spot where a raw caught `error` object was handed to `res.json(...)`, which can leak internal error details (including stack-trace-derived data) to clients.

The fix introduces a small `sendErrorResponse(res, status, message)` helper that returns a generic sanitized JSON body, and replaces every flagged call site with it. Full error objects continue to be logged server-side via the existing `console.error` calls, so debuggability is unchanged.

### Alerts addressed

- [#19 — line 512 (GET /mcp catch)](https://github.com/modelcontextprotocol/inspector/security/code-scanning/19)
- [#22 — line 599 (POST /mcp outer catch)](https://github.com/modelcontextprotocol/inspector/security/code-scanning/22)
- [#23 — line 630 (DELETE /mcp catch)](https://github.com/modelcontextprotocol/inspector/security/code-scanning/23)
- [#25 — line 739 (/stdio catch)](https://github.com/modelcontextprotocol/inspector/security/code-scanning/25)
- [#27 — line 790 (/sse 404 branch)](https://github.com/modelcontextprotocol/inspector/security/code-scanning/27)
- [#28 — line 794 (/sse ECONNREFUSED branch)](https://github.com/modelcontextprotocol/inspector/security/code-scanning/28)
- [#29 — line 797 (/sse generic 500)](https://github.com/modelcontextprotocol/inspector/security/code-scanning/29)
- [#30 — line 827 (/message catch)](https://github.com/modelcontextprotocol/inspector/security/code-scanning/30)
- [#43 — line 903 (/config catch)](https://github.com/modelcontextprotocol/inspector/security/code-scanning/43)
- [#51 — line 95 (`sendProxiedUnauthorized` fallback)](https://github.com/modelcontextprotocol/inspector/security/code-scanning/51)
- [#52 — line 548 (POST /mcp inner catch)](https://github.com/modelcontextprotocol/inspector/security/code-scanning/52)

### Incidental fix

The `/sse` handler's `ECONNREFUSED` branch was missing a `return`, so after sending its 500 it fell through to the generic `Error in /sse route` branch and attempted a second response on the already-sent headers. Added the missing `return` since the sanitization pass touched those lines anyway.

### Behavior changes

- Clients no longer receive raw serialized `Error` objects on 4xx/5xx failures from `/mcp`, `/stdio`, `/sse`, `/message`, or `/config`. They now receive `{ "error": "<generic message>" }`.
- `sendProxiedUnauthorized` no longer takes an `error` parameter — the upstream-capture path was already ignoring it, and the fallback path now returns a plain `{ error: "Unauthorized" }` instead of JSON-encoding the caught exception.
- Server-side logs are unchanged — every site still logs the full error via `console.error` before responding.

## Test plan

- [x] `npm run build-server` passes (tsc)
- [x] `npm run prettier-fix` clean
- [ ] Manually verify an error path (e.g. connect `/mcp` to an unreachable URL) returns `{ "error": "Internal server error" }` rather than a serialized exception, and that `console.error` still logs full details server-side
- [ ] Manually verify OAuth 401 forwarding from an upstream MCP server still returns the captured `WWW-Authenticate` header and body (the non-fallback path in `sendProxiedUnauthorized`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)