### PR TITLE
feat(auth): support OAuth 2.0 client_credentials grant type

### DIFF
--- a/client/src/components/AuthDebugger.tsx
+++ b/client/src/components/AuthDebugger.tsx
@@ -1,5 +1,8 @@
-import { useCallback, useMemo, useEffect } from "react";
+import { useCallback, useMemo, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { DebugInspectorOAuthClientProvider } from "../lib/auth";
 import { AlertCircle } from "lucide-react";
 import { AuthDebuggerState, EMPTY_DEBUGGER_STATE } from "../lib/auth-types";
@@ -9,6 +12,7 @@ import { createProxyFetch } from "../lib/proxyFetch";
 import { SESSION_KEYS } from "../lib/constants";
 import { validateRedirectUrl } from "@/utils/urlValidation";
 import type { InspectorConfig } from "../lib/configurationTypes";
+import { exchangeClientCredentials } from "../lib/clientCredentialsAuth";
 
 export interface AuthDebuggerProps {
   serverUrl: string;
@@ -255,6 +259,92 @@ const AuthDebugger = ({
     }
   }, [serverUrl, updateAuthState]);
 
+  // ----- Client Credentials grant -----
+  // Form state is local: this flow is a single token request, not a multi-step
+  // state machine, so it doesn't need to live in shared AuthDebuggerState.
+  const [ccTokenEndpoint, setCcTokenEndpoint] = useState("");
+  const [ccClientId, setCcClientId] = useState("");
+  const [ccClientSecret, setCcClientSecret] = useState("");
+  const [ccScope, setCcScope] = useState("");
+  const [ccAuthMethod, setCcAuthMethod] = useState<"basic" | "body">("basic");
+
+  const handleClientCredentialsExchange = useCallback(async () => {
+    if (!serverUrl) {
+      updateAuthState({
+        statusMessage: {
+          type: "error",
+          message:
+            "Please enter a server URL in the sidebar before authenticating",
+        },
+      });
+      return;
+    }
+
+    if (!ccTokenEndpoint || !ccClientId || !ccClientSecret) {
+      updateAuthState({
+        statusMessage: {
+          type: "error",
+          message:
+            "Token Endpoint, Client ID, and Client Secret are required for client_credentials",
+        },
+      });
+      return;
+    }
+
+    updateAuthState({
+      isInitiatingAuth: true,
+      statusMessage: null,
+      latestError: null,
+    });
+
+    try {
+      const tokens = await exchangeClientCredentials(
+        {
+          tokenEndpoint: ccTokenEndpoint,
+          clientId: ccClientId,
+          clientSecret: ccClientSecret,
+          scope: ccScope || undefined,
+          authMethod: ccAuthMethod,
+        },
+        fetchFn,
+      );
+
+      const provider = new DebugInspectorOAuthClientProvider(serverUrl);
+      provider.saveTokens(tokens);
+
+      updateAuthState({
+        oauthTokens: tokens,
+        oauthStep: "complete",
+        statusMessage: {
+          type: "success",
+          message:
+            "Obtained access token via client_credentials grant. It will be used automatically for server requests.",
+        },
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      updateAuthState({
+        latestError: error instanceof Error ? error : new Error(message),
+        statusMessage: {
+          type: "error",
+          message: `client_credentials flow failed: ${message}`,
+        },
+      });
+    } finally {
+      updateAuthState({ isInitiatingAuth: false });
+    }
+  }, [
+    serverUrl,
+    ccTokenEndpoint,
+    ccClientId,
+    ccClientSecret,
+    ccScope,
+    ccAuthMethod,
+    fetchFn,
+    updateAuthState,
+  ]);
+
   return (
     <div className="w-full p-4">
       <div className="flex justify-between items-center mb-6">
@@ -281,48 +371,163 @@ const AuthDebugger = ({
                 <StatusMessage message={authState.statusMessage} />
               )}
 
-              <div className="space-y-4">
-                {authState.oauthTokens && (
-                  <div className="space-y-2">
-                    <p className="text-sm font-medium">Access Token:</p>
-                    <div className="bg-muted p-2 rounded-md text-xs overflow-x-auto">
-                      {authState.oauthTokens.access_token.substring(0, 25)}...
+              {authState.oauthTokens && (
+                <div className="space-y-2">
+                  <p className="text-sm font-medium">Access Token:</p>
+                  <div className="bg-muted p-2 rounded-md text-xs overflow-x-auto">
+                    {authState.oauthTokens.access_token.substring(0, 25)}...
+                  </div>
+                </div>
+              )}
+
+              <Tabs defaultValue="authorization_code" className="w-full">
+                <TabsList>
+                  <TabsTrigger value="authorization_code">
+                    Authorization Code
+                  </TabsTrigger>
+                  <TabsTrigger value="client_credentials">
+                    Client Credentials
+                  </TabsTrigger>
+                </TabsList>
+
+                <TabsContent
+                  value="authorization_code"
+                  className="space-y-4 pt-4"
+                >
+                  <div className="flex gap-4 flex-wrap">
+                    <Button
+                      variant="outline"
+                      onClick={startOAuthFlow}
+                      disabled={authState.isInitiatingAuth}
+                    >
+                      {authState.oauthTokens
+                        ? "Guided Token Refresh"
+                        : "Guided OAuth Flow"}
+                    </Button>
+
+                    <Button
+                      onClick={handleQuickOAuth}
+                      disabled={authState.isInitiatingAuth}
+                    >
+                      {authState.isInitiatingAuth
+                        ? "Initiating..."
+                        : authState.oauthTokens
+                          ? "Quick Refresh"
+                          : "Quick OAuth Flow"}
+                    </Button>
+
+                    <Button variant="outline" onClick={handleClearOAuth}>
+                      Clear OAuth State
+                    </Button>
+                  </div>
+
+                  <p className="text-xs text-muted-foreground">
+                    Choose "Guided" for step-by-step instructions or "Quick" for
+                    the standard automatic flow.
+                  </p>
+                </TabsContent>
+
+                <TabsContent
+                  value="client_credentials"
+                  className="space-y-4 pt-4"
+                >
+                  <p className="text-sm text-muted-foreground">
+                    OAuth 2.0 client_credentials grant. Use this for
+                    service-to-service MCP servers (e.g. behind an API gateway)
+                    where the inspector is the client.
+                  </p>
+
+                  <div className="grid gap-3">
+                    <div className="grid gap-1.5">
+                      <Label htmlFor="cc-token-endpoint">
+                        Token Endpoint
+                      </Label>
+                      <Input
+                        id="cc-token-endpoint"
+                        type="url"
+                        autoComplete="off"
+                        placeholder="https://auth.example.com/oauth/token"
+                        value={ccTokenEndpoint}
+                        onChange={(e) => setCcTokenEndpoint(e.target.value)}
+                      />
+                    </div>
+
+                    <div className="grid gap-1.5">
+                      <Label htmlFor="cc-client-id">Client ID</Label>
+                      <Input
+                        id="cc-client-id"
+                        autoComplete="off"
+                        value={ccClientId}
+                        onChange={(e) => setCcClientId(e.target.value)}
+                      />
+                    </div>
+
+                    <div className="grid gap-1.5">
+                      <Label htmlFor="cc-client-secret">Client Secret</Label>
+                      <Input
+                        id="cc-client-secret"
+                        type="password"
+                        autoComplete="off"
+                        value={ccClientSecret}
+                        onChange={(e) => setCcClientSecret(e.target.value)}
+                      />
+                    </div>
+
+                    <div className="grid gap-1.5">
+                      <Label htmlFor="cc-scope">Scope (optional)</Label>
+                      <Input
+                        id="cc-scope"
+                        autoComplete="off"
+                        placeholder="space-separated, e.g. read write"
+                        value={ccScope}
+                        onChange={(e) => setCcScope(e.target.value)}
+                      />
+                    </div>
+
+                    <div className="grid gap-1.5">
+                      <Label htmlFor="cc-auth-method">
+                        Client Authentication
+                      </Label>
+                      <select
+                        id="cc-auth-method"
+                        className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        value={ccAuthMethod}
+                        onChange={(e) =>
+                          setCcAuthMethod(
+                            e.target.value === "body" ? "body" : "basic",
+                          )
+                        }
+                      >
+                        <option value="basic">
+                          HTTP Basic (Authorization header)
+                        </option>
+                        <option value="body">
+                          Request body (client_id + client_secret)
+                        </option>
+                      </select>
+                      <p className="text-xs text-muted-foreground">
+                        Most authorization servers accept Basic. Switch to body
+                        if your server requires credentials in the form body.
+                      </p>
                     </div>
                   </div>
-                )}
 
-                <div className="flex gap-4">
-                  <Button
-                    variant="outline"
-                    onClick={startOAuthFlow}
-                    disabled={authState.isInitiatingAuth}
-                  >
-                    {authState.oauthTokens
-                      ? "Guided Token Refresh"
-                      : "Guided OAuth Flow"}
-                  </Button>
+                  <div className="flex gap-3 flex-wrap">
+                    <Button
+                      onClick={handleClientCredentialsExchange}
+                      disabled={authState.isInitiatingAuth}
+                    >
+                      {authState.isInitiatingAuth
+                        ? "Requesting token..."
+                        : "Request Token"}
+                    </Button>
 
-                  <Button
-                    onClick={handleQuickOAuth}
-                    disabled={authState.isInitiatingAuth}
-                  >
-                    {authState.isInitiatingAuth
-                      ? "Initiating..."
-                      : authState.oauthTokens
-                        ? "Quick Refresh"
-                        : "Quick OAuth Flow"}
-                  </Button>
-
-                  <Button variant="outline" onClick={handleClearOAuth}>
-                    Clear OAuth State
-                  </Button>
-                </div>
-
-                <p className="text-xs text-muted-foreground">
-                  Choose "Guided" for step-by-step instructions or "Quick" for
-                  the standard automatic flow.
-                </p>
-              </div>
+                    <Button variant="outline" onClick={handleClearOAuth}>
+                      Clear OAuth State
+                    </Button>
+                  </div>
+                </TabsContent>
+              </Tabs>
             </div>
 
             <OAuthFlowProgress

--- a/client/src/lib/__tests__/clientCredentialsAuth.test.ts
+++ b/client/src/lib/__tests__/clientCredentialsAuth.test.ts
@@ -1,0 +1,167 @@
+import {
+  buildClientCredentialsRequest,
+  exchangeClientCredentials,
+} from "../clientCredentialsAuth";
+
+describe("buildClientCredentialsRequest", () => {
+  it("uses HTTP Basic auth by default and form-encodes the body", () => {
+    const { headers, body } = buildClientCredentialsRequest({
+      tokenEndpoint: "https://auth.example.com/token",
+      clientId: "my-client",
+      clientSecret: "s3cr3t",
+    });
+
+    expect(body.get("grant_type")).toBe("client_credentials");
+    expect(body.has("client_id")).toBe(false);
+    expect(body.has("client_secret")).toBe(false);
+
+    expect(headers["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    expect(headers.Accept).toBe("application/json");
+    // base64("my-client:s3cr3t") = "bXktY2xpZW50OnMzY3IzdA=="
+    expect(headers.Authorization).toBe("Basic bXktY2xpZW50OnMzY3IzdA==");
+  });
+
+  it("includes the optional scope when provided (trimmed)", () => {
+    const { body } = buildClientCredentialsRequest({
+      tokenEndpoint: "https://auth.example.com/token",
+      clientId: "id",
+      clientSecret: "secret",
+      scope: "  read write  ",
+    });
+
+    expect(body.get("scope")).toBe("read write");
+  });
+
+  it("omits scope when blank or whitespace", () => {
+    const { body } = buildClientCredentialsRequest({
+      tokenEndpoint: "https://auth.example.com/token",
+      clientId: "id",
+      clientSecret: "secret",
+      scope: "   ",
+    });
+
+    expect(body.has("scope")).toBe(false);
+  });
+
+  it("includes optional RFC 8707 resource when provided", () => {
+    const { body } = buildClientCredentialsRequest({
+      tokenEndpoint: "https://auth.example.com/token",
+      clientId: "id",
+      clientSecret: "secret",
+      resource: "https://mcp.example.com/api",
+    });
+
+    expect(body.get("resource")).toBe("https://mcp.example.com/api");
+  });
+
+  it("sends client credentials in the body when authMethod=body", () => {
+    const { headers, body } = buildClientCredentialsRequest({
+      tokenEndpoint: "https://auth.example.com/token",
+      clientId: "my-client",
+      clientSecret: "s3cr3t",
+      authMethod: "body",
+    });
+
+    expect(headers.Authorization).toBeUndefined();
+    expect(body.get("client_id")).toBe("my-client");
+    expect(body.get("client_secret")).toBe("s3cr3t");
+  });
+
+  it("URL-encodes special characters in basic credentials", () => {
+    const { headers } = buildClientCredentialsRequest({
+      tokenEndpoint: "https://auth.example.com/token",
+      clientId: "id with space",
+      clientSecret: "p:w@rd",
+    });
+
+    // encodeURIComponent("id with space") = "id%20with%20space"
+    // encodeURIComponent("p:w@rd") = "p%3Aw%40rd"
+    // base64("id%20with%20space:p%3Aw%40rd") = "aWQlMjB3aXRoJTIwc3BhY2U6cCUzQXclNDByZA=="
+    expect(headers.Authorization).toBe(
+      "Basic aWQlMjB3aXRoJTIwc3BhY2U6cCUzQXclNDByZA==",
+    );
+  });
+});
+
+describe("exchangeClientCredentials", () => {
+  const baseInput = {
+    tokenEndpoint: "https://auth.example.com/token",
+    clientId: "my-client",
+    clientSecret: "s3cr3t",
+  };
+
+  it("POSTs to the token endpoint and returns parsed tokens on success", async () => {
+    const fetchFn = jest.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          access_token: "tkn",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "read write",
+        }),
+        {
+          status: 200,
+          statusText: "OK",
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    const tokens = await exchangeClientCredentials(
+      { ...baseInput, scope: "read write" },
+      fetchFn,
+    );
+
+    expect(tokens.access_token).toBe("tkn");
+    expect(tokens.token_type).toBe("Bearer");
+    expect(tokens.expires_in).toBe(3600);
+    expect(tokens.scope).toBe("read write");
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetchFn as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("https://auth.example.com/token");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(URLSearchParams);
+    const sentBody = init.body as URLSearchParams;
+    expect(sentBody.get("grant_type")).toBe("client_credentials");
+    expect(sentBody.get("scope")).toBe("read write");
+  });
+
+  it("throws with the OAuth error payload on a non-2xx response", async () => {
+    const fetchFn = jest.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          error: "invalid_client",
+          error_description: "secret rejected",
+        }),
+        {
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    await expect(
+      exchangeClientCredentials(baseInput, fetchFn),
+    ).rejects.toThrow(/invalid_client.*secret rejected/);
+  });
+
+  it("falls back to status line when error body is not JSON", async () => {
+    const fetchFn = jest.fn(async () => {
+      return new Response("oops", {
+        status: 500,
+        statusText: "Internal Server Error",
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      exchangeClientCredentials(baseInput, fetchFn),
+    ).rejects.toThrow(/500/);
+  });
+});

--- a/client/src/lib/clientCredentialsAuth.ts
+++ b/client/src/lib/clientCredentialsAuth.ts
@@ -1,0 +1,129 @@
+import {
+  OAuthTokens,
+  OAuthTokensSchema,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+
+/**
+ * Inputs for the OAuth 2.0 Client Credentials grant token request.
+ *
+ * RFC 6749 section 4.4.2 defines the request as:
+ *   grant_type=client_credentials [&scope=...]
+ * with the client authenticating to the token endpoint via either HTTP Basic
+ * (preferred when supported) or by including client_id/client_secret in the
+ * request body.
+ *
+ * See: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4
+ */
+export interface ClientCredentialsRequest {
+  tokenEndpoint: string;
+  clientId: string;
+  clientSecret: string;
+  scope?: string;
+  /**
+   * Optional resource indicator (RFC 8707). Some authorization servers
+   * (e.g. those securing MCP servers behind an API gateway) require it.
+   */
+  resource?: string;
+  /**
+   * How the client credentials are sent to the token endpoint. Defaults to
+   * "basic" (HTTP Basic Authentication, the OAuth 2.1 recommended approach).
+   * Use "body" when the authorization server only accepts credentials in the
+   * request body.
+   */
+  authMethod?: "basic" | "body";
+}
+
+/**
+ * Builds the body and headers for a client_credentials token request.
+ * Exposed so it can be unit-tested without performing a real fetch.
+ */
+export function buildClientCredentialsRequest(
+  options: ClientCredentialsRequest,
+): { headers: Record<string, string>; body: URLSearchParams } {
+  const { clientId, clientSecret, scope, resource, authMethod } = options;
+  const method = authMethod ?? "basic";
+
+  const body = new URLSearchParams();
+  body.set("grant_type", "client_credentials");
+  if (scope && scope.trim() !== "") {
+    body.set("scope", scope.trim());
+  }
+  if (resource) {
+    body.set("resource", resource);
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json",
+  };
+
+  if (method === "basic") {
+    // RFC 6749 section 2.3.1: client_id and client_secret must be
+    // form-urlencoded before being concatenated and base64-encoded for HTTP
+    // Basic.
+    const credentials = `${encodeURIComponent(clientId)}:${encodeURIComponent(
+      clientSecret,
+    )}`;
+    headers.Authorization = `Basic ${btoa(credentials)}`;
+  } else {
+    body.set("client_id", clientId);
+    body.set("client_secret", clientSecret);
+  }
+
+  return { headers, body };
+}
+
+/**
+ * Performs an OAuth 2.0 client_credentials token exchange against the given
+ * token endpoint and returns the parsed tokens. Throws on non-2xx responses
+ * with a message that includes the server's error/description if present.
+ */
+export async function exchangeClientCredentials(
+  options: ClientCredentialsRequest,
+  fetchFn: typeof fetch = fetch,
+): Promise<OAuthTokens> {
+  const { tokenEndpoint } = options;
+  const { headers, body } = buildClientCredentialsRequest(options);
+
+  const response = await fetchFn(tokenEndpoint, {
+    method: "POST",
+    headers,
+    body,
+  });
+
+  // Read body as text first so we can surface the OAuth error payload even
+  // when the server returns a non-JSON response.
+  const text = await response.text();
+
+  if (!response.ok) {
+    let detail = `${response.status} ${response.statusText}`.trim();
+    try {
+      const parsed = JSON.parse(text) as {
+        error?: string;
+        error_description?: string;
+      };
+      if (parsed.error) {
+        detail = parsed.error_description
+          ? `${parsed.error}: ${parsed.error_description}`
+          : parsed.error;
+      }
+    } catch {
+      // Non-JSON error body — fall back to status line, append text if short.
+      if (text && text.length < 500) {
+        detail = `${detail} - ${text}`;
+      }
+    }
+    throw new Error(`client_credentials token request failed: ${detail}`);
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new Error(
+      "client_credentials token request returned a non-JSON response",
+    );
+  }
+
+  return await OAuthTokensSchema.parseAsync(json);
+}


### PR DESCRIPTION
Closes #1225

## Why

MCP servers fronted by an API gateway with M2M credentials currently require users to manually obtain a Bearer token outside the inspector and paste it into a custom header. The issue asks for native `client_credentials` support so the inspector can do this exchange itself.

## What

- New `client/src/lib/clientCredentialsAuth.ts` exporting:
  - `buildClientCredentialsRequest()` - pure builder for the RFC 6749 section 4.4 token request (HTTP Basic by default, body fallback, optional scope, optional RFC 8707 `resource`).
  - `exchangeClientCredentials()` - performs the POST against the token endpoint, surfaces OAuth `error`/`error_description` on failure, returns parsed `OAuthTokens`.
- Refactored `AuthDebugger` to expose two tabs: **Authorization Code** (existing, unchanged behaviour) and **Client Credentials** (new). The new tab renders fields for token endpoint, client ID, client secret, optional scope, and a select for `Basic` vs `body` client authentication.
- Tokens obtained via the new flow are saved through the existing `DebugInspectorOAuthClientProvider`, so the rest of the connection / proxy stack picks them up unchanged. The proxy `fetchFn` is reused too, so the request goes through the inspector proxy when one is configured (avoids browser CORS on the auth server's token endpoint).

## Tested

- New unit tests in `client/src/lib/__tests__/clientCredentialsAuth.test.ts`:
  - default Basic auth + body shape
  - scope trimming / omission
  - body-mode credentials
  - URL-encoded special chars in basic credentials
  - successful token round-trip with a mocked `fetch`
  - error payload surfacing (`invalid_client: secret rejected`)
  - non-JSON error fallback to status line
- Existing `AuthDebugger` tests remain valid: the default tab is `authorization_code`, so all previously-asserted buttons (`Guided OAuth Flow`, `Quick OAuth Flow`, `Clear OAuth State`, `Continue` from `OAuthFlowProgress`) are still rendered.

Manual verification (suggested for reviewers): point the inspector at any MCP server behind an OAuth 2.0 client_credentials gateway (Auth0 M2M, Okta service apps, Keycloak service accounts, etc.), open Authentication Settings -> Client Credentials, fill in token endpoint / client id / secret / optional scope, click "Request Token", confirm the access token is fetched and used by subsequent requests without any header copy/paste.
