### PR TITLE
Phase 2: Refactor Prompts cluster to MCP SDK types

### DIFF
--- a/clients/web/src/components/elements/MessageBubble/MessageBubble.tsx
+++ b/clients/web/src/components/elements/MessageBubble/MessageBubble.tsx
@@ -78,6 +78,7 @@ const BubbleContainer = Paper.withProps({
 const RoleLabel = Text.withProps({
   size: "xs",
   c: "dimmed",
+  ff: "monospace",
 });
 
 const PreviewImage = Image.withProps({

--- a/clients/web/src/components/groups/PromptArgumentsForm/PromptArgumentsForm.stories.tsx
+++ b/clients/web/src/components/groups/PromptArgumentsForm/PromptArgumentsForm.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { fn } from "storybook/test";
 import { PromptArgumentsForm } from "./PromptArgumentsForm";
 
@@ -14,64 +15,73 @@ const meta: Meta<typeof PromptArgumentsForm> = {
 export default meta;
 type Story = StoryObj<typeof PromptArgumentsForm>;
 
+const summarizePrompt: Prompt = {
+  name: "summarize",
+  description: "Summarize the given text into key points",
+};
+
+const translatePrompt: Prompt = {
+  name: "translate",
+  description: "Translate text from one language to another",
+  arguments: [
+    { name: "text", required: true, description: "The text to translate" },
+    {
+      name: "targetLanguage",
+      required: true,
+      description: "The language to translate into",
+    },
+  ],
+};
+
+const summarizeWithArgsPrompt: Prompt = {
+  name: "summarize",
+  description: "Summarize the given text into key points",
+  arguments: [
+    { name: "text", required: true, description: "The text to summarize" },
+    {
+      name: "maxLength",
+      required: true,
+      description: "Maximum length of summary in words",
+    },
+    {
+      name: "format",
+      required: false,
+      description: "Output format (bullets or paragraph)",
+    },
+  ],
+};
+
+const codeReviewPrompt: Prompt = {
+  name: "code-review",
+  arguments: [
+    { name: "code", required: true, description: "The code to review" },
+  ],
+};
+
 export const NoArguments: Story = {
   args: {
-    name: "summarize",
-    description: "Summarize the given text into key points",
-    arguments: [],
+    prompt: summarizePrompt,
     argumentValues: {},
   },
 };
 
 export const WithArguments: Story = {
   args: {
-    name: "translate",
-    description: "Translate text from one language to another",
-    arguments: [
-      { name: "text", required: true, description: "The text to translate" },
-      {
-        name: "targetLanguage",
-        required: true,
-        description: "The language to translate into",
-      },
-    ],
+    prompt: translatePrompt,
     argumentValues: {},
   },
 };
 
 export const WithRequiredAndOptional: Story = {
   args: {
-    name: "summarize",
-    description: "Summarize the given text into key points",
-    arguments: [
-      { name: "text", required: true, description: "The text to summarize" },
-      {
-        name: "maxLength",
-        required: true,
-        description: "Maximum length of summary in words",
-      },
-      {
-        name: "format",
-        required: false,
-        description: "Output format (bullets or paragraph)",
-      },
-    ],
+    prompt: summarizeWithArgsPrompt,
     argumentValues: {},
   },
 };
 
 export const AllFilled: Story = {
   args: {
-    name: "translate",
-    description: "Translate text from one language to another",
-    arguments: [
-      { name: "text", required: true, description: "The text to translate" },
-      {
-        name: "targetLanguage",
-        required: true,
-        description: "The language to translate into",
-      },
-    ],
+    prompt: translatePrompt,
     argumentValues: {
       text: "Hello, how are you?",
       targetLanguage: "Spanish",
@@ -81,10 +91,7 @@ export const AllFilled: Story = {
 
 export const NoDescription: Story = {
   args: {
-    name: "code-review",
-    arguments: [
-      { name: "code", required: true, description: "The code to review" },
-    ],
+    prompt: codeReviewPrompt,
     argumentValues: {},
   },
 };

--- a/clients/web/src/components/groups/PromptArgumentsForm/PromptArgumentsForm.tsx
+++ b/clients/web/src/components/groups/PromptArgumentsForm/PromptArgumentsForm.tsx
@@ -1,19 +1,18 @@
 import { Button, Group, Stack, Text, TextInput, Title } from "@mantine/core";
-
-export interface PromptArgument {
-  name: string;
-  required: boolean;
-  description?: string;
-}
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 
 export interface PromptArgumentsFormProps {
-  name: string;
-  description?: string;
-  arguments: PromptArgument[];
+  prompt: Prompt;
   argumentValues: Record<string, string>;
   onArgumentChange: (name: string, value: string) => void;
   onGetPrompt: () => void;
 }
+
+const PromptTitle = Text.withProps({
+  fw: 700,
+  size: "lg",
+  truncate: "end",
+});
 
 const DescriptionText = Text.withProps({
   size: "sm",
@@ -25,23 +24,25 @@ function formatPlaceholder(name: string): string {
 }
 
 export function PromptArgumentsForm({
-  description,
-  arguments: promptArguments,
+  prompt,
   argumentValues,
   onArgumentChange,
   onGetPrompt,
 }: PromptArgumentsFormProps) {
+  const { name, title, description, arguments: promptArguments } = prompt;
+
   return (
     <Stack gap="md">
-      <Title order={4}>Prompt Arguments</Title>
+      <PromptTitle>{title ?? name}</PromptTitle>
       {description && <DescriptionText>{description}</DescriptionText>}
-      {promptArguments.length > 0 && (
+      <Title order={4}>Arguments</Title>
+      {promptArguments && promptArguments.length > 0 && (
         <Stack gap="sm">
           {promptArguments.map((arg) => (
             <TextInput
               key={arg.name}
               label={arg.name}
-              withAsterisk={arg.required}
+              withAsterisk={arg.required === true}
               description={arg.description}
               placeholder={formatPlaceholder(arg.name)}
               value={argumentValues[arg.name] || ""}

--- a/clients/web/src/components/groups/PromptArgumentsForm/PromptArgumentsForm.tsx
+++ b/clients/web/src/components/groups/PromptArgumentsForm/PromptArgumentsForm.tsx
@@ -35,23 +35,25 @@ export function PromptArgumentsForm({
     <Stack gap="md">
       <PromptTitle>{title ?? name}</PromptTitle>
       {description && <DescriptionText>{description}</DescriptionText>}
-      <Title order={4}>Arguments</Title>
       {promptArguments && promptArguments.length > 0 && (
-        <Stack gap="sm">
-          {promptArguments.map((arg) => (
-            <TextInput
-              key={arg.name}
-              label={arg.name}
-              withAsterisk={arg.required === true}
-              description={arg.description}
-              placeholder={formatPlaceholder(arg.name)}
-              value={argumentValues[arg.name] || ""}
-              onChange={(event) =>
-                onArgumentChange(arg.name, event.currentTarget.value)
-              }
-            />
-          ))}
-        </Stack>
+        <>
+          <Title order={4}>Arguments</Title>
+          <Stack gap="sm">
+            {promptArguments.map((arg) => (
+              <TextInput
+                key={arg.name}
+                label={arg.name}
+                withAsterisk={arg.required === true}
+                description={arg.description}
+                placeholder={formatPlaceholder(arg.name)}
+                value={argumentValues[arg.name] || ""}
+                onChange={(event) =>
+                  onArgumentChange(arg.name, event.currentTarget.value)
+                }
+              />
+            ))}
+          </Stack>
+        </>
       )}
       <Group justify="flex-end">
         <Button size="sm" onClick={onGetPrompt}>

--- a/clients/web/src/components/groups/PromptControls/PromptControls.stories.tsx
+++ b/clients/web/src/components/groups/PromptControls/PromptControls.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { fn } from "storybook/test";
 import { PromptControls } from "./PromptControls";
 
@@ -15,28 +16,24 @@ const meta: Meta<typeof PromptControls> = {
 export default meta;
 type Story = StoryObj<typeof PromptControls>;
 
-const samplePrompts = [
+const samplePrompts: Prompt[] = [
   {
     name: "summarize",
     description: "Summarize the given text into key points",
-    selected: false,
   },
   {
     name: "translate",
     description: "Translate text from one language to another",
-    selected: false,
   },
   {
     name: "analyze",
     description: "Analyze sentiment and tone of the text",
-    selected: false,
   },
   {
     name: "code-review",
     description: "Review code for issues",
-    selected: false,
   },
-  { name: "refactor", selected: false },
+  { name: "refactor" },
 ];
 
 export const Default: Story = {
@@ -47,9 +44,8 @@ export const Default: Story = {
 
 export const WithSelection: Story = {
   args: {
-    prompts: samplePrompts.map((p) =>
-      p.name === "translate" ? { ...p, selected: true } : p,
-    ),
+    prompts: samplePrompts,
+    selectedName: "translate",
   },
 };
 

--- a/clients/web/src/components/groups/PromptControls/PromptControls.tsx
+++ b/clients/web/src/components/groups/PromptControls/PromptControls.tsx
@@ -1,22 +1,23 @@
 import { useState } from "react";
 import { Group, ScrollArea, Stack, TextInput, Title } from "@mantine/core";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { ListChangedIndicator } from "../../elements/ListChangedIndicator/ListChangedIndicator";
 import { PromptListItem } from "../PromptListItem/PromptListItem";
-import type { PromptItem } from "../../screens/PromptsScreen/PromptsScreen";
 
 export interface PromptControlsProps {
-  prompts: PromptItem[];
+  prompts: Prompt[];
+  selectedName?: string;
   listChanged: boolean;
   onRefreshList: () => void;
   onSelectPrompt: (name: string) => void;
 }
 
-function listMaxHeight(): string {
-  return "calc(100vh - var(--app-shell-header-height, 0px) - var(--mantine-spacing-xl) * 2 - 160px)";
-}
+const LIST_MAX_HEIGHT =
+  "calc(100vh - var(--app-shell-header-height, 0px) - var(--mantine-spacing-xl) * 2 - 160px)";
 
 export function PromptControls({
   prompts,
+  selectedName,
   listChanged,
   onRefreshList,
   onSelectPrompt,
@@ -26,6 +27,7 @@ export function PromptControls({
   const filteredPrompts = prompts.filter(
     (p) =>
       p.name.toLowerCase().includes(query) ||
+      (p.title?.toLowerCase().includes(query) ?? false) ||
       (p.description?.toLowerCase().includes(query) ?? false),
   );
 
@@ -40,15 +42,16 @@ export function PromptControls({
         value={searchText}
         onChange={(e) => setSearchText(e.currentTarget.value)}
       />
-      <ScrollArea.Autosize mah={listMaxHeight()}>
+      <ScrollArea.Autosize mah={LIST_MAX_HEIGHT}>
         <Stack gap="xs">
           {filteredPrompts.map((prompt) => (
             <PromptListItem
               key={prompt.name}
-              name={prompt.name}
-              description={prompt.description}
-              selected={prompt.selected}
-              onClick={() => onSelectPrompt(prompt.name)}
+              prompt={prompt}
+              selected={prompt.name === selectedName}
+              onClick={() => {
+                if (prompt.name !== selectedName) onSelectPrompt(prompt.name);
+              }}
             />
           ))}
         </Stack>

--- a/clients/web/src/components/groups/PromptListItem/PromptListItem.stories.tsx
+++ b/clients/web/src/components/groups/PromptListItem/PromptListItem.stories.tsx
@@ -15,23 +15,40 @@ type Story = StoryObj<typeof PromptListItem>;
 
 export const Default: Story = {
   args: {
-    name: "summarize",
-    description: "Summarize the given text into key points",
+    prompt: {
+      name: "summarize",
+      description: "Summarize the given text into key points",
+    },
     selected: false,
   },
 };
 
 export const Selected: Story = {
   args: {
-    name: "translate",
-    description: "Translate text from one language to another",
+    prompt: {
+      name: "translate",
+      description: "Translate text from one language to another",
+    },
     selected: true,
+  },
+};
+
+export const WithTitle: Story = {
+  args: {
+    prompt: {
+      name: "code-review",
+      title: "Code Review",
+      description: "Review code for issues and best practices",
+    },
+    selected: false,
   },
 };
 
 export const NoDescription: Story = {
   args: {
-    name: "code-review",
+    prompt: {
+      name: "code-review",
+    },
     selected: false,
   },
 };

--- a/clients/web/src/components/groups/PromptListItem/PromptListItem.tsx
+++ b/clients/web/src/components/groups/PromptListItem/PromptListItem.tsx
@@ -1,8 +1,8 @@
 import { Stack, Text, UnstyledButton } from "@mantine/core";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 
 export interface PromptListItemProps {
-  name: string;
-  description?: string;
+  prompt: Prompt;
   selected: boolean;
   onClick: () => void;
 }
@@ -18,11 +18,11 @@ const DescriptionText = Text.withProps({
 });
 
 export function PromptListItem({
-  name,
-  description,
+  prompt,
   selected,
   onClick,
 }: PromptListItemProps) {
+  const { name, title, description } = prompt;
   return (
     <UnstyledButton
       w="100%"
@@ -32,7 +32,7 @@ export function PromptListItem({
       onClick={onClick}
     >
       <Stack gap={2}>
-        <NameText>{name}</NameText>
+        <NameText>{title ?? name}</NameText>
         {description && <DescriptionText>{description}</DescriptionText>}
       </Stack>
     </UnstyledButton>

--- a/clients/web/src/components/groups/PromptMessagesDisplay/PromptMessagesDisplay.stories.tsx
+++ b/clients/web/src/components/groups/PromptMessagesDisplay/PromptMessagesDisplay.stories.tsx
@@ -52,17 +52,11 @@ export const WithImage: Story = {
     messages: [
       {
         role: "user",
-        content: [
-          {
-            type: "text",
-            text: "Here is a photo for you to analyze.",
-          },
-          {
-            type: "image",
-            data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
-            mimeType: "image/png",
-          },
-        ],
+        content: {
+          type: "image",
+          data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+          mimeType: "image/png",
+        },
       },
     ],
   },

--- a/clients/web/src/components/groups/PromptMessagesDisplay/PromptMessagesDisplay.tsx
+++ b/clients/web/src/components/groups/PromptMessagesDisplay/PromptMessagesDisplay.tsx
@@ -1,19 +1,16 @@
 import { Button, Group, Stack, Text, Title } from "@mantine/core";
-import type {
-  PromptMessage,
-  SamplingMessage,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { PromptMessage } from "@modelcontextprotocol/sdk/types.js";
 import { MessageBubble } from "../../elements/MessageBubble/MessageBubble";
+
+export interface PromptMessagesDisplayProps {
+  messages: PromptMessage[];
+  onCopyAll?: () => void;
+}
 
 const CopyAllButton = Button.withProps({
   variant: "subtle",
   size: "sm",
 });
-
-export interface PromptMessagesDisplayProps {
-  messages: (PromptMessage | SamplingMessage)[];
-  onCopyAll?: () => void;
-}
 
 export function PromptMessagesDisplay({
   messages,

--- a/clients/web/src/components/screens/PromptsScreen/PromptsScreen.stories.tsx
+++ b/clients/web/src/components/screens/PromptsScreen/PromptsScreen.stories.tsx
@@ -91,6 +91,26 @@ export const WithResult: Story = {
   },
 };
 
+export const Loading: Story = {
+  args: {
+    prompts: samplePrompts,
+    selectedPromptName: "translate",
+    getPromptState: { status: "pending" },
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    prompts: samplePrompts,
+    selectedPromptName: "translate",
+    getPromptState: {
+      status: "error",
+      error:
+        'Prompt "translate" requires argument "text" but none was provided. Please fill in all required arguments before submitting.',
+    },
+  },
+};
+
 export const ListChanged: Story = {
   args: {
     prompts: samplePrompts,

--- a/clients/web/src/components/screens/PromptsScreen/PromptsScreen.stories.tsx
+++ b/clients/web/src/components/screens/PromptsScreen/PromptsScreen.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { fn } from "storybook/test";
 import { PromptsScreen } from "./PromptsScreen";
-import type { PromptItem, SelectedPrompt } from "./PromptsScreen";
+import type { GetPromptState } from "./PromptsScreen";
 
 const meta: Meta<typeof PromptsScreen> = {
   title: "Screens/PromptsScreen",
@@ -10,8 +11,8 @@ const meta: Meta<typeof PromptsScreen> = {
   args: {
     onRefreshList: fn(),
     onSelectPrompt: fn(),
-    onArgumentChange: fn(),
     onGetPrompt: fn(),
+    onCopyMessages: fn(),
     listChanged: false,
   },
 };
@@ -19,42 +20,54 @@ const meta: Meta<typeof PromptsScreen> = {
 export default meta;
 type Story = StoryObj<typeof PromptsScreen>;
 
-const samplePrompts: PromptItem[] = [
+const samplePrompts: Prompt[] = [
   {
     name: "summarize",
     description: "Summarize the given text into key points",
-    selected: false,
   },
   {
     name: "translate",
     description: "Translate text from one language to another",
-    selected: false,
+    arguments: [
+      { name: "text", required: true, description: "The text to translate" },
+      {
+        name: "targetLanguage",
+        required: true,
+        description: "Target language code",
+      },
+    ],
   },
   {
     name: "code-review",
     description: "Review code for issues",
-    selected: false,
   },
   {
     name: "analyze",
     description: "Analyze sentiment and tone of the text",
-    selected: false,
   },
-  { name: "refactor", selected: false },
+  { name: "refactor" },
 ];
 
-const selectedTranslate: SelectedPrompt = {
-  name: "translate",
-  description: "Translate text from one language to another",
-  arguments: [
-    { name: "text", required: true, description: "The text to translate" },
-    {
-      name: "targetLanguage",
-      required: true,
-      description: "Target language code",
-    },
-  ],
-  argumentValues: {},
+const translateResult: GetPromptState = {
+  status: "ok",
+  result: {
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: 'Translate the following text to Spanish: "Hello, how are you?"',
+        },
+      },
+      {
+        role: "assistant",
+        content: {
+          type: "text",
+          text: "Hola, como estas?",
+        },
+      },
+    ],
+  },
 };
 
 export const NoSelection: Story = {
@@ -65,44 +78,16 @@ export const NoSelection: Story = {
 
 export const PromptSelected: Story = {
   args: {
-    prompts: samplePrompts.map((p) =>
-      p.name === "translate" ? { ...p, selected: true } : p,
-    ),
-    selectedPrompt: selectedTranslate,
+    prompts: samplePrompts,
+    selectedPromptName: "translate",
   },
 };
 
 export const WithResult: Story = {
   args: {
-    prompts: samplePrompts.map((p) =>
-      p.name === "translate" ? { ...p, selected: true } : p,
-    ),
-    selectedPrompt: {
-      ...selectedTranslate,
-      argumentValues: {
-        text: "Hello, how are you?",
-        targetLanguage: "es",
-      },
-    },
-    messages: {
-      onCopyAll: fn(),
-      messages: [
-        {
-          role: "user",
-          content: {
-            type: "text",
-            text: 'Translate the following text to Spanish: "Hello, how are you?"',
-          },
-        },
-        {
-          role: "assistant",
-          content: {
-            type: "text",
-            text: "Hola, como estas?",
-          },
-        },
-      ],
-    },
+    prompts: samplePrompts,
+    selectedPromptName: "translate",
+    getPromptState: translateResult,
   },
 };
 

--- a/clients/web/src/components/screens/PromptsScreen/PromptsScreen.tsx
+++ b/clients/web/src/components/screens/PromptsScreen/PromptsScreen.tsx
@@ -1,32 +1,28 @@
+import { useState } from "react";
 import { Card, Flex, Group, ScrollArea, Stack, Text } from "@mantine/core";
+import type {
+  GetPromptResult,
+  Prompt,
+} from "@modelcontextprotocol/sdk/types.js";
 import { PromptControls } from "../../groups/PromptControls/PromptControls";
 import { PromptArgumentsForm } from "../../groups/PromptArgumentsForm/PromptArgumentsForm";
 import { PromptMessagesDisplay } from "../../groups/PromptMessagesDisplay/PromptMessagesDisplay";
-import type { PromptArgument } from "../../groups/PromptArgumentsForm/PromptArgumentsForm";
-import type { PromptMessagesDisplayProps } from "../../groups/PromptMessagesDisplay/PromptMessagesDisplay";
 
-export interface PromptItem {
-  name: string;
-  description?: string;
-  selected: boolean;
-}
-
-export interface SelectedPrompt {
-  name: string;
-  description?: string;
-  arguments: PromptArgument[];
-  argumentValues: Record<string, string>;
+export interface GetPromptState {
+  status: "idle" | "pending" | "ok" | "error";
+  result?: GetPromptResult;
+  error?: string;
 }
 
 export interface PromptsScreenProps {
-  prompts: PromptItem[];
-  selectedPrompt?: SelectedPrompt;
-  messages?: PromptMessagesDisplayProps;
+  prompts: Prompt[];
+  selectedPromptName?: string;
+  getPromptState?: GetPromptState;
   listChanged: boolean;
   onRefreshList: () => void;
   onSelectPrompt: (name: string) => void;
-  onArgumentChange: (name: string, value: string) => void;
-  onGetPrompt: () => void;
+  onGetPrompt: (name: string, args: Record<string, string>) => void;
+  onCopyMessages?: () => void;
 }
 
 const ScreenLayout = Flex.withProps({
@@ -60,23 +56,34 @@ const EmptyState = Text.withProps({
 
 export function PromptsScreen({
   prompts,
-  selectedPrompt,
-  messages,
+  selectedPromptName,
+  getPromptState,
   listChanged,
   onRefreshList,
   onSelectPrompt,
-  onArgumentChange,
   onGetPrompt,
+  onCopyMessages,
 }: PromptsScreenProps) {
+  const [argumentValues, setArgumentValues] = useState<Record<string, string>>(
+    {},
+  );
+  const selectedPrompt = selectedPromptName
+    ? prompts.find((p) => p.name === selectedPromptName)
+    : undefined;
+
   return (
     <ScreenLayout>
       <Sidebar>
         <SidebarCard>
           <PromptControls
             prompts={prompts}
+            selectedName={selectedPromptName}
             listChanged={listChanged}
             onRefreshList={onRefreshList}
-            onSelectPrompt={onSelectPrompt}
+            onSelectPrompt={(name) => {
+              setArgumentValues({});
+              onSelectPrompt(name);
+            }}
           />
         </SidebarCard>
       </Sidebar>
@@ -90,17 +97,22 @@ export function PromptsScreen({
             <>
               <DetailCard>
                 <PromptArgumentsForm
-                  name={selectedPrompt.name}
-                  description={selectedPrompt.description}
-                  arguments={selectedPrompt.arguments}
-                  argumentValues={selectedPrompt.argumentValues}
-                  onArgumentChange={onArgumentChange}
-                  onGetPrompt={onGetPrompt}
+                  prompt={selectedPrompt}
+                  argumentValues={argumentValues}
+                  onArgumentChange={(name, value) =>
+                    setArgumentValues((prev) => ({ ...prev, [name]: value }))
+                  }
+                  onGetPrompt={() =>
+                    onGetPrompt(selectedPrompt.name, argumentValues)
+                  }
                 />
               </DetailCard>
-              {messages && (
+              {getPromptState?.result && (
                 <DetailCard>
-                  <PromptMessagesDisplay {...messages} />
+                  <PromptMessagesDisplay
+                    messages={getPromptState.result.messages}
+                    onCopyAll={onCopyMessages}
+                  />
                 </DetailCard>
               )}
             </>

--- a/clients/web/src/components/screens/PromptsScreen/PromptsScreen.tsx
+++ b/clients/web/src/components/screens/PromptsScreen/PromptsScreen.tsx
@@ -1,5 +1,14 @@
 import { useState } from "react";
-import { Card, Flex, Group, ScrollArea, Stack, Text } from "@mantine/core";
+import {
+  Alert,
+  Card,
+  Flex,
+  Group,
+  Loader,
+  ScrollArea,
+  Stack,
+  Text,
+} from "@mantine/core";
 import type {
   GetPromptResult,
   Prompt,
@@ -107,6 +116,21 @@ export function PromptsScreen({
                   }
                 />
               </DetailCard>
+              {getPromptState?.status === "pending" && (
+                <DetailCard>
+                  <Stack align="center" py="xl">
+                    <Loader size="sm" />
+                    <Text c="dimmed">Loading prompt...</Text>
+                  </Stack>
+                </DetailCard>
+              )}
+              {getPromptState?.status === "error" && (
+                <DetailCard>
+                  <Alert color="red" variant="light" title="Prompt Error">
+                    {getPromptState.error ?? "Failed to get prompt"}
+                  </Alert>
+                </DetailCard>
+              )}
               {getPromptState?.result && (
                 <DetailCard>
                   <PromptMessagesDisplay

--- a/clients/web/src/components/views/ConnectedView/ConnectedView.stories.tsx
+++ b/clients/web/src/components/views/ConnectedView/ConnectedView.stories.tsx
@@ -594,60 +594,52 @@ export const PromptsActive: Story = {
           {
             name: "summarize",
             description: "Summarize a document",
-            selected: false,
           },
           {
             name: "translate",
             description: "Translate text to another language",
-            selected: true,
+            arguments: [
+              {
+                name: "text",
+                required: true,
+                description: "The text to translate",
+              },
+              {
+                name: "targetLanguage",
+                required: true,
+                description: "Target language code",
+              },
+            ],
           },
           {
             name: "code-review",
             description: "Review code for issues",
-            selected: false,
           },
         ]}
-        selectedPrompt={{
-          name: "translate",
-          description: "Translate text to another language",
-          arguments: [
-            {
-              name: "text",
-              required: true,
-              description: "The text to translate",
-            },
-            {
-              name: "targetLanguage",
-              required: true,
-              description: "Target language code",
-            },
-          ],
-          argumentValues: {
-            text: "Hello, how are you?",
-            targetLanguage: "es",
-          },
-        }}
-        messages={{
-          onCopyAll: fn(),
-          messages: [
-            {
-              role: "user",
-              content: {
-                type: "text",
-                text: 'Translate the following text to Spanish: "Hello, how are you?"',
+        selectedPromptName="translate"
+        getPromptState={{
+          status: "ok",
+          result: {
+            messages: [
+              {
+                role: "user",
+                content: {
+                  type: "text",
+                  text: 'Translate the following text to Spanish: "Hello, how are you?"',
+                },
               },
-            },
-            {
-              role: "assistant",
-              content: { type: "text", text: "Hola, como estas?" },
-            },
-          ],
+              {
+                role: "assistant",
+                content: { type: "text", text: "Hola, como estas?" },
+              },
+            ],
+          },
         }}
         listChanged={true}
         onRefreshList={fn()}
         onSelectPrompt={fn()}
-        onArgumentChange={fn()}
         onGetPrompt={fn()}
+        onCopyMessages={fn()}
       />
     ),
   },


### PR DESCRIPTION
## Summary

- **PromptListItem**: accepts `prompt: Prompt` instead of flat `name`/`description`; renders `title ?? name`
- **PromptControls**: accepts `Prompt[]` + `selectedName` instead of `PromptItem[]`; no-ops on re-selecting; search includes `title`
- **PromptArgumentsForm**: accepts `prompt: Prompt` instead of flat props; reads `prompt.arguments` directly; shows `title ?? name` heading
- **PromptMessagesDisplay**: narrowed from `(PromptMessage | SamplingMessage)[]` to `PromptMessage[]`
- **PromptsScreen**: accepts `Prompt[]` + `selectedPromptName` + `GetPromptState` discriminated union; derives selected prompt via `prompts.find()`; owns `argumentValues` state locally; resets on prompt switch
- Updates ConnectedView `PromptsActive` story

### Deleted local types
| Old type | Replaced by |
|---|---|
| `PromptItem` (PromptsScreen) | `Prompt` from SDK |
| `SelectedPrompt` (PromptsScreen) | `Prompt` from SDK + local `argumentValues` |
| `PromptArgument` (PromptArgumentsForm) | `PromptArgument` from SDK (note: `required` is `boolean?` not `boolean`) |

## Test plan
- [x] `npm run format` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` (includes `tsc -b`) — passes
- [ ] Visually verify Storybook stories for all Prompts cluster components
- [ ] Verify ConnectedView PromptsActive story renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)