### PR TITLE
fix(history): clear stale methodFilter on clear-all

### DIFF
--- a/clients/web/src/components/screens/HistoryScreen/HistoryScreen.stories.tsx
+++ b/clients/web/src/components/screens/HistoryScreen/HistoryScreen.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { MessageEntry } from "../../../../../../core/mcp/types.js";
-import { fn } from "storybook/test";
+import { expect, fn, screen, userEvent, within } from "storybook/test";
 import { HistoryScreen } from "./HistoryScreen";
 
 const meta: Meta<typeof HistoryScreen> = {
@@ -122,5 +122,27 @@ export const WithEntries: Story = {
 export const Empty: Story = {
   args: {
     entries: [],
+  },
+};
+
+export const MethodFilterClearedOnClearAll: Story = {
+  args: {
+    entries: sampleEntries,
+    pinnedIds: new Set<string>(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const filter = canvas.getByPlaceholderText(
+      "All methods",
+    ) as HTMLInputElement;
+
+    await userEvent.click(filter);
+    await userEvent.click(
+      await screen.findByRole("option", { name: "tools/call" }),
+    );
+    await expect(filter).toHaveValue("tools/call");
+
+    await userEvent.click(canvas.getByRole("button", { name: /^clear$/i }));
+    await expect(filter).toHaveValue("");
   },
 };

--- a/clients/web/src/components/screens/HistoryScreen/HistoryScreen.tsx
+++ b/clients/web/src/components/screens/HistoryScreen/HistoryScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Card, Flex, Stack } from "@mantine/core";
 import type { MessageEntry, MessageMethod } from "@inspector/core/mcp/types.js";
 import { HistoryControls } from "../../groups/HistoryControls/HistoryControls";
@@ -47,6 +47,11 @@ export function HistoryScreen({
     [entries],
   );
 
+  const handleClearAll = useCallback(() => {
+    setMethodFilter(undefined);
+    onClearAll();
+  }, [onClearAll]);
+
   return (
     <ScreenLayout>
       <Sidebar>
@@ -65,7 +70,7 @@ export function HistoryScreen({
         pinnedIds={pinnedIds}
         searchText={searchText}
         methodFilter={methodFilter}
-        onClearAll={onClearAll}
+        onClearAll={handleClearAll}
         onExport={onExport}
         onReplay={onReplay}
         onTogglePin={onTogglePin}


### PR DESCRIPTION
Closes #1237.

## Summary

- Wraps `onClearAll` in `HistoryScreen` so it resets `methodFilter` to `undefined` alongside clearing entries (Option C from the issue) — the simplest correct fix, no effects, no render-time divergence between the displayed Select value and the applied filter.
- Adds a play-driven story (`MethodFilterClearedOnClearAll`) that selects `tools/call`, asserts the Select reflects it, clicks **Clear**, and asserts the Select is empty again.

## Test plan

- [x] `npm run validate` (format:check, lint, build) passes.
- [x] `npx vitest run --project=storybook src/components/screens/HistoryScreen` — 3/3 stories pass including the new interaction.
- [ ] Reproduce the original repro from #1237 in dev (`npm run dev`) and confirm the filter dropdown clears alongside the entry list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)