### PR TITLE
feat: handle tools/resources/prompts list_changed notifications

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -401,6 +401,27 @@ const App = () => {
     onNotification: (notification) => {
       setNotifications((prev) => [...prev, notification as ServerNotification]);
 
+      if (notification.method === "notifications/tools/list_changed") {
+        setNextToolCursor(undefined);
+        setTools([]);
+        void listTools();
+      }
+
+      if (notification.method === "notifications/resources/list_changed") {
+        setNextResourceCursor(undefined);
+        setNextResourceTemplateCursor(undefined);
+        setResources([]);
+        setResourceTemplates([]);
+        void listResources();
+        void listResourceTemplates();
+      }
+
+      if (notification.method === "notifications/prompts/list_changed") {
+        setNextPromptCursor(undefined);
+        setPrompts([]);
+        void listPrompts();
+      }
+
       if (notification.method === "notifications/tasks/list_changed") {
         void listTasks();
       }


### PR DESCRIPTION
## Summary

- Add handlers for `notifications/tools/list_changed`, `notifications/resources/list_changed`, and `notifications/prompts/list_changed` in the `onNotification` callback
- When a server sends these notifications, the inspector resets pagination cursors and re-fetches the corresponding lists
- Enables dynamic tool/resource/prompt registration use cases (e.g., gateway MCP servers that load/unload capabilities at runtime)

## Changes

In `client/src/App.tsx`, added three conditional blocks to the existing `onNotification` callback, following the same pattern as the existing `notifications/tasks/list_changed` handler:

- `notifications/tools/list_changed` -- resets tool cursor, clears tools, re-fetches via `listTools()`
- `notifications/resources/list_changed` -- resets resource and template cursors, clears both lists, re-fetches via `listResources()` and `listResourceTemplates()`
- `notifications/prompts/list_changed` -- resets prompt cursor, clears prompts, re-fetches via `listPrompts()`

The notification schemas (`ToolListChangedNotificationSchema`, `ResourceListChangedNotificationSchema`, `PromptListChangedNotificationSchema`) are already imported and registered on the MCP client in `useConnection.ts` -- this PR adds the missing response logic.

## Testing

1. Connect the inspector to an MCP server that supports dynamic tool registration
2. Add/remove a tool on the server side
3. The server sends a `notifications/tools/list_changed` notification
4. Verify the Tools tab automatically refreshes to show the updated tool list
5. Same flow applies for resources and prompts

Build passes (`npm run build` succeeds).

Fixes #832