### PR TITLE
fix(oauth): pass resource_metadata URL to auth() across all error sources

### DIFF
--- a/client/src/lib/__tests__/extractResourceMetadataUrl.test.ts
+++ b/client/src/lib/__tests__/extractResourceMetadataUrl.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "@jest/globals";
+import { extractResourceMetadataUrlFromError } from "../extractResourceMetadataUrl";
+
+const META_URL =
+  "https://example.com/runtimes/abc/.well-known/oauth-protected-resource?qualifier=DEFAULT";
+
+describe("extractResourceMetadataUrlFromError", () => {
+  it("returns undefined for non-objects, plain Errors, empty objects", () => {
+    expect(
+      extractResourceMetadataUrlFromError(new Error("boom")),
+    ).toBeUndefined();
+    expect(extractResourceMetadataUrlFromError(undefined)).toBeUndefined();
+    expect(extractResourceMetadataUrlFromError(null)).toBeUndefined();
+    expect(extractResourceMetadataUrlFromError({})).toBeUndefined();
+    expect(extractResourceMetadataUrlFromError("string error")).toBeUndefined();
+  });
+
+  it("extracts from .resourceMetadataUrl as URL", () => {
+    expect(
+      extractResourceMetadataUrlFromError({
+        resourceMetadataUrl: new URL(META_URL),
+      })?.toString(),
+    ).toBe(META_URL);
+  });
+
+  it("extracts from .resourceMetadataUrl as string", () => {
+    expect(
+      extractResourceMetadataUrlFromError({
+        resourceMetadataUrl: META_URL,
+      })?.toString(),
+    ).toBe(META_URL);
+  });
+
+  it("ignores .resourceMetadataUrl when not parseable, falls through", () => {
+    expect(
+      extractResourceMetadataUrlFromError({
+        resourceMetadataUrl: "not a url",
+        data: {
+          upstream401: {
+            wwwAuthenticate: `Bearer resource_metadata="${META_URL}"`,
+          },
+        },
+      })?.toString(),
+    ).toBe(META_URL);
+  });
+
+  it("extracts from .response.headers (quoted resource_metadata)", () => {
+    const err = {
+      response: {
+        headers: new Headers({
+          "www-authenticate": `Bearer realm="mcp", resource_metadata="${META_URL}"`,
+        }),
+      },
+    };
+    expect(extractResourceMetadataUrlFromError(err)?.toString()).toBe(META_URL);
+  });
+
+  it("extracts from .headers (unquoted resource_metadata)", () => {
+    const err = {
+      headers: new Headers({
+        "www-authenticate": `Bearer resource_metadata=${META_URL}`,
+      }),
+    };
+    expect(extractResourceMetadataUrlFromError(err)?.toString()).toBe(META_URL);
+  });
+
+  it("extracts from data.upstream401.wwwAuthenticate (proxy-mode)", () => {
+    const err = {
+      code: -32099,
+      data: {
+        httpStatus: 401,
+        upstream401: {
+          wwwAuthenticate: `Bearer realm="mcp", resource_metadata="${META_URL}"`,
+          body: '{"error":"Missing Authentication Token"}',
+          contentType: "application/json",
+        },
+      },
+    };
+    expect(extractResourceMetadataUrlFromError(err)?.toString()).toBe(META_URL);
+  });
+
+  it("returns undefined for upstream401 without WWW-Authenticate", () => {
+    expect(
+      extractResourceMetadataUrlFromError({
+        data: { upstream401: { body: "x" } },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when resource_metadata is not a valid URL", () => {
+    expect(
+      extractResourceMetadataUrlFromError({
+        data: {
+          upstream401: {
+            wwwAuthenticate: 'Bearer resource_metadata="bad url"',
+          },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("priority: .resourceMetadataUrl beats both header and envelope", () => {
+    const winner = "https://winner.example.com/.well-known/x";
+    const err = {
+      resourceMetadataUrl: winner,
+      response: {
+        headers: new Headers({
+          "www-authenticate": `Bearer resource_metadata="${META_URL}"`,
+        }),
+      },
+      data: {
+        upstream401: {
+          wwwAuthenticate: `Bearer resource_metadata="https://other"`,
+        },
+      },
+    };
+    expect(extractResourceMetadataUrlFromError(err)?.toString()).toBe(winner);
+  });
+});

--- a/client/src/lib/connectionAuthErrors.ts
+++ b/client/src/lib/connectionAuthErrors.ts
@@ -20,6 +20,8 @@ export function mcpProxyTransportErrorDataIndicatesUnauthorized(
   return typeof status === "number" && status === 401;
 }
 
+export { extractResourceMetadataUrlFromError } from "./extractResourceMetadataUrl";
+
 /**
  * Whether `handleAuthError` / OAuth recovery should run for this failure.
  */

--- a/client/src/lib/extractResourceMetadataUrl.ts
+++ b/client/src/lib/extractResourceMetadataUrl.ts
@@ -1,0 +1,89 @@
+/**
+ * RFC 9728 helper: extract `resource_metadata=...` URL from auth-related
+ * errors, regardless of which transport / connection mode produced them.
+ *
+ * Why: Inspector's proxy mode unwraps upstream 401s into JSON-RPC errors with
+ * `data.upstream401.wwwAuthenticate`. The SDK transport never sees a 401, so
+ * its `onUnauthorized` hook can't fire. Without the verbatim metadata URL,
+ * `auth()` falls back to path-aware probes that 404 against resource servers
+ * like AWS AgentCore (which exposes RFC 9728 metadata at the "suffix" path)
+ * and the user is redirected to a bogus `<resource-host>/authorize`.
+ *
+ * Sources, in priority order:
+ *   1. `error.resourceMetadataUrl` — set by the SDK transport on
+ *      `UnauthorizedError` for direct 401s.
+ *   2. `error.response.headers` or `error.headers` — `WWW-Authenticate` header
+ *      on Sse/StreamableHTTP errors (duck-typed so this module is independent
+ *      of the SDK's CJS auth bundle, which has Jest resolution issues).
+ *   3. `error.data.upstream401.wwwAuthenticate` — the proxy-relayed envelope
+ *      used when `connectionType === "proxy"`.
+ *
+ * Returns `undefined` when no advertised URL is available; callers fall back
+ * to default discovery.
+ */
+
+function parseResourceMetadataFromWwwAuthenticate(
+  wwwAuthenticate: unknown,
+): URL | undefined {
+  if (typeof wwwAuthenticate !== "string") return undefined;
+  // RFC 9728 / RFC 6750: quoted-string preferred; bare token tolerated.
+  const match = wwwAuthenticate.match(
+    /resource_metadata\s*=\s*(?:"([^"]+)"|([^\s,]+))/i,
+  );
+  const raw = match?.[1] ?? match?.[2];
+  if (!raw) return undefined;
+  try {
+    return new URL(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function extractResourceMetadataUrlFromError(
+  error: unknown,
+): URL | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const e = error as {
+    resourceMetadataUrl?: unknown;
+    response?: { headers?: { get?: (k: string) => string | null } };
+    headers?: Headers | unknown;
+    data?: unknown;
+  };
+
+  // 1. SDK UnauthorizedError carries it directly
+  const direct = e.resourceMetadataUrl;
+  if (direct instanceof URL) return direct;
+  if (typeof direct === "string") {
+    try {
+      return new URL(direct);
+    } catch {
+      /* fall through */
+    }
+  }
+
+  // 2. WWW-Authenticate on the error (Sse/StreamableHTTP/fetch-style)
+  const wwwAuth =
+    e.response?.headers?.get?.("www-authenticate") ??
+    (e.headers instanceof Headers
+      ? e.headers.get("www-authenticate")
+      : undefined);
+  const fromHeader = parseResourceMetadataFromWwwAuthenticate(wwwAuth);
+  if (fromHeader) return fromHeader;
+
+  // 3. Proxy-relayed `upstream401` envelope (Inspector's proxy mode)
+  if (
+    isPlainObject(e.data) &&
+    "upstream401" in e.data &&
+    isPlainObject(e.data.upstream401)
+  ) {
+    return parseResourceMetadataFromWwwAuthenticate(
+      e.data.upstream401.wwwAuthenticate,
+    );
+  }
+
+  return undefined;
+}

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -49,7 +49,10 @@ import { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import { useEffect, useRef, useState } from "react";
 import { useToast } from "@/lib/hooks/useToast";
 import { ConnectionStatus, CLIENT_IDENTITY } from "../constants";
-import { isConnectionAuthError } from "../connectionAuthErrors";
+import {
+  extractResourceMetadataUrlFromError,
+  isConnectionAuthError,
+} from "../connectionAuthErrors";
 import { Notification } from "../notificationTypes";
 import {
   auth,
@@ -392,13 +395,23 @@ export function useConnection({
       const fetchFn =
         connectionType === "proxy" ? createProxyFetch(config) : undefined;
 
+      // RFC 9728: the resource server advertises its protected-resource
+      // metadata location via `WWW-Authenticate: Bearer resource_metadata=...`.
+      // Use that URL verbatim instead of letting the SDK probe path-style
+      // heuristics — those don't match resource servers (e.g. AWS AgentCore)
+      // that expose metadata at the suffix path defined in RFC 9728 §3.
+      // Without this, discovery 404s, the SDK falls back to treating the
+      // resource server as the auth server, and the user is redirected to
+      // a bogus `<resource-host>/authorize`. See issue #675.
+      const resourceMetadataUrl = extractResourceMetadataUrlFromError(error);
+
       if (!scope) {
         // Only discover resource metadata when we need to discover scopes
         let resourceMetadata;
         try {
           resourceMetadata = await discoverOAuthProtectedResourceMetadata(
             new URL("/", sseUrl),
-            {},
+            resourceMetadataUrl ? { resourceMetadataUrl } : {},
             fetchFn,
           );
         } catch {
@@ -414,6 +427,7 @@ export function useConnection({
         const result = await auth(serverAuthProvider, {
           serverUrl: sseUrl,
           scope,
+          ...(resourceMetadataUrl ? { resourceMetadataUrl } : {}),
           ...(fetchFn && { fetchFn }),
         });
         return result === "AUTHORIZED";


### PR DESCRIPTION
## Summary

Fixes a class of OAuth failures where Inspector ignores the `resource_metadata=...` URL advertised in `WWW-Authenticate` and falls back to default discovery — sending users to a bogus `<resource-host>/authorize`.

The proxy-mode path is the most broken: the proxy unwraps upstream 401s into JSON-RPC errors with `data.upstream401.wwwAuthenticate`. The SDK transport never sees a 401 status, so its `onUnauthorized` hook never fires, and `handleAuthError` doesn't currently look at the envelope.

This is one of several reports under #675.

## Root Cause

`handleAuthError` in `useConnection.ts` calls `auth()` without `resourceMetadataUrl`. The SDK's `auth()` then falls into `discoverOAuthServerInfo` → `discoverOAuthProtectedResourceMetadata(serverUrl, {})`, which builds a path-aware "prepend"-style URL (`/.well-known/oauth-protected-resource/<path>`). When the resource server exposes metadata at the suffix path defined in [RFC 9728 §3, paragraph 3](https://datatracker.ietf.org/doc/html/rfc9728#section-3), that 404s, the SDK falls back to treating `serverUrl` as the auth server, and `startAuthorization` builds `<host>/authorize`.

When `connectionType === "proxy"`, the proxy returns 200 with an SSE event wrapping the upstream 401 (see `serializeProxyTransportError` in `server/src/mcpProxy.ts`), so Inspector's `isConnectionAuthError` recognizes it via `data.upstream401`, but `handleAuthError` doesn't extract `wwwAuthenticate` from there — so even when the upstream advertises a metadata URL, we ignore it.

## Changes

- New `client/src/lib/extractResourceMetadataUrl.ts`: a flexible extractor that pulls `resource_metadata=...` from any of three sources, in priority order:
  1. `error.resourceMetadataUrl` (SDK `UnauthorizedError`-style — direct mode)
  2. `error.response.headers` / `error.headers` `WWW-Authenticate` (Sse/StreamableHTTP errors with attached headers)
  3. `error.data.upstream401.wwwAuthenticate` (proxy-relayed envelope — the broken path today)
- `connectionAuthErrors.ts`: re-export the new helper.
- `useConnection.ts`: in `handleAuthError`, call the extractor and pass the result to both `discoverOAuthProtectedResourceMetadata` and `auth()`.

The new module is intentionally split out so the unit tests don't transitively import the SDK's CJS auth bundle (which `require()`s the ESM-only `pkce-challenge` package and breaks Jest module resolution).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test updates

## Testing

- New unit tests: 10/10 passing. Covers all three extraction sources, priority resolution, and malformed inputs.
- Manual e2e via Playwright against an MCP server using JWT inbound auth with RFC 9728 metadata exposed at the suffix path:
  - **Vanilla v0.21.2**: redirect → `<resource-host>/authorize` → 404 ❌
  - **Patched**: redirect → `<auth-server>/oauth2/v1/authorize?response_type=code&client_id=...&code_challenge=...&resource=...` → completes OAuth → `tools/list` returns the full tool catalog ✅
- [x] Tested in UI mode (proxy + streamable-http transport)
- [x] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [x] Manual testing performed

## Related Issues

Refs #675. Reproduces the symptom described by `@embesozzi`, `@ravij3`, `@kevklam`, `@segevfiner`, and others. PR #1133 (closed without merging) addressed a related bug in `discoverScopes`; this PR addresses the `handleAuthError` path which is hit before `discoverScopes`.

## Breaking Changes

None.
