### PR TITLE
fix(client): fully collapse Output Schema and Meta panels in ToolsTab

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -736,15 +736,9 @@ const ToolsTab = ({
                         )}
                       </Button>
                     </div>
-                    <div
-                      className={`transition-all ${
-                        isOutputSchemaExpanded
-                          ? ""
-                          : "max-h-[8rem] overflow-y-auto"
-                      }`}
-                    >
+                    {isOutputSchemaExpanded && (
                       <JsonView data={selectedTool.outputSchema} />
-                    </div>
+                    )}
                   </div>
                 )}
                 {selectedTool &&
@@ -774,15 +768,9 @@ const ToolsTab = ({
                           )}
                         </Button>
                       </div>
-                      <div
-                        className={`transition-all ${
-                          isMetadataExpanded
-                            ? ""
-                            : "max-h-[8rem] overflow-y-auto"
-                        }`}
-                      >
+                      {isMetadataExpanded && (
                         <JsonView data={selectedTool._meta} />
-                      </div>
+                      )}
                     </div>
                   )}
                 {taskSupport !== "forbidden" && (


### PR DESCRIPTION
## Summary

The Output Schema and Meta panels in the tool detail view kept rendering their JSON body inside a clipped scroll well (`max-h-[8rem] overflow-y-auto`) when "collapsed", so a chunk of the panel content stayed on screen and the toggle didn't really collapse anything. The issue's screenshot shows this clearly.

This PR conditionally renders each body only when the corresponding `isOutputSchemaExpanded` / `isMetadataExpanded` flag is true. Collapsed state now shows just the header row and the Expand button, matching the user expectation in #928.

The fix targets V1 (`client/src/components/ToolsTab.tsx`); the issue's screenshot is from the current V1 UI even though the issue carries the `v2` label.

Fixes #928

## Test plan

- [x] `npm run prettier-fix` clean
- [x] Manual: connect to the Everything server in UI mode, open a tool with an output schema, toggle Expand/Collapse on both the Output Schema and Meta panels. Collapsed state now shows only the header.
- [ ] No existing test asserted collapsed-DOM contents in `client/src/components/__tests__/ToolsTab.test.tsx`, so no new test was added.