### PR TITLE
chore: bump version to 0.21.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-cli",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "CLI for the Model Context Protocol inspector",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Model Context Protocol a Series of LF Projects, LLC.",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-client",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Client-side application for the Model Context Protocol inspector",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Model Context Protocol a Series of LF Projects, LLC.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/inspector",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "SEE LICENSE IN LICENSE",
       "workspaces": [
         "client",
@@ -14,9 +14,9 @@
         "cli"
       ],
       "dependencies": {
-        "@modelcontextprotocol/inspector-cli": "^0.21.1",
-        "@modelcontextprotocol/inspector-client": "^0.21.1",
-        "@modelcontextprotocol/inspector-server": "^0.21.1",
+        "@modelcontextprotocol/inspector-cli": "^0.21.2",
+        "@modelcontextprotocol/inspector-client": "^0.21.2",
+        "@modelcontextprotocol/inspector-server": "^0.21.2",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "concurrently": "^9.2.0",
         "node-fetch": "^3.3.2",
@@ -48,7 +48,7 @@
     },
     "cli": {
       "name": "@modelcontextprotocol/inspector-cli",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
@@ -76,7 +76,7 @@
     },
     "client": {
       "name": "@modelcontextprotocol/inspector-client",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@mcp-ui/client": "^6.0.0",
@@ -14003,7 +14003,7 @@
     },
     "server": {
       "name": "@modelcontextprotocol/inspector-server",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Model Context Protocol inspector",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Model Context Protocol a Series of LF Projects, LLC.",
@@ -48,9 +48,9 @@
     "check-version": "node scripts/check-version-consistency.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/inspector-cli": "^0.21.1",
-    "@modelcontextprotocol/inspector-client": "^0.21.1",
-    "@modelcontextprotocol/inspector-server": "^0.21.1",
+    "@modelcontextprotocol/inspector-cli": "^0.21.2",
+    "@modelcontextprotocol/inspector-client": "^0.21.2",
+    "@modelcontextprotocol/inspector-server": "^0.21.2",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "concurrently": "^9.2.0",
     "node-fetch": "^3.3.2",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-server",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Server-side application for the Model Context Protocol inspector",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Model Context Protocol a Series of LF Projects, LLC.",


### PR DESCRIPTION
## Summary
- Bumps version from 0.21.1 to 0.21.2 across all workspace packages (root, client, server, cli)
- Updates workspace dependency references and package-lock.json
- Verified consistency with `npm run check-version`

## Test plan
- [x] `npm run update-version 0.21.2` completed successfully
- [x] `npm run check-version` passed — all 4 packages consistent
- [x] Build completed successfully during `npm install` (prepare hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)