### PR TITLE
Update package.json to contain repository.url in for npm trusted publisher setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "bin": {
     "mcp-inspector": "cli/build/cli.js"
   },
+  "repository": {
+    "url": "https://github.com/modelcontextprotocol/inspector"
+  },
   "files": [
     "client/bin",
     "client/dist",


### PR DESCRIPTION
## Summary
We are changing from tokens to OIDC trusted publisher on npm. 
* Part of that was handled by #1199 
* But the [failure log](https://github.com/modelcontextprotocol/inspector/actions/runs/24404092842/job/71282741874) showed we also needed to add `repository.url` to the `package.json` file, which this PR does

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [x] Build/CI improvements

Screenshots are encouraged to share your testing results for this change.

## Breaking Changes
Nope.