### PR TITLE
fix(cli): allow empty-string env variable values

### DIFF
--- a/cli/__tests__/cli.test.ts
+++ b/cli/__tests__/cli.test.ts
@@ -103,6 +103,31 @@ describe("CLI Tests", () => {
       expectCliFailure(result);
     });
 
+    it("should accept empty-string environment variable value (#629)", async () => {
+      // An empty string is a meaningful, distinct value from "unset" for
+      // environment variables; `-e KEY=` must not be rejected.
+      const { command, args } = getTestMcpServerCommand();
+      const result = await runCli([
+        command,
+        ...args,
+        "-e",
+        "EMPTY_VAR=",
+        "-e",
+        "NON_EMPTY=value",
+        "--cli",
+        "--method",
+        "resources/read",
+        "--uri",
+        "test://env",
+      ]);
+
+      expectCliSuccess(result);
+      const json = expectValidJson(result);
+      const envVars = JSON.parse(json.contents[0].text);
+      expect(envVars.EMPTY_VAR).toBe("");
+      expect(envVars.NON_EMPTY).toBe("value");
+    });
+
     it("should handle environment variable with equals sign in value", async () => {
       const { command, args } = getTestMcpServerCommand();
       const result = await runCli([

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -205,17 +205,23 @@ function parseKeyValuePair(
   value: string,
   previous: Record<string, string> = {},
 ): Record<string, string> {
-  const parts = value.split("=");
-  const key = parts[0];
-  const val = parts.slice(1).join("=");
+  // Locate the first `=` so the value can contain additional `=` characters
+  // (e.g. base64 padding, JWTs, query strings).
+  const equalIndex = value.indexOf("=");
 
-  if (val === undefined || val === "") {
+  // Require an `=` separator and a non-empty key, but allow an empty value
+  // (e.g. `-e MY_ENV=`) — an empty string is a meaningful, distinct state
+  // from "unset" for environment variables. Fixes #629.
+  if (equalIndex <= 0) {
     throw new Error(
       `Invalid parameter format: ${value}. Use key=value format.`,
     );
   }
 
-  return { ...previous, [key as string]: val };
+  const key = value.substring(0, equalIndex);
+  const val = value.substring(equalIndex + 1);
+
+  return { ...previous, [key]: val };
 }
 
 function parseHeaderPair(


### PR DESCRIPTION
Fixes #629.

## Why

The CLI rejects `-e KEY=` with `Invalid parameter format: KEY=. Use key=value format.` even though an empty string is a meaningful, distinct value from "unset" for environment variables. Some programs branch on `MY_VAR === ""` vs `MY_VAR === undefined` (e.g. to mean "explicitly disabled" vs "defaults"), and there is currently no way to express the empty-string state through `mcp-inspector -e`.

Reproduction from the issue:

```sh
npm exec -- mcp-inspector -e MY_ENV= -- node main.js
# Invalid parameter format: MY_ENV=. Use key=value format.
```

## What

`cli/src/cli.ts` — rewrite `parseKeyValuePair` to use `indexOf("=")`:

- Require an `=` separator and a non-empty key (so `INVALID_FORMAT` and `=value` still fail).
- Allow an empty value after the `=`.
- Use a single `substring` split instead of `split("=")` + `slice(1).join("=")` — clearer and equally correct for values containing additional `=` characters (e.g. base64, JWTs, query strings; existing tests cover both).

Scope intentionally narrow: `parseKeyValuePair` in `cli/src/cli.ts` is only wired to the `-e <env>` option (see line 264). A function with the same name in `cli/src/index.ts` parses tool args / prompt args / metadata and is left untouched — those values go through `JSON.parse` afterwards and the empty-value semantics there deserve a separate discussion.

## Tested

Added a regression test in `cli/__tests__/cli.test.ts` (`should accept empty-string environment variable value (#629)`) that runs the CLI with `-e EMPTY_VAR= -e NON_EMPTY=value` against the test stdio server and asserts both values come through correctly.

The existing `should reject invalid environment variable format` test (input `INVALID_FORMAT`, no `=`) still passes — `indexOf("=")` returns `-1` and the guard `equalIndex <= 0` keeps that case failing.

## Motivation / Checklist

- [x] I have read the [contributing guidelines](https://github.com/modelcontextprotocol/inspector/blob/main/CONTRIBUTING.md).
- [x] Tests added / updated.
- [x] No breaking changes — all existing positive-case and negative-case env tests still pass.
