### PR TITLE
fix: render nested/Optional arrays as structured forms & align string field style with ToolsTab

### DIFF
--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -8,6 +8,8 @@ import {
 } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
 import JsonEditor from "./JsonEditor";
 import { updateValueAtPath } from "@/utils/jsonUtils";
 import { generateDefaultValue, normalizeUnionType } from "@/utils/schemaUtils";
@@ -310,6 +312,15 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
       // so that maxDepth enforcement and the type switch both see the real type.
       propSchema = normalizeUnionType(propSchema);
 
+      // Trim description to remove leading/trailing whitespace from multi-line
+      // Python triple-quoted strings (e.g. """\n            - text\n            """)
+      if (propSchema.description) {
+        propSchema = {
+          ...propSchema,
+          description: propSchema.description.trim(),
+        };
+      }
+
       if (
         depth >= maxDepth &&
         (propSchema.type === "object" || propSchema.type === "array")
@@ -429,39 +440,41 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
             );
           }
 
-          let inputType = "text";
-          switch (propSchema.format) {
-            case "email":
-              inputType = "email";
-              break;
-            case "uri":
-              inputType = "url";
-              break;
-            case "date":
-              inputType = "date";
-              break;
-            case "date-time":
-              inputType = "datetime-local";
-              break;
-            default:
-              inputType = "text";
-              break;
+          // Special formats keep a typed <Input>; plain text uses <Textarea> to
+          // match the height and style of direct-parameter string inputs.
+          type SpecialFormat = "email" | "uri" | "date" | "date-time";
+          const specialFormatMap: Record<SpecialFormat, string> = {
+            email: "email",
+            uri: "url",
+            date: "date",
+            "date-time": "datetime-local",
+          };
+          const specialInputType =
+            specialFormatMap[propSchema.format as SpecialFormat];
+
+          if (specialInputType) {
+            return (
+              <Input
+                type={specialInputType}
+                value={(currentValue as string) ?? ""}
+                onChange={(e) => handleFieldChange(path, e.target.value)}
+                placeholder={propSchema.description}
+                required={isRequired}
+                minLength={propSchema.minLength}
+                maxLength={propSchema.maxLength}
+                pattern={propSchema.pattern}
+              />
+            );
           }
 
           return (
-            <Input
-              type={inputType}
+            <Textarea
               value={(currentValue as string) ?? ""}
-              onChange={(e) => {
-                const val = e.target.value;
-                // Always allow setting string values, including empty strings
-                handleFieldChange(path, val);
-              }}
+              onChange={(e) => handleFieldChange(path, e.target.value)}
               placeholder={propSchema.description}
               required={isRequired}
               minLength={propSchema.minLength}
               maxLength={propSchema.maxLength}
-              pattern={propSchema.pattern}
             />
           );
         }
@@ -543,19 +556,23 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
 
         case "boolean":
           return (
-            <div className="space-y-2">
+            <div className="space-y-1">
               {propSchema.description && (
-                <p className="text-sm text-gray-600">
+                <p className="text-xs text-gray-500 dark:text-gray-400">
                   {propSchema.description}
                 </p>
               )}
-              <Input
-                type="checkbox"
-                checked={(currentValue as boolean) ?? false}
-                onChange={(e) => handleFieldChange(path, e.target.checked)}
-                className="w-4 h-4"
-                required={isRequired}
-              />
+              <div className="flex items-center gap-3 py-1">
+                <Switch
+                  checked={(currentValue as boolean) ?? false}
+                  onCheckedChange={(checked) =>
+                    handleFieldChange(path, checked)
+                  }
+                />
+                <span className="text-sm text-gray-600 dark:text-gray-400">
+                  {(currentValue as boolean) ? "True" : "False"}
+                </span>
+              </div>
             </div>
           );
         case "null":
@@ -683,18 +700,6 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
           if (isSimpleObject(itemSchema) || itemIsObject) {
             return (
               <div className="space-y-4">
-                {propSchema.description && (
-                  <p className="text-sm text-gray-600">
-                    {propSchema.description}
-                  </p>
-                )}
-
-                {itemSchema.description && (
-                  <p className="text-sm text-gray-500">
-                    {itemSchema.description}
-                  </p>
-                )}
-
                 <div className="space-y-2">
                   {arrayValue.map((item, index) =>
                     itemIsObject ? (

--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import JsonEditor from "./JsonEditor";
 import { updateValueAtPath } from "@/utils/jsonUtils";
-import { generateDefaultValue } from "@/utils/schemaUtils";
+import { generateDefaultValue, normalizeUnionType } from "@/utils/schemaUtils";
 import type {
   JsonValue,
   JsonSchemaType,
@@ -87,6 +87,9 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
     // - Arrays with defined items are form-capable
     // - Primitive types are form-capable
     const canRenderTopLevelForm = (s: JsonSchemaType): boolean => {
+      // Unwrap Optional[X] at the top level so anyOf:[X,null] is treated as X
+      s = normalizeUnionType(s);
+
       const primitiveTypes = ["string", "number", "integer", "boolean", "null"];
 
       const hasType = Array.isArray(s.type) ? s.type.length > 0 : !!s.type;
@@ -303,6 +306,10 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
       parentSchema?: JsonSchemaType,
       propertyName?: string,
     ) => {
+      // Unwrap Optional[X] / nullable unions (anyOf: [X, null]) before ANY type checks
+      // so that maxDepth enforcement and the type switch both see the real type.
+      propSchema = normalizeUnionType(propSchema);
+
       if (
         depth >= maxDepth &&
         (propSchema.type === "object" || propSchema.type === "array")
@@ -601,7 +608,10 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
           if (!propSchema.items) return null;
 
           // Special handling: array of enums -> render multi-select control
-          const itemSchema = propSchema.items as JsonSchemaType;
+          // Normalize items so Optional[X] (anyOf:[X,null]) is unwrapped correctly.
+          const itemSchema = normalizeUnionType(
+            propSchema.items as JsonSchemaType,
+          );
           let multiOptions: { value: string; label: string }[] | null = null;
 
           const titledMulti = (
@@ -666,8 +676,11 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
             );
           }
 
-          // If the array items are simple, render as form fields, otherwise use JSON editor
-          if (isSimpleObject(propSchema.items)) {
+          // Typed object items → structured form with Add/Remove; untyped → JSON fallback
+          const itemIsObject =
+            itemSchema.type === "object" && !!itemSchema.properties;
+
+          if (isSimpleObject(itemSchema) || itemIsObject) {
             return (
               <div className="space-y-4">
                 {propSchema.description && (
@@ -676,46 +689,68 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
                   </p>
                 )}
 
-                {propSchema.items?.description && (
+                {itemSchema.description && (
                   <p className="text-sm text-gray-500">
-                    Items: {propSchema.items.description}
+                    {itemSchema.description}
                   </p>
                 )}
 
                 <div className="space-y-2">
-                  {arrayValue.map((item, index) => (
-                    <div key={index} className="flex items-center gap-2">
-                      {renderFormFields(
-                        propSchema.items as JsonSchemaType,
-                        item,
-                        [...path, index.toString()],
-                        depth + 1,
-                      )}
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          const newArray = [...arrayValue];
-                          newArray.splice(index, 1);
-                          handleFieldChange(path, newArray);
-                        }}
-                      >
-                        Remove
-                      </Button>
-                    </div>
-                  ))}
+                  {arrayValue.map((item, index) =>
+                    itemIsObject ? (
+                      <div key={index} className="space-y-2">
+                        {renderFormFields(
+                          itemSchema,
+                          item,
+                          [...path, index.toString()],
+                          depth + 1,
+                        )}
+                        <div className="flex justify-end">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              const newArray = [...arrayValue];
+                              newArray.splice(index, 1);
+                              handleFieldChange(path, newArray);
+                            }}
+                          >
+                            Remove
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div key={index} className="flex items-center gap-2">
+                        {renderFormFields(
+                          itemSchema,
+                          item,
+                          [...path, index.toString()],
+                          depth + 1,
+                        )}
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            const newArray = [...arrayValue];
+                            newArray.splice(index, 1);
+                            handleFieldChange(path, newArray);
+                          }}
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                    ),
+                  )}
                   <Button
                     variant="outline"
                     size="sm"
                     onClick={() => {
-                      const defaultValue = getArrayItemDefault(
-                        propSchema.items as JsonSchemaType,
-                      );
+                      const defaultValue = getArrayItemDefault(itemSchema);
                       handleFieldChange(path, [...arrayValue, defaultValue]);
                     }}
                     title={
-                      propSchema.items?.description
-                        ? `Add new ${propSchema.items.description}`
+                      itemSchema.description
+                        ? `Add new ${itemSchema.description}`
                         : "Add new item"
                     }
                   >
@@ -726,7 +761,7 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
             );
           }
 
-          // For complex arrays, fall back to JSON editor
+          // For truly unstructured arrays (no type or no properties), fall back to JSON editor
           return (
             <JsonEditor
               value={JSON.stringify(currentValue ?? [], null, 2)}

--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -300,7 +300,7 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
     }));
 
     const renderFormFields = (
-      propSchema: JsonSchemaType,
+      rawSchema: JsonSchemaType,
       currentValue: JsonValue,
       path: string[] = [],
       depth: number = 0,
@@ -309,7 +309,7 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
     ) => {
       // Unwrap Optional[X] / nullable unions (anyOf: [X, null]) before ANY type checks
       // so that maxDepth enforcement and the type switch both see the real type.
-      propSchema = normalizeUnionType(propSchema);
+      let propSchema = normalizeUnionType(rawSchema);
 
       // Trim description to remove leading/trailing whitespace from multi-line
       // Python triple-quoted strings (e.g. """\n            - text\n            """)

--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -715,6 +715,16 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
           if (isSimpleObject(itemSchema) || itemIsObject) {
             return (
               <div className="space-y-4">
+                {propSchema.description && (
+                  <p className="text-sm text-gray-600">
+                    {propSchema.description}
+                  </p>
+                )}
+                {propSchema.items?.description && (
+                  <p className="text-sm text-gray-500">
+                    Items: {propSchema.items.description}
+                  </p>
+                )}
                 <div className="space-y-2">
                   {arrayValue.map((item, index) =>
                     itemIsObject ? (

--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -72,7 +72,7 @@ const getArrayItemDefault = (schema: JsonSchemaType): JsonValue => {
     case "array":
       return [];
     case "object":
-      return {};
+      return generateDefaultValue(schema) ?? {};
     case "null":
       return null;
     default:
@@ -226,9 +226,23 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
         }
       } else {
         // Update raw JSON value when switching to JSON mode
-        setRawJsonValue(
-          JSON.stringify(value ?? generateDefaultValue(schema), null, 2),
-        );
+        let valueToShow: JsonValue = value ?? generateDefaultValue(schema);
+        // For an empty structured array, seed one template item so the user can
+        // see the expected field structure instead of a bare [].
+        if (
+          schema.type === "array" &&
+          schema.items &&
+          Array.isArray(valueToShow) &&
+          valueToShow.length === 0
+        ) {
+          const itemDefault = getArrayItemDefault(
+            normalizeUnionType(schema.items as JsonSchemaType),
+          );
+          if (typeof itemDefault === "object" && itemDefault !== null) {
+            valueToShow = [itemDefault];
+          }
+        }
+        setRawJsonValue(JSON.stringify(valueToShow, null, 2));
         setIsJsonMode(true);
       }
     };

--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -467,6 +467,21 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
             );
           }
 
+          if (propSchema.pattern) {
+            return (
+              <Input
+                type="text"
+                value={(currentValue as string) ?? ""}
+                onChange={(e) => handleFieldChange(path, e.target.value)}
+                placeholder={propSchema.description}
+                required={isRequired}
+                minLength={propSchema.minLength}
+                maxLength={propSchema.maxLength}
+                pattern={propSchema.pattern}
+              />
+            );
+          }
+
           return (
             <Textarea
               value={(currentValue as string) ?? ""}

--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -9,7 +9,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Switch } from "@/components/ui/switch";
 import JsonEditor from "./JsonEditor";
 import { updateValueAtPath } from "@/utils/jsonUtils";
 import { generateDefaultValue, normalizeUnionType } from "@/utils/schemaUtils";
@@ -571,23 +570,19 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
 
         case "boolean":
           return (
-            <div className="space-y-1">
+            <div className="space-y-2">
               {propSchema.description && (
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-sm text-gray-600">
                   {propSchema.description}
                 </p>
               )}
-              <div className="flex items-center gap-3 py-1">
-                <Switch
-                  checked={(currentValue as boolean) ?? false}
-                  onCheckedChange={(checked) =>
-                    handleFieldChange(path, checked)
-                  }
-                />
-                <span className="text-sm text-gray-600 dark:text-gray-400">
-                  {(currentValue as boolean) ? "True" : "False"}
-                </span>
-              </div>
+              <Input
+                type="checkbox"
+                checked={(currentValue as boolean) ?? false}
+                onChange={(e) => handleFieldChange(path, e.target.checked)}
+                className="w-4 h-4"
+                required={isRequired}
+              />
             </div>
           );
         case "null":

--- a/client/src/components/__tests__/DynamicJsonForm.array.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.array.test.tsx
@@ -43,10 +43,6 @@ describe("DynamicJsonForm Array Fields", () => {
     it("should render form fields for simple array items", () => {
       renderSimpleArrayForm({ value: ["item1", "item2"] });
 
-      // Should show array description
-      expect(screen.getByText("Test array field")).toBeDefined();
-      expect(screen.getByText("Array item")).toBeDefined();
-
       // Should show input fields for each item
       const inputs = screen.getAllByRole("textbox");
       expect(inputs).toHaveLength(2);
@@ -94,8 +90,7 @@ describe("DynamicJsonForm Array Fields", () => {
     it("should handle empty arrays", () => {
       renderSimpleArrayForm({ value: [] });
 
-      // Should show description and add button but no items
-      expect(screen.getByText("Test array field")).toBeDefined();
+      // Should show add button but no items
       expect(screen.getByText("Add Item")).toBeDefined();
       expect(screen.queryByText("Remove")).toBeNull();
     });
@@ -186,11 +181,9 @@ describe("DynamicJsonForm Array Fields", () => {
       };
       renderSimpleArrayForm({ schema, value: ["test"] });
 
-      // Should render form fields, not JSON editor
-      expect(screen.getByRole("textbox")).not.toHaveProperty(
-        "type",
-        "textarea",
-      );
+      // Structured form controls are shown (not the JSON editor fallback)
+      expect(screen.getByText("Add Item")).toBeDefined();
+      expect(screen.getByText("Remove")).toBeDefined();
     });
 
     it("should detect number arrays as simple", () => {
@@ -212,9 +205,9 @@ describe("DynamicJsonForm Array Fields", () => {
       };
       renderSimpleArrayForm({ schema, value: [true, false] });
 
-      // Should render form fields (checkboxes)
-      const checkboxes = screen.getAllByRole("checkbox");
-      expect(checkboxes).toHaveLength(2);
+      // Should render Switch toggles (role="switch") for boolean items
+      const switches = screen.getAllByRole("switch");
+      expect(switches).toHaveLength(2);
     });
 
     it("should detect simple object arrays as simple", () => {
@@ -339,10 +332,10 @@ describe("DynamicJsonForm Array Fields", () => {
       const onChange = jest.fn();
       renderSimpleArrayForm({ schema, value: [true, false], onChange });
 
-      const checkboxes = screen.getAllByRole("checkbox");
-      expect(checkboxes).toHaveLength(2);
-      expect(checkboxes[0]).toHaveProperty("checked", true);
-      expect(checkboxes[1]).toHaveProperty("checked", false);
+      const switches = screen.getAllByRole("switch");
+      expect(switches).toHaveLength(2);
+      expect(switches[0]).toHaveAttribute("aria-checked", "true");
+      expect(switches[1]).toHaveAttribute("aria-checked", "false");
 
       // Test adding new boolean item
       const addButton = screen.getByText("Add Item");
@@ -362,9 +355,6 @@ describe("DynamicJsonForm Array Fields", () => {
         },
       };
       renderSimpleArrayForm({ schema });
-
-      expect(screen.getByText("List of names")).toBeDefined();
-      expect(screen.getByText("Person name")).toBeDefined();
     });
 
     it("should use item description in add button title", () => {

--- a/client/src/components/__tests__/DynamicJsonForm.array.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.array.test.tsx
@@ -45,7 +45,7 @@ describe("DynamicJsonForm Array Fields", () => {
 
       // Should show array description
       expect(screen.getByText("Test array field")).toBeDefined();
-      expect(screen.getByText("Items: Array item")).toBeDefined();
+      expect(screen.getByText("Array item")).toBeDefined();
 
       // Should show input fields for each item
       const inputs = screen.getAllByRole("textbox");
@@ -101,21 +101,80 @@ describe("DynamicJsonForm Array Fields", () => {
     });
   });
 
-  describe("Complex Array Fallback", () => {
-    it("should render JSON editor for complex arrays", () => {
-      renderComplexArrayForm();
+  describe("Complex Array Rendering", () => {
+    it("should render structured form for arrays of objects with properties", () => {
+      renderComplexArrayForm({ value: [{ nested: {} }] });
 
-      // Initially renders form view with Switch to JSON button; switch to JSON to see textarea
-      const switchBtn = screen.getByRole("button", { name: /switch to json/i });
-      expect(switchBtn).toBeInTheDocument();
-      fireEvent.click(switchBtn);
+      // Should show Add Item and Remove — not fall back to raw JSON
+      expect(screen.getByText("Add Item")).toBeInTheDocument();
+      expect(screen.getByText("Remove")).toBeInTheDocument();
 
-      const textarea = screen.getByRole("textbox");
-      expect(textarea).toHaveProperty("type", "textarea");
+      // Switch to JSON should still be available
+      expect(
+        screen.getByRole("button", { name: /switch to json/i }),
+      ).toBeInTheDocument();
+    });
 
-      // Should not show form-specific array controls
+    it("should render JSON editor for untyped (no-type) array items", () => {
+      const schema: JsonSchemaType = {
+        type: "array",
+        items: {} as JsonSchemaType, // no type at all
+      };
+      render(
+        <DynamicJsonForm schema={schema} value={[]} onChange={jest.fn()} />,
+      );
+
+      // Falls back to JSON editor; no structured controls
       expect(screen.queryByText("Add Item")).toBeNull();
-      expect(screen.queryByText("Remove")).toBeNull();
+    });
+
+    it("should render structured form for Optional array (anyOf:[array,null])", () => {
+      const schema: JsonSchemaType = {
+        anyOf: [
+          {
+            type: "array",
+            items: { type: "string" as const },
+          },
+          { type: "null" },
+        ],
+      } as unknown as JsonSchemaType;
+      render(
+        <DynamicJsonForm
+          schema={schema}
+          value={["hello"]}
+          onChange={jest.fn()}
+        />,
+      );
+
+      // Should render as a structured string-array form, not a raw JSON box
+      expect(screen.getByText("Add Item")).toBeInTheDocument();
+      const inputs = screen.getAllByRole("textbox");
+      expect(inputs[0]).toHaveProperty("value", "hello");
+    });
+
+    it("should render structured form for array of Optional objects (items anyOf:[object,null])", () => {
+      const schema: JsonSchemaType = {
+        type: "array",
+        items: {
+          anyOf: [
+            {
+              type: "object" as const,
+              properties: { name: { type: "string" as const } },
+            },
+            { type: "null" },
+          ],
+        } as unknown as JsonSchemaType,
+      };
+      render(
+        <DynamicJsonForm
+          schema={schema}
+          value={[{ name: "Alice" }]}
+          onChange={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText("Add Item")).toBeInTheDocument();
+      expect(screen.getByText("Remove")).toBeInTheDocument();
     });
   });
 
@@ -305,7 +364,7 @@ describe("DynamicJsonForm Array Fields", () => {
       renderSimpleArrayForm({ schema });
 
       expect(screen.getByText("List of names")).toBeDefined();
-      expect(screen.getByText("Items: Person name")).toBeDefined();
+      expect(screen.getByText("Person name")).toBeDefined();
     });
 
     it("should use item description in add button title", () => {

--- a/client/src/components/__tests__/DynamicJsonForm.array.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.array.test.tsx
@@ -355,6 +355,11 @@ describe("DynamicJsonForm Array Fields", () => {
         },
       };
       renderSimpleArrayForm({ schema });
+
+      // Both the array-level description and the per-item description render
+      // above the items list (top-level arrays have no parent label upstream).
+      expect(screen.getByText("List of names")).toBeInTheDocument();
+      expect(screen.getByText("Items: Person name")).toBeInTheDocument();
     });
 
     it("should use item description in add button title", () => {

--- a/client/src/components/__tests__/DynamicJsonForm.array.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.array.test.tsx
@@ -205,9 +205,9 @@ describe("DynamicJsonForm Array Fields", () => {
       };
       renderSimpleArrayForm({ schema, value: [true, false] });
 
-      // Should render Switch toggles (role="switch") for boolean items
-      const switches = screen.getAllByRole("switch");
-      expect(switches).toHaveLength(2);
+      // Should render form fields (checkboxes)
+      const checkboxes = screen.getAllByRole("checkbox");
+      expect(checkboxes).toHaveLength(2);
     });
 
     it("should detect simple object arrays as simple", () => {
@@ -332,10 +332,10 @@ describe("DynamicJsonForm Array Fields", () => {
       const onChange = jest.fn();
       renderSimpleArrayForm({ schema, value: [true, false], onChange });
 
-      const switches = screen.getAllByRole("switch");
-      expect(switches).toHaveLength(2);
-      expect(switches[0]).toHaveAttribute("aria-checked", "true");
-      expect(switches[1]).toHaveAttribute("aria-checked", "false");
+      const checkboxes = screen.getAllByRole("checkbox");
+      expect(checkboxes).toHaveLength(2);
+      expect(checkboxes[0]).toHaveProperty("checked", true);
+      expect(checkboxes[1]).toHaveProperty("checked", false);
 
       // Test adding new boolean item
       const addButton = screen.getByText("Add Item");

--- a/client/src/components/__tests__/DynamicJsonForm.array.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.array.test.tsx
@@ -387,4 +387,45 @@ describe("DynamicJsonForm Array Fields", () => {
       expect(addButton).toHaveProperty("title", "Add new item");
     });
   });
+
+  describe("Array Item Defaults", () => {
+    it("should pre-populate required fields when adding an object array item", () => {
+      const onChange = jest.fn();
+      const schema = {
+        type: "array" as const,
+        items: {
+          type: "object" as const,
+          required: ["name"],
+          properties: {
+            name: { type: "string" as const },
+            age: { type: "number" as const },
+          },
+        },
+      };
+      renderSimpleArrayForm({ schema, value: [], onChange });
+
+      fireEvent.click(screen.getByText("Add Item"));
+
+      // New item is seeded with its required field (name), not a bare {}
+      expect(onChange).toHaveBeenCalledWith([{ name: "" }]);
+    });
+
+    it("should seed a template item when switching an empty object array to JSON", () => {
+      const schema = {
+        type: "array" as const,
+        items: {
+          type: "object" as const,
+          required: ["name"],
+          properties: { name: { type: "string" as const } },
+        },
+      };
+      renderSimpleArrayForm({ schema, value: [] });
+
+      fireEvent.click(screen.getByRole("button", { name: /switch to json/i }));
+
+      // JSON view shows one template object so the shape is visible, not []
+      const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+      expect(textarea.value).toContain('"name"');
+    });
+  });
 });

--- a/client/src/components/__tests__/DynamicJsonForm.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.test.tsx
@@ -31,10 +31,10 @@ describe("DynamicJsonForm String Fields", () => {
       expect(typeof onChange.mock.calls[0][0]).toBe("string");
     });
 
-    it("should render as text input, not number input", () => {
+    it("should render as textarea, not number input", () => {
       renderForm();
       const input = screen.getByRole("textbox");
-      expect(input).toHaveProperty("type", "text");
+      expect(input).toHaveProperty("type", "textarea");
     });
 
     it("should handle a union type of string and null", () => {
@@ -46,7 +46,7 @@ describe("DynamicJsonForm String Fields", () => {
         <DynamicJsonForm schema={schema} value={null} onChange={jest.fn()} />,
       );
       const input = screen.getByRole("textbox");
-      expect(input).toHaveProperty("type", "text");
+      expect(input).toHaveProperty("type", "textarea");
     });
   });
 
@@ -268,17 +268,8 @@ describe("DynamicJsonForm String Fields", () => {
       expect(input).toHaveProperty("maxLength", 10);
     });
 
-    it("should apply pattern validation", () => {
-      const schema: JsonSchemaType = {
-        type: "string",
-        pattern: "^[A-Za-z]+$",
-        description: "Letters only",
-      };
-      render(<DynamicJsonForm schema={schema} value="" onChange={jest.fn()} />);
-
-      const input = screen.getByRole("textbox");
-      expect(input).toHaveProperty("pattern", "^[A-Za-z]+$");
-    });
+    // Note: pattern is an <input>-only attribute; <textarea> does not support it,
+    // so plain-text string fields do not expose a pattern property.
   });
 });
 
@@ -430,7 +421,7 @@ describe("DynamicJsonForm Number Fields", () => {
 
 describe("DynamicJsonForm Boolean Fields", () => {
   describe("Basic Operations", () => {
-    it("should render checkbox for boolean type", () => {
+    it("should render switch for boolean type", () => {
       const schema: JsonSchemaType = {
         type: "boolean",
         description: "Enable notifications",
@@ -439,8 +430,8 @@ describe("DynamicJsonForm Boolean Fields", () => {
         <DynamicJsonForm schema={schema} value={false} onChange={jest.fn()} />,
       );
 
-      const checkbox = screen.getByRole("checkbox");
-      expect(checkbox).toHaveProperty("type", "checkbox");
+      const toggle = screen.getByRole("switch");
+      expect(toggle).toHaveAttribute("aria-checked", "false");
     });
 
     it("should call onChange with boolean value", () => {
@@ -453,8 +444,8 @@ describe("DynamicJsonForm Boolean Fields", () => {
         <DynamicJsonForm schema={schema} value={false} onChange={onChange} />,
       );
 
-      const checkbox = screen.getByRole("checkbox");
-      fireEvent.click(checkbox);
+      const toggle = screen.getByRole("switch");
+      fireEvent.click(toggle);
 
       expect(onChange).toHaveBeenCalledWith(true);
     });
@@ -468,8 +459,8 @@ describe("DynamicJsonForm Boolean Fields", () => {
         <DynamicJsonForm schema={schema} value={false} onChange={jest.fn()} />,
       );
 
-      const checkbox = screen.getByRole("checkbox");
-      expect(checkbox).toHaveProperty("checked", false);
+      const toggle = screen.getByRole("switch");
+      expect(toggle).toHaveAttribute("aria-checked", "false");
     });
   });
 });
@@ -507,8 +498,8 @@ describe("DynamicJsonForm Object Fields", () => {
       const numberInput = screen.getByRole("spinbutton");
 
       expect(textInputs).toHaveLength(2);
-      expect(textInputs[0]).toHaveProperty("type", "text");
-      expect(textInputs[1]).toHaveProperty("type", "email");
+      expect(textInputs[0]).toHaveProperty("type", "textarea"); // plain text → <textarea>
+      expect(textInputs[1]).toHaveProperty("type", "email"); // email format → <input type="email">
       expect(numberInput).toHaveProperty("type", "number");
       expect(numberInput).toHaveProperty("min", "18");
     });
@@ -610,10 +601,10 @@ describe("DynamicJsonForm Object Fields", () => {
       const nameLabel = screen.getByText("Name");
       const optionalLabel = screen.getByText("Optional");
 
-      const nameInput = nameLabel.closest("div")?.querySelector("input");
+      const nameInput = nameLabel.closest("div")?.querySelector("textarea");
       const optionalInput = optionalLabel
         .closest("div")
-        ?.querySelector("input");
+        ?.querySelector("textarea");
 
       expect(nameInput).toHaveProperty("required", true);
       expect(optionalInput).toHaveProperty("required", false);

--- a/client/src/components/__tests__/DynamicJsonForm.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.test.tsx
@@ -268,8 +268,21 @@ describe("DynamicJsonForm String Fields", () => {
       expect(input).toHaveProperty("maxLength", 10);
     });
 
-    // Note: pattern is an <input>-only attribute; <textarea> does not support it,
-    // so plain-text string fields do not expose a pattern property.
+    // pattern is an <input>-only attribute; a string field that declares a
+    // pattern must therefore fall back to <input type="text"> (not <textarea>)
+    // so the constraint is preserved client-side.
+    it("should render <input> with pattern attribute (not textarea) when pattern is set", () => {
+      const schema: JsonSchemaType = {
+        type: "string",
+        pattern: "^[a-z]+$",
+        description: "Lowercase only",
+      };
+      render(<DynamicJsonForm schema={schema} value="" onChange={jest.fn()} />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveProperty("type", "text");
+      expect(input).toHaveProperty("pattern", "^[a-z]+$");
+    });
   });
 });
 

--- a/client/src/components/__tests__/DynamicJsonForm.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.test.tsx
@@ -434,7 +434,7 @@ describe("DynamicJsonForm Number Fields", () => {
 
 describe("DynamicJsonForm Boolean Fields", () => {
   describe("Basic Operations", () => {
-    it("should render switch for boolean type", () => {
+    it("should render checkbox for boolean type", () => {
       const schema: JsonSchemaType = {
         type: "boolean",
         description: "Enable notifications",
@@ -443,8 +443,8 @@ describe("DynamicJsonForm Boolean Fields", () => {
         <DynamicJsonForm schema={schema} value={false} onChange={jest.fn()} />,
       );
 
-      const toggle = screen.getByRole("switch");
-      expect(toggle).toHaveAttribute("aria-checked", "false");
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).toHaveProperty("type", "checkbox");
     });
 
     it("should call onChange with boolean value", () => {
@@ -457,8 +457,8 @@ describe("DynamicJsonForm Boolean Fields", () => {
         <DynamicJsonForm schema={schema} value={false} onChange={onChange} />,
       );
 
-      const toggle = screen.getByRole("switch");
-      fireEvent.click(toggle);
+      const checkbox = screen.getByRole("checkbox");
+      fireEvent.click(checkbox);
 
       expect(onChange).toHaveBeenCalledWith(true);
     });
@@ -472,8 +472,8 @@ describe("DynamicJsonForm Boolean Fields", () => {
         <DynamicJsonForm schema={schema} value={false} onChange={jest.fn()} />,
       );
 
-      const toggle = screen.getByRole("switch");
-      expect(toggle).toHaveAttribute("aria-checked", "false");
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).toHaveProperty("checked", false);
     });
   });
 });

--- a/client/src/utils/__tests__/schemaUtils.test.ts
+++ b/client/src/utils/__tests__/schemaUtils.test.ts
@@ -39,8 +39,8 @@ describe("generateDefaultValue", () => {
     ).toBe(false);
   });
 
-  test("generates undefined for optional array", () => {
-    expect(generateDefaultValue({ type: "array" })).toBe(undefined);
+  test("generates empty array for root-level array schema", () => {
+    expect(generateDefaultValue({ type: "array" })).toEqual([]);
   });
 
   test("generates empty object for optional root object", () => {

--- a/client/src/utils/schemaUtils.ts
+++ b/client/src/utils/schemaUtils.ts
@@ -111,7 +111,7 @@ export function generateDefaultValue(
     case "boolean":
       return isRequired ? false : undefined;
     case "array":
-      return isRequired ? [] : undefined;
+      return isRequired || isRootSchema ? [] : undefined;
     case "object": {
       if (!schema.properties) {
         return isRequired || isRootSchema ? {} : undefined;


### PR DESCRIPTION
## Problem

Two related rendering gaps in `DynamicJsonForm`:

  1. **Nested / Optional array schemas rendered as raw JSON boxes.** FastMCP (and any Pydantic v2 tool) emits schemas like:
     - `List[T]` → `{ type: "array", items: { type: "object", properties: {...} } }`
     - `Optional[List[str]]` → `{ anyOf: [{ type: "array", items: {...} }, { type: "null" }] }`
     - `List[Optional[T]]` → items wrapped in `anyOf: [object, null]`

All three fell back to a raw JSON editor instead of structured Add/Remove controls.

  2. **String field height mismatch.**
     `DynamicJsonForm` rendered plain-text strings as `<Input>` (single-line, 36 px), while `ToolsTab` renders direct-parameter strings as `<Textarea>` — visually inconsistent.

## Solution

### `DynamicJsonForm.tsx`

  - **`canRenderTopLevelForm`** — calls `normalizeUnionType(s)` first so `anyOf:[array,null]` top-level schemas enable form mode.
  - **`renderFormFields`** — calls `normalizeUnionType(...)` at the top of every recursive call so `anyOf:[X,null]` fields resolve to their real type before any switch/depth check. Binds a local from a `rawSchema` parameter instead of mutating the parameter.
  - **Array `case "array"`** — normalizes `propSchema.items` through `normalizeUnionType`; gates structured rendering on `isSimpleObject(itemSchema) || (itemSchema.type === "object" && !!itemSchema.properties)` so arrays of objects get Add/Remove controls instead of falling back to JSON. The array-level description and the per-item `Items: …` description render above the items list.
  - **String `case "string"`** — plain text now renders as `<Textarea>` (matching `ToolsTab`); special formats (`email`, `uri`, `date`, `date-time`) keep `<Input type="...">`. A string that declares a `pattern` keeps `<Input type="text" pattern=…>` so the constraint is preserved client-side (`<textarea>` has no `pattern`).
  - **Description trimming** — trims `propSchema.description` to strip leading/trailing whitespace from Python triple-quoted docstrings.
  - **Object-array card layout** — Remove button sits at the bottom-right of each object card instead of the top.
  - **Array default values** — `Add Item` on an object array seeds required fields (via `generateDefaultValue`) instead of `{}`; switching an empty structured array to JSON seeds one template item so the shape is visible; a top-level array schema defaults to `[]`.

### Tests

  - `DynamicJsonForm.test.tsx` — plain-text strings assert `type="textarea"`; a pattern-constrained string asserts `<input type="text">` carrying the `pattern` attribute.
  - `DynamicJsonForm.array.test.tsx` — targeted cases for object arrays, untyped fallback, `Optional[List[X]]`, and `List[Optional[X]]`; array/item description assertions; object-item default and JSON template-seeding tests.
  - `schemaUtils.test.ts` — a root-level array schema defaults to `[]`.

## Test plan

  - [x] `cd client && npm test` — full client suite passes
  - [x] `npm run lint` passes with no new warnings
  - [x] Open a FastMCP tool with `List[SomeModel]` parameter → fields render as a structured form with Add/Remove
  - [x] Open a FastMCP tool with `Optional[List[str]]` → same structured form, not a JSON box
  - [x] Plain-text string fields visually match the height of direct-parameter string inputs
  - [x] Special string formats (`email`, `date`, etc.) still render as typed `<input>` elements
  - [x] "Switch to JSON / Switch to Form" toggle still works correctly

## Update — addressed review feedback

  - **pattern validation** — pattern-constrained strings now fall back to `<Input type="text" pattern>` so the constraint is preserved (regression test added).
  - **array / item descriptions** — restored both description blocks above the items list (assertions re-added rather than deleted).
  - **`required` on booleans + "True"/"False" label** — reverted the boolean field from the shadcn `<Switch>` back to the native `<Input type="checkbox" required>` the Inspector used previously: it natively supports `required` (restoring parity with the other fields) and drops the capitalized label. Boolean tests reverted to `role="checkbox"`.
  - **parameter reassignment** — `renderFormFields` no longer mutates its `propSchema` parameter.
