### PR TITLE
fix(client): update resourceContent display when reading cached resources

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -903,7 +903,12 @@ const App = () => {
   };
 
   const readResource = async (uri: string) => {
-    if (fetchingResources.has(uri) || resourceContentMap[uri]) {
+    if (fetchingResources.has(uri)) {
+      return;
+    }
+
+    if (resourceContentMap[uri]) {
+      setResourceContent(resourceContentMap[uri]);
       return;
     }
 


### PR DESCRIPTION
## Bug Description

When clicking on a resource that was already cached in `resourceContentMap`, the right panel failed to update and continued showing stale content from a previously viewed resource or template.

### Reproduction Steps

1. Connect an MCP server with both a static resource and a resource template
2. Click the static resource → content displays correctly
3. Click the template, fill parameters, and read → template content displays
4. Click back on the static resource → **right panel still shows template content**

### Root Cause

In `readResource()`, the early return for cached resources never called `setResourceContent()`:

```typescript
if (fetchingResources.has(uri) || resourceContentMap[uri]) {
  return;  // Missing setResourceContent() call
}
```

### Fix

Separate the two conditions and display cached content before returning:

```typescript
if (fetchingResources.has(uri)) {
  return;
}

if (resourceContentMap[uri]) {
  setResourceContent(resourceContentMap[uri]);
  return;
}
```

This ensures the right panel always reflects the selected resource, even when served from cache.