### PR TITLE
fix(client): preserve Request semantics in createProxyFetch

### DIFF
--- a/client/src/lib/__tests__/proxyFetch.test.ts
+++ b/client/src/lib/__tests__/proxyFetch.test.ts
@@ -241,4 +241,43 @@ describe("createProxyFetch", () => {
     const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(callBody.url).toBe("https://example.com/from-request");
   });
+
+  it("preserves Request method, headers, and body when input is a Request", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: "",
+        }),
+    });
+
+    const fetchFn = createProxyFetch(configWithProxy);
+    await fetchFn(
+      new Request("https://example.com/token", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "X-Test": "1",
+        },
+        body: "grant_type=authorization_code&code=abc",
+      }),
+    );
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(callBody).toEqual({
+      url: "https://example.com/token",
+      init: {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "x-test": "1",
+        },
+        body: "grant_type=authorization_code&code=abc",
+      },
+    });
+  });
 });

--- a/client/src/lib/__tests__/proxyFetch.test.ts
+++ b/client/src/lib/__tests__/proxyFetch.test.ts
@@ -280,4 +280,52 @@ describe("createProxyFetch", () => {
       },
     });
   });
+
+  it("lets an explicit init override method, headers, and body from a Request input", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: "",
+        }),
+    });
+
+    const fetchFn = createProxyFetch(configWithProxy);
+    await fetchFn(
+      new Request("https://example.com/token", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "X-Test": "1",
+        },
+        body: "grant_type=authorization_code&code=abc",
+      }),
+      {
+        method: "PUT",
+        headers: {
+          "X-Test": "override",
+          "X-Extra": "2",
+        },
+        body: "override-body",
+      },
+    );
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(callBody).toEqual({
+      url: "https://example.com/token",
+      init: {
+        method: "PUT",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "x-test": "override",
+          "x-extra": "2",
+        },
+        body: "override-body",
+      },
+    });
+  });
 });

--- a/client/src/lib/proxyFetch.ts
+++ b/client/src/lib/proxyFetch.ts
@@ -92,25 +92,45 @@ export function createProxyFetch(config: InspectorConfig): typeof fetch {
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> => {
+    const requestInput = input instanceof Request ? input : undefined;
     const url =
       typeof input === "string"
         ? input
-        : input instanceof Request
-          ? input.url
+        : requestInput
+          ? requestInput.url
           : input.toString();
 
     // Serialize body for JSON transport. URLSearchParams and similar don't
     // JSON-serialize (they become {}), so we must convert to string first.
     let serializedBody: string | undefined;
-    if (init?.body != null) {
-      if (typeof init.body === "string") {
-        serializedBody = init.body;
-      } else if (init.body instanceof URLSearchParams) {
-        serializedBody = init.body.toString();
+    const requestBody =
+      requestInput &&
+      !requestInput.bodyUsed &&
+      !["GET", "HEAD"].includes(requestInput.method)
+        ? await requestInput.clone().text()
+        : undefined;
+    const effectiveBody = init?.body ?? requestBody;
+    if (effectiveBody != null) {
+      if (typeof effectiveBody === "string") {
+        serializedBody = effectiveBody;
+      } else if (effectiveBody instanceof URLSearchParams) {
+        serializedBody = effectiveBody.toString();
       } else {
-        serializedBody = String(init.body);
+        serializedBody = String(effectiveBody);
       }
     }
+
+    const forwardedHeaders = new Headers(requestInput?.headers);
+    if (init?.headers) {
+      new Headers(init.headers).forEach((value, key) => {
+        forwardedHeaders.set(key, value);
+      });
+    }
+    const serializedHeadersObject = Object.fromEntries(forwardedHeaders.entries());
+    const serializedHeaders =
+      Object.keys(serializedHeadersObject).length > 0
+        ? serializedHeadersObject
+        : undefined;
 
     const proxyResponse = await fetch(`${proxyAddress}/fetch`, {
       method: "POST",
@@ -121,10 +141,8 @@ export function createProxyFetch(config: InspectorConfig): typeof fetch {
       body: JSON.stringify({
         url,
         init: {
-          method: init?.method,
-          headers: init?.headers
-            ? Object.fromEntries(new Headers(init.headers))
-            : undefined,
+          method: init?.method ?? requestInput?.method,
+          headers: serializedHeaders,
           body: serializedBody,
         },
       }),

--- a/client/src/lib/proxyFetch.ts
+++ b/client/src/lib/proxyFetch.ts
@@ -126,7 +126,9 @@ export function createProxyFetch(config: InspectorConfig): typeof fetch {
         forwardedHeaders.set(key, value);
       });
     }
-    const serializedHeadersObject = Object.fromEntries(forwardedHeaders.entries());
+    const serializedHeadersObject = Object.fromEntries(
+      forwardedHeaders.entries(),
+    );
     const serializedHeaders =
       Object.keys(serializedHeadersObject).length > 0
         ? serializedHeadersObject


### PR DESCRIPTION
## Summary

`createProxyFetch()` currently preserves request semantics when it is called as `(url, init)`, but not when the caller passes a real `Request` object. In the `Request` case, the proxy payload keeps `request.url` but drops the original `method`, `headers`, and `body`.

This patch preserves those fields for `Request` inputs, still lets an explicit `init` override them, and adds focused regression coverage for both the passthrough and override cases.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test updates
- [ ] Build/CI improvements

## Changes Made

- read `method`, `headers`, and `body` from `Request` inputs inside `client/src/lib/proxyFetch.ts`
- preserve the existing `(url, init)` behavior
- let an explicit `init` continue to override the values derived from the `Request`
- add regression tests in `client/src/lib/__tests__/proxyFetch.test.ts` that cover:
  - the basic `Request` passthrough case
  - the `init`-overrides-`Request` precedence case

## Related Issues

Fixes #1207

## Testing

- [ ] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

Added focused regression tests for the `Request` input path in `client/src/lib/__tests__/proxyFetch.test.ts`.

Local verification in this environment used targeted Node 22 harnesses against the checked-out source to confirm:
1. `(url, init)` still forwards `method`, `headers`, and `body`
2. `new Request(...)` now forwards the same fields instead of sending an empty `init`
3. when both a `Request` and an explicit `init` are provided, the explicit `init` values win

Reviewers can test the change by running the client unit tests, or by comparing the serialized `POST /fetch` payload before and after this patch when `createProxyFetch()` is called with a `Request`.

## Checklist

- [ ] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None.

## Additional Context

This keeps `createProxyFetch()` closer to normal fetch-wrapper expectations: callers should not get different proxy behavior solely because they constructed a `Request` object instead of passing `(url, init)` separately.
