### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,10 +61,13 @@ jobs:
       # - run: npm ci
       - run: npm install --no-package-lock
 
-      # TODO: Add --provenance once the repo is public
+      # OIDC trusted publishing requires npm >=11.5.1; Node 22's bundled npm is 10.x.
+      - name: Ensure npm CLI supports OIDC trusted publishing
+        run: npm install -g npm@^11.5.1
+
       - run: npm run publish-all
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
 
   publish-github-container-registry:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Replaces the `NPM_TOKEN` secret with npm's OIDC trusted publishing for the `publish` job.

- Installs `npm@^11.5.1` before publish (Node 22's bundled npm 10.x doesn't support OIDC)
- Removes `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`
- Sets `NPM_CONFIG_PROVENANCE: "true"` so all 4 packages get provenance attestations
- `id-token: write` and `registry-url` were already present, so no other changes needed

The GitHub environment has been renamed `Release` → `release` (delete + recreate via API with identical required-reviewers) so the env name, workflow yaml, and npm trusted-publisher config all match exactly. npm matches the OIDC `environment` claim case-sensitively against the yaml value.

## Required manual setup before merge

On npmjs.com, configure a **GitHub Actions trusted publisher** for each package with:

| Field | Value |
|---|---|
| Organization | `modelcontextprotocol` |
| Repository | `inspector` |
| Workflow filename | `main.yml` |
| Environment | `release` |

Packages to configure:
- `@modelcontextprotocol/inspector`
- `@modelcontextprotocol/inspector-client`
- `@modelcontextprotocol/inspector-server`
- `@modelcontextprotocol/inspector-cli`

## Test plan

- [ ] Trusted publisher configured on npmjs.com for all 4 packages
- [ ] Cut a release and confirm `publish` job succeeds without `NPM_TOKEN`
- [ ] Verify provenance badge appears on the published packages
- [ ] Delete the repo-level `NPM_TOKEN` secret if one exists (env-level secret was already removed with the old environment)