### PR TITLE
fix(stories): scope ResourceSelected click to URIs region

### DIFF
--- a/clients/web/src/components/screens/ResourcesScreen/ResourcesScreen.stories.tsx
+++ b/clients/web/src/components/screens/ResourcesScreen/ResourcesScreen.stories.tsx
@@ -122,9 +122,16 @@ const readUserProfileState: ReadResourceState = {
   isSubscribed: false,
 };
 
-async function clickByText(canvasElement: HTMLElement, label: string) {
+async function clickByText(
+  canvasElement: HTMLElement,
+  label: string,
+  regionName?: RegExp,
+) {
   const canvas = within(canvasElement);
-  await userEvent.click(await canvas.findByText(label));
+  const scope = regionName
+    ? within(await canvas.findByRole("region", { name: regionName }))
+    : canvas;
+  await userEvent.click(await scope.findByText(label));
 }
 
 // The userId value typed below must match the `{userId}` segment in
@@ -153,7 +160,7 @@ export const ResourceSelected: Story = {
     readState: readConfigState,
   },
   play: async ({ canvasElement }) => {
-    await clickByText(canvasElement, "config.json");
+    await clickByText(canvasElement, "config.json", /^URIs/);
   },
 };
 


### PR DESCRIPTION
Closes #1248.

## Summary

Adopts **Option A** from the issue (scope the click to the resource list specifically). `clickByText` now takes an optional `regionName: RegExp` parameter; when provided, the helper resolves an `aria-region` matching that name first and runs `findByText` inside it. `ResourceSelected` calls it with `/^URIs/` so the click resolves uniquely to the resources list, regardless of what the subscriptions panel shows.

The other `clickByText("User Profile")` call site stays unchanged — `User Profile` only appears in `sampleTemplates`, so it's already unambiguous.

## Why region scoping vs. splitting the story

The issue's Option A vs. B trade-off favored A because the story's whole point is "selection from the populated list with subscriptions visible in the backdrop." Splitting into two stories (one with subscriptions, one without) would weaken that demonstration. Scoping the play function leaves the rendered card identical and just disambiguates the click.

## Test plan

- [x] `npm run validate` passes.
- [x] `npx vitest run --project=storybook src/components/screens/ResourcesScreen` — 7/7 stories pass.
- [x] **Full storybook suite green: 273/273 across 62 files.** This was the precondition flagged in #1251 — turning on a CI play-test gate is now safe.

## Out of scope

- The `test:storybook` script + CI gate from #1251 — separate work, this PR clears the precondition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
