### PR TITLE
fix(client): omit x-custom-auth-headers on direct connections

### DIFF
--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -1259,6 +1259,36 @@ describe("useConnection", () => {
       );
     });
 
+    test("does NOT add x-custom-auth-headers when connectionType is direct", async () => {
+      // Regression test for #1294: the x-custom-auth-headers is an
+      // inspector-proxy-specific protocol header. Sending it to a direct MCP
+      // server breaks the CORS preflight because the upstream server does not
+      // include it in Access-Control-Allow-Headers.
+      const customHeaders: CustomHeaders = [
+        { name: "X-Tenant-ID", value: "acme-inc", enabled: true },
+        { name: "X-Environment", value: "staging", enabled: true },
+      ];
+
+      const directProps = {
+        ...defaultProps,
+        connectionType: "direct" as const,
+        customHeaders,
+      };
+
+      const { result } = renderHook(() => useConnection(directProps));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      const headers = mockSSETransport.options?.requestInit?.headers;
+      // The actual custom headers ARE still sent
+      expect(headers).toHaveProperty("X-Tenant-ID", "acme-inc");
+      expect(headers).toHaveProperty("X-Environment", "staging");
+      // But the proxy-only metadata header is omitted
+      expect(headers).not.toHaveProperty("x-custom-auth-headers");
+    });
+
     test("ignores disabled custom headers", async () => {
       const customHeaders: CustomHeaders = [
         { name: "Authorization", value: "Bearer token123", enabled: true },

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -553,8 +553,12 @@ export function useConnection({
         }
       });
 
-      // Add custom header names as a special request header for server processing
-      if (customHeaderNames.length > 0) {
+      // Add custom header names as a special request header so the inspector's
+      // proxy server knows which custom headers to forward upstream. This is an
+      // inspector-proxy-specific protocol header; it must NOT be sent on direct
+      // connections, where the target MCP server doesn't expect it and may
+      // reject the CORS preflight because of it (issue #1294).
+      if (customHeaderNames.length > 0 && connectionType !== "direct") {
         headers["x-custom-auth-headers"] = JSON.stringify(customHeaderNames);
       }
 


### PR DESCRIPTION
## Summary

Fixes #1294.

The `x-custom-auth-headers` request header is an inspector-proxy-specific protocol header — the inspector's proxy server parses it (`server/src/index.ts`, lines 162-182) to know which client-supplied custom headers to forward upstream. On **direct** connections this header is meaningless to the target MCP server, and worse: it pollutes the CORS preflight (`Access-Control-Request-Headers: ..., x-custom-auth-headers, ...`). When the user's MCP server does not list `x-custom-auth-headers` in `Access-Control-Allow-Headers`, the preflight fails and the actual request — including the user's intended custom headers — never reaches the server.

This matches the symptom in #1294: the tcpdump shows the user-configured `x-custom1` appearing in the preflight `Access-Control-Request-Headers` list, but the actual POST is never sent.

## Fix

Gate the addition of `x-custom-auth-headers` on `connectionType !== "direct"`. The actual user-defined custom headers are still added to the request in both modes.

```ts
if (customHeaderNames.length > 0 && connectionType !== "direct") {
  headers["x-custom-auth-headers"] = JSON.stringify(customHeaderNames);
}
```

## Test

Added a regression test in `useConnection.test.tsx` that:
- Configures `X-Tenant-ID` and `X-Environment` custom headers with `connectionType: "direct"`.
- Asserts the user headers ARE present on the transport's `requestInit.headers`.
- Asserts `x-custom-auth-headers` is NOT present.

The existing proxy-mode tests (which use the default `connectionType`, i.e. `"proxy"`) continue to assert the metadata header IS added, so backwards compatibility for proxy users is preserved.

## Notes

- Scope is intentionally narrow: only the metadata header is gated. The behaviour of the per-header forwarding (lines 540-554) is unchanged.
- `headerName.toLowerCase() !== "authorization"` filter on line 550 is unaffected — `customHeaderNames` is still populated the same way; it's just not serialised onto the wire in direct mode.