### PR TITLE
ci: gate claude.yml on author_association to skip unauthorized invokes

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,24 +16,16 @@ jobs:
       (
         (github.event_name == 'issue_comment' &&
           contains(github.event.comment.body, '@claude') &&
-          (github.event.comment.author_association == 'OWNER' ||
-           github.event.comment.author_association == 'MEMBER' ||
-           github.event.comment.author_association == 'COLLABORATOR')) ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
         (github.event_name == 'pull_request_review_comment' &&
           contains(github.event.comment.body, '@claude') &&
-          (github.event.comment.author_association == 'OWNER' ||
-           github.event.comment.author_association == 'MEMBER' ||
-           github.event.comment.author_association == 'COLLABORATOR')) ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
         (github.event_name == 'pull_request_review' &&
           contains(github.event.review.body, '@claude') &&
-          (github.event.review.author_association == 'OWNER' ||
-           github.event.review.author_association == 'MEMBER' ||
-           github.event.review.author_association == 'COLLABORATOR')) ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
         (github.event_name == 'issues' &&
           (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-          (github.event.issue.author_association == 'OWNER' ||
-           github.event.issue.author_association == 'MEMBER' ||
-           github.event.issue.author_association == 'COLLABORATOR'))
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
       )
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,10 +14,26 @@ jobs:
   claude:
     if: |
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        (github.event_name == 'issue_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          (github.event.comment.author_association == 'OWNER' ||
+           github.event.comment.author_association == 'MEMBER' ||
+           github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          (github.event.comment.author_association == 'OWNER' ||
+           github.event.comment.author_association == 'MEMBER' ||
+           github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review' &&
+          contains(github.event.review.body, '@claude') &&
+          (github.event.review.author_association == 'OWNER' ||
+           github.event.review.author_association == 'MEMBER' ||
+           github.event.review.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'issues' &&
+          (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+          (github.event.issue.author_association == 'OWNER' ||
+           github.event.issue.author_association == 'MEMBER' ||
+           github.event.issue.author_association == 'COLLABORATOR'))
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Tighten the trigger conditions for `.github/workflows/claude.yml` so the job is skipped at workflow evaluation time when the invoking user does not have write access, rather than starting and later failing when the action tries to perform privileged operations.

## Background

We observed a case where someone left an `@claude` comment on a PR and the workflow started running, then errored out partway through because the commenter didn't have the repo permissions Claude needs to act on their behalf. That's the intended security posture (only trusted users should be able to drive Claude in this repo), but the failure mode wasn't great:

- Red workflow runs cluttered the Actions tab for what is really an authorization rejection, not a real failure.
- Runner minutes were spent spinning up a job that was never going to succeed.
- The user got a confusing in-progress run followed by an opaque error, instead of a clean no-op.

## Change

Add an `author_association` check to each of the four trigger branches (`issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues`). The job's `if:` now requires the author to be `OWNER`, `MEMBER`, or `COLLABORATOR` in addition to the existing event-type and `@claude` body checks.

`author_association` is supplied by GitHub on the event payload itself, so this check happens during workflow evaluation — before a runner is allocated. Comments from users without write access become silent no-ops instead of failed runs.

This doesn't change who is *allowed* to drive Claude (the action itself already enforces this); it just moves the rejection earlier in the pipeline and makes it quiet.

## Test plan

- [ ] Comment `@claude ...` from an account with write access on an issue or PR — workflow runs as before.
- [ ] Comment `@claude ...` from an account without write access — workflow is skipped (no run appears in Actions), instead of starting and failing.
- [ ] Confirm all four trigger paths (`issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues`) behave consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)