### PR TITLE
docs(agents): require version label on new issues and PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ All work should be driven by items on the project board.
 - When work begins, create a feature branch and move the item to "In Progress".
 - When work is complete:
   - Run format, lint, typecheck, build, and test — ensure all checks pass
-  - Open a PR against `main` and move the item to "In Review"
+  - Open a PR against the matching base branch (`main` for v1, `v1.5/main` for v1.5, `v2/main` for v2) and move the item to "In Review"
 - If new tasks are discovered or requested during development, create issues and add them to the board.
 
 ### Always test new or modified code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,12 @@ All work should be driven by items on the project board.
 
 - Before starting work, check the board for the relevant item.
 - **Draft items vs. issues**: Board items may be draft items (no issue number) or full GitHub issues. Before creating a new issue, always check if a matching draft item already exists on the board. If it does, convert it to an issue using `gh project item-edit` or create the issue and link it — **never create a duplicate**.
+- **Label by version.** New issues and PRs must carry the label matching the target board / branch:
+  - `main` → `v1`
+  - `v1.5/main` → `v1.5`
+  - `v2/main` → `v2`
+
+  Set the label at create time (`gh issue create --label v2 ...`, `gh pr create --label v2 ...`) — don't rely on backfilling later, since unlabeled PRs are easy to miss when filtering by version.
 - When work begins, create a feature branch and move the item to "In Progress".
 - When work is complete:
   - Run format, lint, typecheck, build, and test — ensure all checks pass


### PR DESCRIPTION
Closes #1256.

## Summary

Adds a new bullet under "Issue-driven Work Style" in `AGENTS.md` codifying the branch → label mapping (`main` → `v1`, `v1.5/main` → `v1.5`, `v2/main` → `v2`) and noting the label should be set at PR/issue create time via `--label` rather than backfilled.

## Context

PRs #1247, #1249, #1250, #1252, #1255 all landed (or are landing) without a label. Backfilled them by hand; this rule is the durable fix.

## Test plan

- [x] `npm run validate` clean (markdown-only change, but per AGENTS.md).
- [x] This PR itself dogfoods the new rule — created with `--label v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)