### PR TITLE
fix(layout): make all panels resizable, not just History

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1360,7 +1360,7 @@ const App = () => {
         />
       </div>
       <div className="flex-1 flex flex-col overflow-hidden">
-        <div className="flex-1 overflow-auto">
+        <div className="flex-1 overflow-auto min-h-0">
           {mcpClient ? (
             <Tabs
               value={activeTab}
@@ -1706,7 +1706,7 @@ const App = () => {
           )}
         </div>
         <div
-          className="relative border-t border-border"
+          className="relative border-t border-border flex-shrink-0"
           style={{
             height: `${historyPaneHeight}px`,
           }}


### PR DESCRIPTION
Closes #1172.

Classic flex-column bug: the right content column nested a `flex-1 overflow-auto` top pane that inherited `min-height: auto`, so Tools, Prompts, and Resources kept their intrinsic height and refused to shrink. The History pane updated visually because it had an explicit `style.height`. Added `min-h-0` to the top pane and `flex-shrink-0` to the History pane in `client/src/App.tsx`.

`useDraggablePane` was already correct; CSS only.