### PR TITLE
feat(sampling): replace InlineSamplingRequest responseText with draftResult

### DIFF
--- a/clients/web/src/components/groups/InlineSamplingRequest/InlineSamplingRequest.stories.tsx
+++ b/clients/web/src/components/groups/InlineSamplingRequest/InlineSamplingRequest.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import type { CreateMessageRequestParams } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CreateMessageRequestParams,
+  CreateMessageResult,
+} from "@modelcontextprotocol/sdk/types.js";
 import { fn } from "storybook/test";
 import { InlineSamplingRequest } from "./InlineSamplingRequest";
 
@@ -16,13 +19,31 @@ const defaultRequest: CreateMessageRequestParams = {
   maxTokens: 1024,
 };
 
+const textDraft: CreateMessageResult = {
+  role: "assistant",
+  model: "claude-sonnet-4-20250514",
+  content: {
+    type: "text",
+    text: "The code looks good overall. Consider extracting the repeated logic into a helper function and adding type annotations to the public API.",
+  },
+};
+
+const imageDraft: CreateMessageResult = {
+  role: "assistant",
+  model: "claude-sonnet-4-20250514",
+  content: {
+    type: "image",
+    data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+    mimeType: "image/png",
+  },
+};
+
 const meta: Meta<typeof InlineSamplingRequest> = {
   title: "Groups/InlineSamplingRequest",
   component: InlineSamplingRequest,
   args: {
     request: defaultRequest,
     queuePosition: "1 of 1",
-    responseText: "",
     onAutoRespond: fn(),
     onEditAndSend: fn(),
     onReject: fn(),
@@ -49,10 +70,15 @@ export const WithModelHints: Story = {
   },
 };
 
-export const PrefilledResponse: Story = {
+export const WithTextDraft: Story = {
   args: {
-    responseText:
-      "The code looks good overall. Consider extracting the repeated logic into a helper function.",
+    draftResult: textDraft,
+  },
+};
+
+export const WithNonTextDraft: Story = {
+  args: {
+    draftResult: imageDraft,
   },
 };
 

--- a/clients/web/src/components/groups/InlineSamplingRequest/InlineSamplingRequest.tsx
+++ b/clients/web/src/components/groups/InlineSamplingRequest/InlineSamplingRequest.tsx
@@ -1,18 +1,13 @@
-import {
-  Badge,
-  Button,
-  Group,
-  Paper,
-  Stack,
-  Text,
-  Textarea,
-} from "@mantine/core";
-import type { CreateMessageRequestParams } from "@modelcontextprotocol/sdk/types.js";
+import { Badge, Button, Group, Paper, Stack, Text } from "@mantine/core";
+import type {
+  CreateMessageRequestParams,
+  CreateMessageResult,
+} from "@modelcontextprotocol/sdk/types.js";
 
 export interface InlineSamplingRequestProps {
   request: CreateMessageRequestParams;
   queuePosition: string;
-  responseText: string;
+  draftResult?: CreateMessageResult;
   onAutoRespond: () => void;
   onEditAndSend: () => void;
   onReject: () => void;
@@ -32,6 +27,11 @@ const QueueLabel = Text.withProps({
 const PreviewText = Text.withProps({
   size: "sm",
   c: "dimmed",
+  lineClamp: 2,
+});
+
+const DraftPreview = Text.withProps({
+  size: "sm",
   lineClamp: 2,
 });
 
@@ -67,6 +67,17 @@ function extractPreview(request: CreateMessageRequestParams): string {
   return content.type === "text" ? content.text : `[${content.type}]`;
 }
 
+function extractDraftPreview(draft: CreateMessageResult): string {
+  switch (draft.content.type) {
+    case "text":
+      return draft.content.text;
+    case "image":
+      return "[Image content]";
+    case "audio":
+      return "[Audio content]";
+  }
+}
+
 function extractModelHints(
   request: CreateMessageRequestParams,
 ): string[] | undefined {
@@ -82,7 +93,7 @@ function formatModelHints(hints: string[]): string {
 export function InlineSamplingRequest({
   request,
   queuePosition,
-  responseText,
+  draftResult,
   onAutoRespond,
   onEditAndSend,
   onReject,
@@ -90,6 +101,7 @@ export function InlineSamplingRequest({
 }: InlineSamplingRequestProps) {
   const modelHints = extractModelHints(request);
   const messagePreview = extractPreview(request);
+  const draftPreview = draftResult ? extractDraftPreview(draftResult) : null;
 
   return (
     <RequestContainer>
@@ -105,14 +117,7 @@ export function InlineSamplingRequest({
 
         <DetailButton onClick={onViewDetails}>View Details</DetailButton>
 
-        <Textarea
-          size="sm"
-          value={responseText}
-          placeholder="Response..."
-          autosize
-          minRows={2}
-          readOnly
-        />
+        {draftPreview !== null && <DraftPreview>{draftPreview}</DraftPreview>}
 
         <ActionsRow>
           <CompactButton onClick={onAutoRespond}>Auto-respond</CompactButton>

--- a/clients/web/src/components/groups/PendingClientRequests/PendingClientRequests.stories.tsx
+++ b/clients/web/src/components/groups/PendingClientRequests/PendingClientRequests.stories.tsx
@@ -57,7 +57,6 @@ export const SingleSampling: Story = {
           maxTokens: 1024,
         }}
         queuePosition="1 of 1"
-        responseText=""
         onAutoRespond={fn()}
         onEditAndSend={fn()}
         onReject={fn()}
@@ -102,7 +101,6 @@ export const MultipleMixed: Story = {
             maxTokens: 1024,
           }}
           queuePosition="1 of 2"
-          responseText=""
           onAutoRespond={fn()}
           onEditAndSend={fn()}
           onReject={fn()}

--- a/clients/web/src/components/screens/ToolsScreen/ToolsScreen.stories.tsx
+++ b/clients/web/src/components/screens/ToolsScreen/ToolsScreen.stories.tsx
@@ -287,7 +287,6 @@ export const WithPendingRequests: Story = {
               maxTokens: 1024,
             }}
             queuePosition="1 of 2"
-            responseText=""
             onAutoRespond={fn()}
             onEditAndSend={fn()}
             onReject={fn()}


### PR DESCRIPTION
Closes #1239.

## Summary

- `InlineSamplingRequest` now takes `draftResult?: CreateMessageResult` instead of `responseText: string`, matching `SamplingRequestPanel`'s prop shape so a future shared-draft store can feed both views.
- No-draft state: removed the readonly placeholder `Textarea`. The card renders request preview + model hints + action buttons, identical to before minus the empty textarea slot. Buttons (`onAutoRespond`, `onEditAndSend`, `onReject`, `onViewDetails`) — and their callback shapes — are unchanged.
- Text draft: 2-line preview of `draftResult.content.text` via Mantine's `lineClamp`.
- Image / audio draft: `[Image content]` / `[Audio content]` label, matching the `ContentViewer` fallback convention.
- Stories: replaced `PrefilledResponse` with `WithTextDraft` and added `WithNonTextDraft` covering the image branch. Existing `Default`, `WithModelHints`, `InQueue` stories now exercise the no-draft state. Updated the three consumer stories (`PendingClientRequests` × 2, `ToolsScreen`) that threaded `responseText=""` through.

## Open design question (deferred)

The audit asked whether the inline preview should mirror the panel's live draft (shared state) or stay a static snapshot. That's a parent-wiring concern — this PR only changes the prop shape. The component is read-only from this layer's perspective; whoever wires the pending-request store in #1243 / #1244 picks the answer.

## Scope notes

- Removed the readonly `Textarea` rather than keeping it as an empty placeholder. The acceptance criteria call out the four action buttons as "unchanged" but don't list the textarea — and a permanent empty textarea felt redundant with the action buttons already signaling the affordance. Happy to revisit if reviewers prefer a placeholder slot in the no-draft state.
- `git grep responseText` shows only `HistoryListPanel.tsx`, where it's a local variable for entry-search matching — unrelated.

## Test plan

- [x] `npm run validate` passes.
- [x] `npx vitest run --project=storybook src/components/groups/InlineSamplingRequest src/components/groups/PendingClientRequests src/components/screens/ToolsScreen` — 17/17 stories pass.
- [ ] Visual diff in Storybook: no-draft state matches existing card minus the empty Textarea; text-draft and non-text-draft variants render their expected previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
