### PR TITLE
feat(resources): render annotations on ResourceListItem

### DIFF
--- a/clients/web/src/components/groups/ResourceListItem/ResourceListItem.stories.tsx
+++ b/clients/web/src/components/groups/ResourceListItem/ResourceListItem.stories.tsx
@@ -53,3 +53,48 @@ export const Template: Story = {
     selected: false,
   },
 };
+
+export const WithAudience: Story = {
+  args: {
+    resource: {
+      name: "config.json",
+      uri: "file:///config.json",
+      annotations: { audience: ["user"] },
+    },
+    selected: false,
+  },
+};
+
+export const WithPriority: Story = {
+  args: {
+    resource: {
+      name: "schema.sql",
+      uri: "file:///schema.sql",
+      annotations: { priority: 0.8 },
+    },
+    selected: false,
+  },
+};
+
+export const WithAudienceAndPriority: Story = {
+  args: {
+    resource: {
+      name: "config.json",
+      title: "Configuration File",
+      uri: "file:///config.json",
+      annotations: { audience: ["user", "assistant"], priority: 0.5 },
+    },
+    selected: false,
+  },
+};
+
+export const TemplateWithAnnotations: Story = {
+  args: {
+    resource: {
+      name: "User Profile",
+      uriTemplate: "file:///users/{userId}/profile",
+      annotations: { audience: ["assistant"], priority: 0.2 },
+    },
+    selected: false,
+  },
+};

--- a/clients/web/src/components/groups/ResourceListItem/ResourceListItem.stories.tsx
+++ b/clients/web/src/components/groups/ResourceListItem/ResourceListItem.stories.tsx
@@ -57,8 +57,8 @@ export const Template: Story = {
 export const WithAudience: Story = {
   args: {
     resource: {
-      name: "config.json",
-      uri: "file:///config.json",
+      name: "settings.json",
+      uri: "file:///settings.json",
       annotations: { audience: ["user"] },
     },
     selected: false,

--- a/clients/web/src/components/groups/ResourceListItem/ResourceListItem.tsx
+++ b/clients/web/src/components/groups/ResourceListItem/ResourceListItem.tsx
@@ -1,8 +1,9 @@
-import { Text, UnstyledButton } from "@mantine/core";
+import { Group, Text, UnstyledButton } from "@mantine/core";
 import type {
   Resource,
   ResourceTemplate,
 } from "@modelcontextprotocol/sdk/types.js";
+import { AnnotationBadge } from "../../elements/AnnotationBadge/AnnotationBadge";
 
 export interface ResourceListItemProps {
   resource: Resource | ResourceTemplate;
@@ -10,11 +11,29 @@ export interface ResourceListItemProps {
   onClick: () => void;
 }
 
+const RowGroup = Group.withProps({
+  gap: "xs",
+  wrap: "wrap",
+  justify: "space-between",
+});
+
+const BadgeGroup = Group.withProps({
+  gap: "xs",
+  wrap: "wrap",
+});
+
 export function ResourceListItem({
   resource,
   selected,
   onClick,
 }: ResourceListItemProps) {
+  const annotations = resource.annotations;
+  const audience = annotations?.audience;
+  const priority = annotations?.priority;
+  const hasAudience = audience !== undefined && audience.length > 0;
+  const hasPriority = priority !== undefined;
+  const label = <Text fw={500}>{resource.title ?? resource.name}</Text>;
+
   return (
     <UnstyledButton
       w="100%"
@@ -23,7 +42,21 @@ export function ResourceListItem({
       bg={selected ? "var(--mantine-primary-color-light)" : undefined}
       onClick={onClick}
     >
-      <Text fw={500}>{resource.title ?? resource.name}</Text>
+      {hasAudience || hasPriority ? (
+        <RowGroup>
+          {label}
+          <BadgeGroup>
+            {hasAudience && (
+              <AnnotationBadge facet="audience" value={audience} />
+            )}
+            {hasPriority && (
+              <AnnotationBadge facet="priority" value={priority} />
+            )}
+          </BadgeGroup>
+        </RowGroup>
+      ) : (
+        label
+      )}
     </UnstyledButton>
   );
 }

--- a/clients/web/src/components/groups/ResourceListItem/ResourceListItem.tsx
+++ b/clients/web/src/components/groups/ResourceListItem/ResourceListItem.tsx
@@ -27,11 +27,10 @@ export function ResourceListItem({
   selected,
   onClick,
 }: ResourceListItemProps) {
-  const annotations = resource.annotations;
-  const audience = annotations?.audience;
-  const priority = annotations?.priority;
-  const hasAudience = audience !== undefined && audience.length > 0;
-  const hasPriority = priority !== undefined;
+  const audience = resource.annotations?.audience;
+  const priority = resource.annotations?.priority;
+  const showBadges =
+    (audience !== undefined && audience.length > 0) || priority !== undefined;
   const label = <Text fw={500}>{resource.title ?? resource.name}</Text>;
 
   return (
@@ -42,14 +41,14 @@ export function ResourceListItem({
       bg={selected ? "var(--mantine-primary-color-light)" : undefined}
       onClick={onClick}
     >
-      {hasAudience || hasPriority ? (
+      {showBadges ? (
         <RowGroup>
           {label}
           <BadgeGroup>
-            {hasAudience && (
+            {audience !== undefined && audience.length > 0 && (
               <AnnotationBadge facet="audience" value={audience} />
             )}
-            {hasPriority && (
+            {priority !== undefined && (
               <AnnotationBadge facet="priority" value={priority} />
             )}
           </BadgeGroup>


### PR DESCRIPTION
Closes #1238.

## Summary

- `ResourceListItem` now renders `audience` and `priority` annotations via `AnnotationBadge`, matching the pattern already used in `ResourcePreviewPanel`. Closes the second half of the Phase 5 spec target (the `title ?? name` half had already landed).
- Layout: a wrapping `Group` keeps the title and badges on one line when the row is wide and lets badges drop below the title when the container narrows. When the resource has no annotations (or only empty/undefined fields), the row renders the bare `Text` exactly as before — no extra elements, no leaked spacing.
- Adds stories for: audience-only, priority-only, both audience and priority, and a `ResourceTemplate` with annotations.

## Test plan

- [x] `npm run validate` (format:check, lint, build) passes.
- [x] `npx vitest run --project=storybook src/components/groups/ResourceListItem` — 8/8 stories pass.
- [ ] Spot-check `ResourcesScreen.stories.tsx > WithResources` in dev — the sidebar list should now show badges on `config.json` (audience + priority) and `package.json` (audience), with unannotated rows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
