### PR TITLE
Handle task completion notifications to skip polling delay

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -367,6 +367,11 @@ const App = () => {
   } = useDraggableSidebar(320);
 
   const selectedTaskRef = useRef<Task | null>(null);
+  // Signal used to wake up the task polling loop when a task status notification arrives
+  const taskNotificationResolverRef = useRef<{
+    taskId: string;
+    resolve: () => void;
+  } | null>(null);
   useEffect(() => {
     selectedTaskRef.current = selectedTask;
   }, [selectedTask]);
@@ -417,6 +422,15 @@ const App = () => {
         });
         if (selectedTaskRef.current?.taskId === task.taskId) {
           setSelectedTask(task);
+        }
+        // Wake up the polling loop if this task reached a terminal status
+        const terminalStatuses = ["completed", "failed", "cancelled"];
+        if (
+          terminalStatuses.includes(task.status) &&
+          taskNotificationResolverRef.current?.taskId === task.taskId
+        ) {
+          taskNotificationResolverRef.current.resolve();
+          taskNotificationResolverRef.current = null;
         }
       }
     },
@@ -1097,8 +1111,17 @@ const App = () => {
         let taskCompleted = false;
         while (!taskCompleted) {
           try {
-            // Wait for 1 second before polling
-            await new Promise((resolve) => setTimeout(resolve, pollInterval));
+            // Wait for poll interval OR a task status notification, whichever comes first
+            await Promise.race([
+              new Promise((resolve) => setTimeout(resolve, pollInterval)),
+              new Promise<void>((resolve) => {
+                taskNotificationResolverRef.current = { taskId, resolve };
+              }),
+            ]);
+            // Clear the resolver ref if it was not consumed by a notification
+            if (taskNotificationResolverRef.current?.taskId === taskId) {
+              taskNotificationResolverRef.current = null;
+            }
 
             const taskStatus = await sendMCPRequest(
               {


### PR DESCRIPTION
## Summary

Fixes #1037

When a server sends a `notifications/tasks/status` notification with a terminal status (`completed`, `failed`, or `cancelled`) for the task currently being polled, the inspector now immediately proceeds to fetch the result via `tasks/get` instead of waiting for the full poll interval to elapse.

## Problem

The task polling loop in `callTool` used a fixed `setTimeout` with the server's `pollInterval` before each `tasks/get` call. Even when the server sent a `notifications/tasks/status` notification indicating the task was done, the inspector ignored it and kept sleeping until the timer expired. With long poll intervals, this caused a noticeable delay before the result appeared.

## Approach

- Added a `taskNotificationResolverRef` that holds a `{ taskId, resolve }` pair while the polling loop is active
- Modified the `notifications/tasks/status` handler to call `resolve()` when a terminal status arrives for the task being polled
- Replaced the polling loop's `await new Promise(resolve => setTimeout(resolve, pollInterval))` with a `Promise.race` between the poll interval timer and the notification signal

This way, whichever comes first -- the poll interval elapsing or the notification arriving -- the loop proceeds to call `tasks/get` immediately.

## Test plan

- All 515 existing tests pass
- Client builds successfully
- Manual: call a tool as a task against a server that sends `notifications/tasks/status` on completion; the result should appear immediately instead of waiting for the next poll cycle