### PR TITLE
fix(client): support Microsoft Edge browser

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -26,11 +26,27 @@ a:hover {
   color: #535bf2;
 }
 
+/*
+ * Give the document an explicit height chain. The app root uses
+ * Tailwind's `h-screen` (height: 100vh) and several panes use
+ * `h-full`, which on Microsoft Edge can collapse if html/body/#root
+ * do not have an explicit height. This breaks the inspector layout
+ * on Edge while still rendering fine on Chrome (issues #1222, #876).
+ *
+ * Also drop `place-items: center` from body: it was a Vite-scaffold
+ * leftover that could squeeze the UI into a centered column on
+ * Edge, leaving large empty margins on either side.
+ */
+html,
+body,
+#root {
+  height: 100%;
+  width: 100%;
+}
+
 body {
   margin: 0;
-  place-items: center;
   min-width: 320px;
-  min-height: 100vh;
 }
 
 h1 {


### PR DESCRIPTION
Closes #1222.
Addresses #876.

## Why

Microsoft Edge users see a broken inspector layout while Chrome renders correctly (issue #1222 screenshots show the page squeezed/clipped on Edge). The same root cause is described in the older still-open #876, where an Edge user pinpointed `place-items: center` on `<body>` as the trigger and confirmed that removing it instantly restores normal full-width behavior.

There are two related Vite scaffold leftovers in `client/src/index.css` that bite on Edge but not Chrome:

1. `body { place-items: center }` — a no-op on a `display: block` body in most layouts, but Edge can interact with it (combined with `min-height: 100vh`) in a way that leaves the UI centered with empty margins.
2. No explicit height chain on `html`/`body`/`#root` — the App root uses Tailwind's `h-screen` (`height: 100vh`) and nested panes use `h-full`. On Edge these can collapse if the parent chain has no defined height, which makes the layout shift or clip.

## What

`client/src/index.css`:

- Drop `place-items: center` from `body`.
- Add `html, body, #root { height: 100%; width: 100% }` so `h-screen` / `h-full` resolve deterministically on Edge the same way they already do on Chrome.
- Comment explains why so we do not regress this later.

No JS/TS changes, no dependency changes, no new APIs.

## Tested

- Manually verified the inspector loads with full-width layout on Microsoft Edge (Chromium) on the symptoms reported in #1222 and #876.
- Verified Chrome still renders identically (no visual diff).
- `npm run build` in `client/` succeeds.
