### PR TITLE
fix(client): display server stderr logs in Console tab

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1643,7 +1643,7 @@ const App = () => {
                         setNotifications((prev) => [...prev, notification]);
                       }}
                     />
-                    <ConsoleTab />
+                    <ConsoleTab serverLogs={notifications} />
                     <PingTab
                       onPingClick={() => {
                         void sendMCPRequest(

--- a/client/src/components/ConsoleTab.tsx
+++ b/client/src/components/ConsoleTab.tsx
@@ -1,12 +1,108 @@
+import { ServerNotification } from "@modelcontextprotocol/sdk/types.js";
+import { useEffect, useRef, useState } from "react";
 import { TabsContent } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
 
-const ConsoleTab = () => (
-  <TabsContent value="console" className="h-96">
-    <div className="bg-gray-900 text-gray-100 p-4 rounded-lg h-full font-mono text-sm overflow-auto">
-      <div className="opacity-50">Welcome to MCP Client Console</div>
-      {/* Console output would go here */}
-    </div>
-  </TabsContent>
-);
+const LEVEL_COLORS: Record<string, string> = {
+  debug: "text-gray-400",
+  info: "text-green-400",
+  notice: "text-blue-300",
+  warning: "text-yellow-400",
+  warn: "text-yellow-400",
+  error: "text-red-400",
+  critical: "text-red-500",
+  alert: "text-orange-400",
+  emergency: "text-red-600",
+};
+
+const ConsoleTab = ({
+  serverLogs = [],
+}: {
+  serverLogs?: ServerNotification[];
+}) => {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const [clearedCount, setClearedCount] = useState(0);
+
+  const allLogEntries = serverLogs.filter(
+    (n) => n.method === "notifications/message",
+  );
+  const logEntries = allLogEntries.slice(clearedCount);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [logEntries.length]);
+
+  return (
+    <TabsContent value="console" className="h-96">
+      <div className="flex flex-col h-full bg-gray-900 rounded-lg overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-2 border-b border-gray-700">
+          <span className="text-xs text-gray-400 font-mono">
+            Server Logs (stderr / MCP logging)
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setClearedCount(allLogEntries.length)}
+            disabled={logEntries.length === 0}
+            className="text-gray-400 hover:text-gray-200 h-6 text-xs"
+          >
+            Clear
+          </Button>
+        </div>
+        <div className="flex-1 overflow-auto p-3 font-mono text-sm">
+          {logEntries.length === 0 ? (
+            <div className="text-gray-500 opacity-50 text-xs">
+              No server logs yet. Stderr output and MCP logging notifications
+              will appear here.
+            </div>
+          ) : (
+            <div className="space-y-0.5">
+              {logEntries.map((notification, index) => {
+                const params = notification.params as Record<string, unknown>;
+                const level = String(params?.level ?? "info").toLowerCase();
+                const logger = String(params?.logger ?? "");
+                const data = params?.data;
+
+                let message: string;
+                if (typeof data === "string") {
+                  message = data;
+                } else if (typeof data === "object" && data !== null) {
+                  const dataObj = data as Record<string, unknown>;
+                  message =
+                    typeof dataObj.message === "string"
+                      ? dataObj.message
+                      : JSON.stringify(data, null, 2);
+                } else {
+                  message = String(data ?? "");
+                }
+
+                const colorClass = LEVEL_COLORS[level] ?? "text-gray-100";
+
+                return (
+                  <div key={index} className="flex gap-2 leading-5">
+                    <span className="text-gray-500 select-none shrink-0 text-xs">
+                      [{level.toUpperCase().slice(0, 7).padEnd(7)}]
+                    </span>
+                    {logger && logger !== "stdio" && (
+                      <span className="text-gray-600 select-none shrink-0 text-xs">
+                        [{logger}]
+                      </span>
+                    )}
+                    <span
+                      className={`${colorClass} break-all whitespace-pre-wrap`}
+                    >
+                      {message}
+                    </span>
+                  </div>
+                );
+              })}
+              <div ref={bottomRef} />
+            </div>
+          )}
+        </div>
+      </div>
+    </TabsContent>
+  );
+};
 
 export default ConsoleTab;

--- a/client/src/components/ConsoleTab.tsx
+++ b/client/src/components/ConsoleTab.tsx
@@ -26,6 +26,13 @@ const ConsoleTab = ({
   const allLogEntries = serverLogs.filter(
     (n) => n.method === "notifications/message",
   );
+
+  useEffect(() => {
+    setClearedCount((currentClearedCount) =>
+      Math.min(currentClearedCount, allLogEntries.length),
+    );
+  }, [allLogEntries.length]);
+
   const logEntries = allLogEntries.slice(clearedCount);
 
   useEffect(() => {

--- a/client/src/components/ConsoleTab.tsx
+++ b/client/src/components/ConsoleTab.tsx
@@ -36,6 +36,10 @@ const ConsoleTab = ({
   const logEntries = allLogEntries.slice(clearedCount);
 
   useEffect(() => {
+    setClearedCount((prev) => Math.min(prev, allLogEntries.length));
+  }, [allLogEntries.length]);
+
+  useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [logEntries.length]);
 

--- a/client/src/components/ConsoleTab.tsx
+++ b/client/src/components/ConsoleTab.tsx
@@ -36,10 +36,6 @@ const ConsoleTab = ({
   const logEntries = allLogEntries.slice(clearedCount);
 
   useEffect(() => {
-    setClearedCount((prev) => Math.min(prev, allLogEntries.length));
-  }, [allLogEntries.length]);
-
-  useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [logEntries.length]);
 

--- a/client/src/components/__tests__/ConsoleTab.test.tsx
+++ b/client/src/components/__tests__/ConsoleTab.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect } from "@jest/globals";
+import { ServerNotification } from "@modelcontextprotocol/sdk/types.js";
+import { Tabs } from "../ui/tabs";
+import ConsoleTab from "../ConsoleTab";
+
+const makeLog = (level: string, data: string): ServerNotification => ({
+  method: "notifications/message",
+  params: { level, data },
+});
+
+const makeOther = (): ServerNotification => ({
+  method: "notifications/progress",
+  params: { progressToken: "t", progress: 1, total: 10 },
+});
+
+const renderConsole = (logs: ServerNotification[] = []) =>
+  render(
+    <Tabs defaultValue="console">
+      <ConsoleTab serverLogs={logs} />
+    </Tabs>,
+  );
+
+describe("ConsoleTab", () => {
+  it("shows empty state when no logs are present", () => {
+    renderConsole([]);
+    expect(screen.getByText(/No server logs yet/)).toBeTruthy();
+  });
+
+  it("renders only notifications/message entries, ignoring other notification types", () => {
+    renderConsole([makeLog("info", "hello"), makeOther()]);
+    expect(screen.getByText("hello")).toBeTruthy();
+    // "notifications/progress" data should not appear
+    expect(screen.queryByText(/progressToken/)).toBeNull();
+  });
+
+  it("does not render non-message notifications", () => {
+    renderConsole([makeOther(), makeOther()]);
+    expect(screen.getByText(/No server logs yet/)).toBeTruthy();
+  });
+
+  it("clears displayed entries when Clear is clicked without mutating the serverLogs array", () => {
+    const logs: ServerNotification[] = [
+      makeLog("info", "msg-one"),
+      makeLog("error", "msg-two"),
+    ];
+    renderConsole(logs);
+
+    expect(screen.getByText("msg-one")).toBeTruthy();
+    expect(screen.getByText("msg-two")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(screen.queryByText("msg-one")).toBeNull();
+    expect(screen.queryByText("msg-two")).toBeNull();
+    // Original array is untouched
+    expect(logs).toHaveLength(2);
+  });
+
+  it("disables Clear when there are no visible log entries", () => {
+    renderConsole([]);
+    const btn = screen.getByRole("button", { name: "Clear" });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("shows new entries added after Clear", () => {
+    const logs: ServerNotification[] = [makeLog("info", "before-clear")];
+    const { rerender } = renderConsole(logs);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(screen.queryByText("before-clear")).toBeNull();
+
+    const extended = [...logs, makeLog("info", "after-clear")];
+    rerender(
+      <Tabs defaultValue="console">
+        <ConsoleTab serverLogs={extended} />
+      </Tabs>,
+    );
+
+    expect(screen.queryByText("before-clear")).toBeNull();
+    expect(screen.getByText("after-clear")).toBeTruthy();
+  });
+
+  it("clamps clearedCount when the upstream notifications array is reset to empty", () => {
+    const logs: ServerNotification[] = [
+      makeLog("info", "msg-a"),
+      makeLog("info", "msg-b"),
+    ];
+    const { rerender } = renderConsole(logs);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(screen.queryByText("msg-a")).toBeNull();
+
+    // Simulate the parent clearing notifications (e.g. History/Notifications panel Clear)
+    rerender(
+      <Tabs defaultValue="console">
+        <ConsoleTab serverLogs={[]} />
+      </Tabs>,
+    );
+
+    // Now add a new message — it must be visible (not hidden by a stale clearedCount)
+    rerender(
+      <Tabs defaultValue="console">
+        <ConsoleTab serverLogs={[makeLog("info", "fresh-msg")]} />
+      </Tabs>,
+    );
+
+    expect(screen.getByText("fresh-msg")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
 ConsoleTab was a static placeholder that showed no data. The proxy already forwarded MCP server stderr as notifications/message events, but the UI had no dedicated view for them.

  ConsoleTab now receives the notifications array and renders all notifications/message entries in a terminal-style panel: log levels are color-coded, the view auto-scrolls to the latest entry, and a Clear
  button lets users dismiss accumulated output without affecting the History/Notifications panel.

  Fixes #1283

  Type of Change

  - Bug fix (non-breaking change that fixes an issue)

  Changes Made

  - client/src/components/ConsoleTab.tsx — Replaced the static placeholder with a working log viewer. Filters the shared notifications array for notifications/message events and renders them in a dark
  terminal-style panel. Log levels (debug, info, warning, error, emergency, etc.) are color-coded. The panel auto-scrolls to the latest entry. A Clear button dismisses displayed entries without touching the
  History/Notifications panel.
  - client/src/App.tsx — Passes notifications as serverLogs prop to ConsoleTab.

  Related Issues

  Fixes #1283

  Testing

  - Tested with STDIO transport
  - Manual testing performed

  Test Results and/or Instructions

  1. Start the inspector targeting any MCP server that writes to stderr (e.g. a Python server using logging to stderr, or any server with startup messages)
  2. Connect via STDIO transport
  3. Open the Console tab — stderr output appears in real time, color-coded by log level
  4. Click Clear to dismiss entries; the History/Notifications panel is unaffected

  Checklist

  - Code follows the style guidelines (ran npm run prettier-fix)
  - Self-review completed