### PR TITLE
fix: add repository field to workspace package.json files for npm trusted publishing

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -6,6 +6,11 @@
   "author": "Model Context Protocol a Series of LF Projects, LLC.",
   "homepage": "https://modelcontextprotocol.io",
   "bugs": "https://github.com/modelcontextprotocol/inspector/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/modelcontextprotocol/inspector",
+    "directory": "cli"
+  },
   "main": "build/cli.js",
   "type": "module",
   "bin": {

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,11 @@
   "author": "Model Context Protocol a Series of LF Projects, LLC.",
   "homepage": "https://modelcontextprotocol.io",
   "bugs": "https://github.com/modelcontextprotocol/inspector/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/modelcontextprotocol/inspector",
+    "directory": "client"
+  },
   "type": "module",
   "bin": {
     "mcp-inspector-client": "./bin/start.js"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "mcp-inspector": "cli/build/cli.js"
   },
   "repository": {
+    "type": "git",
     "url": "https://github.com/modelcontextprotocol/inspector"
   },
   "files": [

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,11 @@
   "author": "Model Context Protocol a Series of LF Projects, LLC.",
   "homepage": "https://modelcontextprotocol.io",
   "bugs": "https://github.com/modelcontextprotocol/inspector/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/modelcontextprotocol/inspector",
+    "directory": "server"
+  },
   "type": "module",
   "bin": {
     "mcp-inspector-server": "build/index.js"


### PR DESCRIPTION
## Summary
- Follow-up to #1201. The previous fix added `repository.url` only to the root `package.json`, but `npm publish --workspaces` publishes each workspace using its own `package.json`, and the provenance check runs per-package.
- The last publish run failed at `@modelcontextprotocol/inspector-client` with: `Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/modelcontextprotocol/inspector" from provenance`.
- This PR adds a `repository` block to `cli`, `client`, and `server` workspace `package.json` files, and adds `type: "git"` to the root. Workspaces also include `directory` so npm/GitHub link to the correct subpath in the monorepo.

## Test plan
- [ ] Next release publish succeeds under OIDC trusted publishing for all four packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)