### PR TITLE
fix(sandbox): unblock postMessage from inner iframe on Safari/WebKit

### DIFF
--- a/server/static/sandbox_proxy.html
+++ b/server/static/sandbox_proxy.html
@@ -166,7 +166,19 @@
               inner.contentWindow.postMessage(event.data, "*");
             }
           }
-        } else if (event.source === inner.contentWindow) {
+        } else if (
+          event.source === inner.contentWindow ||
+          // Safari/WebKit workaround: postMessage from the inner same-origin
+          // iframe sometimes arrives at this outer sandbox with
+          // `event.source === window` instead of `inner.contentWindow`.
+          // Chromium and Firefox set the source to the inner contentWindow as
+          // expected. Without this branch, messages such as `ui/initialize`
+          // get dropped on Safari and MCP Apps fail to handshake. The origin
+          // check below remains the security boundary -- only same-origin
+          // messages (which can only originate inside this sandbox) are
+          // relayed to the host. See issue #1203.
+          (event.origin === OWN_ORIGIN && event.source === window)
+        ) {
           if (event.origin !== OWN_ORIGIN) {
             console.error(
               "[Sandbox] Rejecting message from inner iframe with unexpected origin:",


### PR DESCRIPTION
## Why

Safari/WebKit dispatches the inner iframe's `postMessage(...)` to this outer sandbox with `event.source === window` instead of `event.source === inner.contentWindow` (Chromium and Firefox use the inner `contentWindow` as expected). The relay's strict source check then dropped valid same-origin messages, so MCP Apps loaded in the inspector never completed `ui/initialize` and rendered blank on Safari desktop and iOS WebKit surfaces.

Reported and root-caused in #1203 with side-by-side Safari/Chromium instrumentation.

## What

In `server/static/sandbox_proxy.html`, accept the Safari case in addition to the existing one:

```js
} else if (
  event.source === inner.contentWindow ||
  // Safari/WebKit: inner iframe postMessage arrives with event.source === window
  (event.origin === OWN_ORIGIN && event.source === window)
) {
  // origin check stays as the security boundary
  if (event.origin !== OWN_ORIGIN) { ... }
  window.parent.postMessage(event.data, EXPECTED_HOST_ORIGIN);
}
```

Security is preserved by the existing `event.origin === OWN_ORIGIN` check: only messages from this sandbox's own origin can be relayed to the host. The added branch only widens the source-identity check, not the origin boundary. The other existing branch (parent → sandbox) is unchanged, and `EXPECTED_HOST_ORIGIN` is still used as the targetOrigin when forwarding upward (no `*`).

No new dependencies. Comment in the code explains the WebKit quirk so future readers do not re-tighten the check.

## Tested

- Read MDN's notes on `MessageEvent.source` and confirmed WebKit's behavior of reporting `window` for same-origin inner-frame messages is observable but not spec-violating; the relaxed source check is the right fix.
- Reviewed the diff against the surrounding handler -- the parent-side branch (`event.source === window.parent`) is untouched; only the inner-iframe branch widens.
- Manual verification path (matches the issue's repro):
  - [ ] Start `@modelcontextprotocol/inspector` and connect to an MCP server that returns an MCP App.
  - [ ] Open in Chromium (Brave/Chrome) -- app initializes and renders (regression check).
  - [ ] Open in Safari desktop and iOS WebKit -- app now completes `ui/initialize` and renders instead of remaining blank.
- No existing unit/playwright tests cover the static sandbox HTML; happy to add a Playwright cross-browser case if maintainers want one in this PR.

Closes #1203