### PR TITLE
Phase 5: Cleanup pass — lift ServerEntry into core/mcp/types.ts

### DIFF
--- a/clients/web/src/components/groups/ServerCard/ServerCard.tsx
+++ b/clients/web/src/components/groups/ServerCard/ServerCard.tsx
@@ -1,8 +1,7 @@
 import { Badge, Button, Card, Group, Stack, Text } from "@mantine/core";
-import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
 import type {
-  ConnectionState,
   MCPServerConfig,
+  ServerEntry,
   ServerType,
 } from "@inspector/core/mcp/types.js";
 import { ServerStatusIndicator } from "../../elements/ServerStatusIndicator/ServerStatusIndicator";
@@ -11,14 +10,7 @@ import { ConnectionToggle } from "../../elements/ConnectionToggle/ConnectionTogg
 import { ContentViewer } from "../../elements/ContentViewer/ContentViewer";
 import { InlineError } from "../../elements/InlineError/InlineError";
 
-export interface ServerCardProps {
-  /** Stable unique identifier — the MCPConfig.mcpServers map key. */
-  id: string;
-  /** Display label shown in the card header. May or may not equal id. */
-  name: string;
-  config: MCPServerConfig;
-  info?: Implementation;
-  connection: ConnectionState;
+export interface ServerCardProps extends ServerEntry {
   activeServer?: string;
   onToggleConnection: (id: string) => void;
   onServerInfo: (id: string) => void;

--- a/clients/web/src/components/screens/ServerListScreen/ServerListScreen.stories.tsx
+++ b/clients/web/src/components/screens/ServerListScreen/ServerListScreen.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
-import { ServerListScreen, type ServerEntry } from "./ServerListScreen";
+import type { ServerEntry } from "@inspector/core/mcp/types.js";
+import { ServerListScreen } from "./ServerListScreen";
 
 const meta: Meta<typeof ServerListScreen> = {
   title: "Screens/ServerListScreen",

--- a/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
+++ b/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
@@ -1,13 +1,8 @@
 import { useState } from "react";
 import { ScrollArea, SimpleGrid, Stack, Text } from "@mantine/core";
+import type { ServerEntry } from "@inspector/core/mcp/types.js";
 import { ServerCard } from "../../groups/ServerCard/ServerCard";
 import { ServerListControls } from "../../groups/ServerListControls/ServerListControls";
-import type { ServerCardProps } from "../../groups/ServerCard/ServerCard";
-
-export type ServerEntry = Pick<
-  ServerCardProps,
-  "id" | "name" | "config" | "info" | "connection"
->;
 
 export interface ServerListScreenProps {
   servers: ServerEntry[];

--- a/clients/web/src/components/views/InspectorView/InspectorView.stories.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.stories.tsx
@@ -7,11 +7,11 @@ import type {
 import type {
   InspectorResourceSubscription,
   MessageEntry,
+  ServerEntry,
 } from "@inspector/core/mcp/types.js";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 import { InspectorView } from "./InspectorView";
-import type { ServerEntry } from "../../screens/ServerListScreen/ServerListScreen";
 import { mixedEntries as demoLogs } from "../../screens/LoggingScreen/LoggingScreen.fixtures";
 import { longToolList as demoTools } from "../../screens/ToolsScreen/ToolsScreen.fixtures";
 import type { TaskProgress } from "../../groups/TaskCard/TaskCard";

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -13,12 +13,10 @@ import type {
   ConnectionStatus,
   InspectorResourceSubscription,
   MessageEntry,
+  ServerEntry,
 } from "@inspector/core/mcp/types.js";
 import { ViewHeader } from "../../groups/ViewHeader/ViewHeader";
-import {
-  ServerListScreen,
-  type ServerEntry,
-} from "../../screens/ServerListScreen/ServerListScreen";
+import { ServerListScreen } from "../../screens/ServerListScreen/ServerListScreen";
 import { ToolsScreen } from "../../screens/ToolsScreen/ToolsScreen";
 import { PromptsScreen } from "../../screens/PromptsScreen/PromptsScreen";
 import { ResourcesScreen } from "../../screens/ResourcesScreen/ResourcesScreen";

--- a/core/mcp/types.ts
+++ b/core/mcp/types.ts
@@ -70,11 +70,6 @@ export interface ConnectionState {
   error?: { message: string; details?: string };
 }
 
-/**
- * One server entry as seen by the UI: identity, transport config, optional
- * `Implementation` info reported during `initialize`, and the current
- * connection snapshot. Cards/screens spread this onto presentational props.
- */
 export interface ServerEntry {
   /** Stable unique identifier — the MCPConfig.mcpServers map key. */
   id: string;

--- a/core/mcp/types.ts
+++ b/core/mcp/types.ts
@@ -70,6 +70,21 @@ export interface ConnectionState {
   error?: { message: string; details?: string };
 }
 
+/**
+ * One server entry as seen by the UI: identity, transport config, optional
+ * `Implementation` info reported during `initialize`, and the current
+ * connection snapshot. Cards/screens spread this onto presentational props.
+ */
+export interface ServerEntry {
+  /** Stable unique identifier — the MCPConfig.mcpServers map key. */
+  id: string;
+  /** Display label shown in the card header. May or may not equal id. */
+  name: string;
+  config: MCPServerConfig;
+  info?: Implementation;
+  connection: ConnectionState;
+}
+
 export interface StderrLogEntry {
   timestamp: Date;
   message: string;


### PR DESCRIPTION
## Summary

Phase 5 of the [V2 UX Component Interfaces plan](specification/v2_ux_interfaces_plan.md) — the cleanup pass after Phases 0-4.

The vast majority of Phase 0.3's local-type inventory was already retired by Phases 1-4 (verified by `git grep`). The one real survivor was **`ServerEntry = Pick<ServerCardProps, ...>`** in `ServerListScreen.tsx` — the "Props as a data shape" smell Phase 5 step 3 calls out by name.

This PR fixes that:

- Adds canonical `ServerEntry` interface to `core/mcp/types.ts` (id, name, config, info?, connection)
- `ServerCardProps extends ServerEntry` instead of `ServerEntry` deriving from it
- `ServerListScreen`, `InspectorView`, and both `*.stories.tsx` consumers now import `ServerEntry` from `core/` directly
- Drops now-unused `Implementation` and `ConnectionState` imports from `ServerCard.tsx`

## Audit findings (no action needed)

- `JsonSchema`, `LogLevel`, `RootEntry`, `PromptItem`, `SelectedPrompt`, `ResourceItem`, `TemplateListItem`, `SubscriptionItem`, `KeyValuePair` — all gone
- Inline `ConnectionStatus` / transport unions — all gone
- `TaskStatus`, `ToolListItemProps`, `TaskCardProps` — survived but each consumes the proper SDK type (`Task`, `Tool`); these are legitimate UI prop interfaces, not data-shape misuse
- `(likely)` hedges in `v2_ux_interfaces.md` — 0 remaining
- `clients/web/README.md` — unmodified Vite scaffolding; references none of the changed shapes
- The "lift `clients/web/src/types/inspector/` into `core/types/`" follow-up from Phase 5 step 5 is moot — that directory never existed; the only file under `clients/web/src/types/` is `navigation.ts` for `InspectorTab`, which the plan explicitly placed there

## Test plan

- [x] `npm run format` clean
- [x] `npm run lint` clean
- [x] `npm run build` (includes `tsc -b`) clean
- [ ] Spot-check `ServerListScreen` and `InspectorView` stories in Storybook still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)