### PR TITLE
Phase 2: Refactor Logs cluster to MCP SDK types

### DIFF
--- a/clients/web/src/components/groups/LogControls/LogControls.stories.tsx
+++ b/clients/web/src/components/groups/LogControls/LogControls.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
 import { fn } from "storybook/test";
 import { LogControls } from "./LogControls";
 
-const allLevelsVisible: Record<string, boolean> = {
+const allLevelsVisible: Record<LoggingLevel, boolean> = {
   debug: true,
   info: true,
   notice: true,

--- a/clients/web/src/components/groups/LogControls/LogControls.tsx
+++ b/clients/web/src/components/groups/LogControls/LogControls.tsx
@@ -73,7 +73,9 @@ export function LogControls({
           data={LOG_LEVELS.map((level) => ({ value: level, label: level }))}
           value={currentLevel}
           onChange={(value) => {
-            if (value) onSetLevel(value as LoggingLevel);
+            if (value && LOG_LEVELS.includes(value as LoggingLevel)) {
+              onSetLevel(value as LoggingLevel);
+            }
           }}
         />
         <Button size="sm" onClick={() => onSetLevel(currentLevel)}>

--- a/clients/web/src/components/groups/LogControls/LogControls.tsx
+++ b/clients/web/src/components/groups/LogControls/LogControls.tsx
@@ -8,8 +8,9 @@ import {
   Title,
   UnstyledButton,
 } from "@mantine/core";
+import type { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
 
-const LOG_LEVELS = [
+const LOG_LEVELS: LoggingLevel[] = [
   "debug",
   "info",
   "notice",
@@ -18,9 +19,9 @@ const LOG_LEVELS = [
   "critical",
   "alert",
   "emergency",
-] as const;
+];
 
-const LEVEL_COLORS: Record<string, { c: string }> = {
+const LEVEL_COLORS: Record<LoggingLevel, { c: string }> = {
   debug: { c: "dimmed" },
   info: { c: "blue" },
   notice: { c: "teal" },
@@ -37,12 +38,12 @@ const SubtleButton = Button.withProps({
 });
 
 export interface LogControlsProps {
-  currentLevel: string;
+  currentLevel: LoggingLevel;
   filterText: string;
-  visibleLevels: Record<string, boolean>;
-  onSetLevel: (level: string) => void;
+  visibleLevels: Record<LoggingLevel, boolean>;
+  onSetLevel: (level: LoggingLevel) => void;
   onFilterChange: (text: string) => void;
-  onToggleLevel: (level: string, visible: boolean) => void;
+  onToggleLevel: (level: LoggingLevel, visible: boolean) => void;
   onToggleAllLevels: () => void;
 }
 
@@ -72,7 +73,7 @@ export function LogControls({
           data={LOG_LEVELS.map((level) => ({ value: level, label: level }))}
           value={currentLevel}
           onChange={(value) => {
-            if (value) onSetLevel(value);
+            if (value) onSetLevel(value as LoggingLevel);
           }}
         />
         <Button size="sm" onClick={() => onSetLevel(currentLevel)}>

--- a/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
+++ b/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
@@ -9,13 +9,14 @@ import {
   Text,
   Title,
 } from "@mantine/core";
+import type { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
 import { LogEntry } from "../../elements/LogEntry/LogEntry";
 import type { LogEntryData } from "../../elements/LogEntry/LogEntry";
 
 export interface LogStreamPanelProps {
   entries: LogEntryData[];
   filterText: string;
-  visibleLevels: Record<string, boolean>;
+  visibleLevels: Record<LoggingLevel, boolean>;
   autoScroll: boolean;
   onToggleAutoScroll: () => void;
   onCopyAll: () => void;
@@ -50,7 +51,7 @@ function formatData(data: unknown): string {
 function matchesFilters(
   entry: LogEntryData,
   filterText: string,
-  visibleLevels: Record<string, boolean>,
+  visibleLevels: Record<LoggingLevel, boolean>,
 ): boolean {
   if (!visibleLevels[entry.params.level]) return false;
   if (filterText) {

--- a/clients/web/src/components/screens/LoggingScreen/LoggingScreen.tsx
+++ b/clients/web/src/components/screens/LoggingScreen/LoggingScreen.tsx
@@ -1,13 +1,14 @@
 import { useState } from "react";
 import { Card, Flex, Stack } from "@mantine/core";
+import type { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
 import { LogControls } from "../../groups/LogControls/LogControls";
 import { LogStreamPanel } from "../../groups/LogStreamPanel/LogStreamPanel";
 import type { LogEntryData } from "../../elements/LogEntry/LogEntry";
 
 export interface LoggingScreenProps {
   entries: LogEntryData[];
-  currentLevel: string;
-  onSetLevel: (level: string) => void;
+  currentLevel: LoggingLevel;
+  onSetLevel: (level: LoggingLevel) => void;
   onClear: () => void;
   onExport: () => void;
   autoScroll: boolean;
@@ -15,7 +16,7 @@ export interface LoggingScreenProps {
   onCopyAll: () => void;
 }
 
-const ALL_LEVELS_VISIBLE: Record<string, boolean> = {
+const ALL_LEVELS_VISIBLE: Record<LoggingLevel, boolean> = {
   debug: true,
   info: true,
   notice: true,
@@ -24,6 +25,17 @@ const ALL_LEVELS_VISIBLE: Record<string, boolean> = {
   critical: true,
   alert: true,
   emergency: true,
+};
+
+const NO_LEVELS_VISIBLE: Record<LoggingLevel, boolean> = {
+  debug: false,
+  info: false,
+  notice: false,
+  warning: false,
+  error: false,
+  critical: false,
+  alert: false,
+  emergency: false,
 };
 
 const ScreenLayout = Flex.withProps({
@@ -55,15 +67,11 @@ export function LoggingScreen({
 }: LoggingScreenProps) {
   const [filterText, setFilterText] = useState("");
   const [visibleLevels, setVisibleLevels] =
-    useState<Record<string, boolean>>(ALL_LEVELS_VISIBLE);
+    useState<Record<LoggingLevel, boolean>>(ALL_LEVELS_VISIBLE);
 
-  function handleToggleLevel(level: string, visible: boolean) {
+  function handleToggleLevel(level: LoggingLevel, visible: boolean) {
     setVisibleLevels((prev) => ({ ...prev, [level]: visible }));
   }
-
-  const NO_LEVELS_VISIBLE: Record<string, boolean> = Object.fromEntries(
-    Object.keys(ALL_LEVELS_VISIBLE).map((k) => [k, false]),
-  );
 
   function handleToggleAllLevels() {
     const allSelected = Object.values(visibleLevels).every(Boolean);


### PR DESCRIPTION
## Summary

- **LogControls**: types `currentLevel`, `visibleLevels`, and all handler params with `LoggingLevel` instead of `string`; `LOG_LEVELS` array and `LEVEL_COLORS` record properly typed
- **LogStreamPanel**: types `visibleLevels` as `Record<LoggingLevel, boolean>`
- **LoggingScreen**: types `currentLevel`, `onSetLevel`, internal `visibleLevels` state and toggle handlers with `LoggingLevel`; extracts `NO_LEVELS_VISIBLE` as module-level constant

This is the smallest cluster — the `LogEntry` element was already refactored in Phase 1 to use `LoggingMessageNotification["params"]` and `LoggingLevel` from the SDK, so the group/screen layer just needed its type signatures tightened to match.

No ConnectedView story changes needed — it already passes valid `LoggingLevel` literals.

## Test plan
- [x] `npm run format` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` (includes `tsc -b`) — passes
- [ ] Visually verify Storybook stories for LogControls, LogStreamPanel, LoggingScreen
- [ ] Verify ConnectedView LoggingActive story renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)