### PR TITLE
Allow local and dev origins in MCP Apps sandbox referrer checks

### DIFF
--- a/server/static/sandbox_proxy.html
+++ b/server/static/sandbox_proxy.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -46,9 +46,60 @@
 
         return allowList.join("; ");
       }
+      function isPrivateIPv4(hostname) {
+        const ipv4Pattern =
+          /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+        const match = hostname.match(ipv4Pattern);
+        if (!match) return false;
 
-      const ALLOWED_REFERRER_PATTERN =
-        /^http:\/\/(localhost|127\.0\.0\.1)(:|\/|$)/;
+        const octets = match.slice(1).map(Number);
+        if (octets.some((n) => Number.isNaN(n) || n < 0 || n > 255)) {
+          return false;
+        }
+
+        const [a, b] = octets;
+        if (a === 10) return true;
+        if (a === 172 && b >= 16 && b <= 31) return true;
+        if (a === 192 && b === 168) return true;
+        return false;
+      }
+
+      function isAllowedDevHost(hostname) {
+        const normalized = hostname.toLowerCase();
+        if (
+          normalized === "localhost" ||
+          normalized === "127.0.0.1" ||
+          normalized === "0.0.0.0" ||
+          normalized === "::1" ||
+          normalized === "[::1]"
+        ) {
+          return true;
+        }
+
+        if (
+          normalized.endsWith(".localhost") ||
+          normalized.endsWith(".local")
+        ) {
+          return true;
+        }
+
+        return isPrivateIPv4(normalized);
+      }
+
+      function isAllowedReferrer(referrer) {
+        try {
+          const referrerUrl = new URL(referrer);
+          if (
+            referrerUrl.protocol !== "http:" &&
+            referrerUrl.protocol !== "https:"
+          ) {
+            return false;
+          }
+          return isAllowedDevHost(referrerUrl.hostname);
+        } catch {
+          return false;
+        }
+      }
 
       if (window.self === window.top) {
         throw new Error("This file is only to be used in an iframe sandbox.");
@@ -58,9 +109,9 @@
         throw new Error("No referrer, cannot validate embedding site.");
       }
 
-      if (!document.referrer.match(ALLOWED_REFERRER_PATTERN)) {
+      if (!isAllowedReferrer(document.referrer)) {
         throw new Error(
-          `Embedding domain not allowed in referrer ${document.referrer}. (Consider updating the validation logic to allow your domain.)`,
+          `Embedding domain not allowed in referrer ${document.referrer}. Only local/dev origins are allowed.`,
         );
       }
 
@@ -107,7 +158,7 @@
       // Message relay: This Sandbox (outer iframe) acts as a bidirectional bridge,
       // forwarding messages between:
       //
-      //   Host (parent window) ↔ Sandbox (outer frame) ↔ View (inner iframe)
+      //   Host (parent window) <-> Sandbox (outer frame) <-> View (inner iframe)
       //
       // Reason: the parent window and inner iframe have different origins and can't
       // communicate directly, so the outer iframe forwards messages in both


### PR DESCRIPTION
## Summary
- replace the hardcoded localhost-only referrer regex with helper-based validation for local and dev hosts
- allow loopback, .localhost, .local, and RFC1918 private IPv4 origins while keeping existing http/https and parent-origin checks
- tighten the rejection message to reflect the intended local/dev-only policy

Closes #1276

## Testing
- Not run locally in this environment