### PR TITLE
feat(core): port v1.5 hook layer (#1243)

### DIFF
--- a/clients/web/src/test/core/mcp/state/fetchRequestLogState.test.ts
+++ b/clients/web/src/test/core/mcp/state/fetchRequestLogState.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { FetchRequestEntry } from "@inspector/core/mcp/types";
+import { FetchRequestLogState } from "@inspector/core/mcp/state/fetchRequestLogState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import type {
+  InspectorClientStorage,
+  InspectorClientSessionState,
+} from "@inspector/core/mcp/sessionStorage";
+
+function entry(id: string, url = `https://x/${id}`): FetchRequestEntry {
+  return {
+    id,
+    timestamp: new Date(2026, 4, 13),
+    method: "GET",
+    url,
+    requestHeaders: {},
+    category: "transport",
+  };
+}
+
+function makeStorage(
+  initial: Record<string, InspectorClientSessionState> = {},
+): InspectorClientStorage & {
+  saves: Array<{ id: string; state: InspectorClientSessionState }>;
+} {
+  const store = new Map(Object.entries(initial));
+  const saves: Array<{ id: string; state: InspectorClientSessionState }> = [];
+  return {
+    saves,
+    async saveSession(sessionId, state) {
+      saves.push({ id: sessionId, state });
+      store.set(sessionId, state);
+    },
+    async loadSession(sessionId) {
+      return store.get(sessionId);
+    },
+    async deleteSession(sessionId) {
+      store.delete(sessionId);
+    },
+  };
+}
+
+describe("FetchRequestLogState", () => {
+  let client: FakeInspectorClient;
+  let state: FetchRequestLogState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new FetchRequestLogState(client);
+  });
+
+  it("starts empty and returns defensive copies", () => {
+    expect(state.getFetchRequests()).toEqual([]);
+    expect(state.getFetchRequests()).not.toBe(state.getFetchRequests());
+  });
+
+  it("appends entries and dispatches fetchRequest + fetchRequestsChange", () => {
+    const seenSingle: FetchRequestEntry[] = [];
+    const seenFull: FetchRequestEntry[][] = [];
+    state.addEventListener("fetchRequest", (e) => seenSingle.push(e.detail));
+    state.addEventListener("fetchRequestsChange", (e) =>
+      seenFull.push(e.detail),
+    );
+
+    client.dispatchTypedEvent("fetchRequest", entry("a"));
+    client.dispatchTypedEvent("fetchRequest", entry("b"));
+
+    expect(state.getFetchRequests().map((e) => e.id)).toEqual(["a", "b"]);
+    expect(seenSingle).toHaveLength(2);
+    expect(seenFull).toHaveLength(2);
+  });
+
+  it("trims the oldest entries when maxFetchRequests is exceeded", () => {
+    const small = new FetchRequestLogState(client, { maxFetchRequests: 2 });
+    client.dispatchTypedEvent("fetchRequest", entry("a"));
+    client.dispatchTypedEvent("fetchRequest", entry("b"));
+    client.dispatchTypedEvent("fetchRequest", entry("c"));
+    expect(small.getFetchRequests().map((e) => e.id)).toEqual(["b", "c"]);
+  });
+
+  it("does not trim when maxFetchRequests is 0", () => {
+    const big = new FetchRequestLogState(client, { maxFetchRequests: 0 });
+    for (let i = 0; i < 5; i++) {
+      client.dispatchTypedEvent("fetchRequest", entry(`m${i}`));
+    }
+    expect(big.getFetchRequests()).toHaveLength(5);
+  });
+
+  it("clearFetchRequests dispatches when the list was non-empty", () => {
+    client.dispatchTypedEvent("fetchRequest", entry("a"));
+    let dispatched = false;
+    state.addEventListener("fetchRequestsChange", () => (dispatched = true));
+    state.clearFetchRequests();
+    expect(dispatched).toBe(true);
+    expect(state.getFetchRequests()).toEqual([]);
+  });
+
+  it("clearFetchRequests is a no-op when empty", () => {
+    let dispatched = false;
+    state.addEventListener("fetchRequestsChange", () => (dispatched = true));
+    state.clearFetchRequests();
+    expect(dispatched).toBe(false);
+  });
+
+  it("does NOT clear on connect or disconnect", () => {
+    client.dispatchTypedEvent("fetchRequest", entry("a"));
+    client.dispatchTypedEvent("connect");
+    expect(state.getFetchRequests().map((e) => e.id)).toEqual(["a"]);
+    client.setStatus("disconnected");
+    expect(state.getFetchRequests().map((e) => e.id)).toEqual(["a"]);
+  });
+
+  it("persists entries via saveSession when sessionStorage is provided", () => {
+    const storage = makeStorage();
+    const sessionState = new FetchRequestLogState(client, {
+      sessionStorage: storage,
+    });
+    client.dispatchTypedEvent("fetchRequest", entry("a"));
+    client.dispatchTypedEvent("saveSession", { sessionId: "sess-1" });
+    expect(storage.saves).toHaveLength(1);
+    expect(storage.saves[0]!.id).toBe("sess-1");
+    expect(storage.saves[0]!.state.fetchRequests.map((e) => e.id)).toEqual([
+      "a",
+    ]);
+    sessionState.destroy();
+  });
+
+  it("swallows saveSession errors (fire and forget)", async () => {
+    const storage = makeStorage();
+    storage.saveSession = vi.fn().mockRejectedValue(new Error("boom"));
+    new FetchRequestLogState(client, { sessionStorage: storage });
+    expect(() =>
+      client.dispatchTypedEvent("saveSession", { sessionId: "sess-1" }),
+    ).not.toThrow();
+    await Promise.resolve();
+    expect(storage.saveSession).toHaveBeenCalled();
+  });
+
+  it("hydrates from storage when sessionId is provided and entries exist", async () => {
+    const storage = makeStorage({
+      "sess-restore": {
+        fetchRequests: [entry("r1"), entry("r2")],
+        createdAt: 0,
+        updatedAt: 0,
+      },
+    });
+    const hydrated = new FetchRequestLogState(client, {
+      sessionStorage: storage,
+      sessionId: "sess-restore",
+    });
+    // hydrate is async via .then(); resolve microtasks
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(hydrated.getFetchRequests().map((e) => e.id)).toEqual(["r1", "r2"]);
+    hydrated.destroy();
+  });
+
+  it("hydrate respects maxFetchRequests trimming", async () => {
+    const storage = makeStorage({
+      "sess-trim": {
+        fetchRequests: [entry("r1"), entry("r2"), entry("r3")],
+        createdAt: 0,
+        updatedAt: 0,
+      },
+    });
+    const hydrated = new FetchRequestLogState(client, {
+      sessionStorage: storage,
+      sessionId: "sess-trim",
+      maxFetchRequests: 2,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(hydrated.getFetchRequests().map((e) => e.id)).toEqual(["r2", "r3"]);
+  });
+
+  it("ignores hydration when destroy() happens first", async () => {
+    let resolveLoad:
+      | ((s: InspectorClientSessionState | undefined) => void)
+      | undefined;
+    const storage: InspectorClientStorage = {
+      async saveSession() {},
+      loadSession: () =>
+        new Promise((resolve) => {
+          resolveLoad = resolve;
+        }),
+      async deleteSession() {},
+    };
+    const hydrated = new FetchRequestLogState(client, {
+      sessionStorage: storage,
+      sessionId: "sess-late",
+    });
+    hydrated.destroy();
+    resolveLoad?.({
+      fetchRequests: [entry("late")],
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    await Promise.resolve();
+    expect(hydrated.getFetchRequests()).toEqual([]);
+  });
+
+  it("destroy stops listening and clears state", () => {
+    client.dispatchTypedEvent("fetchRequest", entry("a"));
+    state.destroy();
+    expect(state.getFetchRequests()).toEqual([]);
+    client.dispatchTypedEvent("fetchRequest", entry("b"));
+    expect(state.getFetchRequests()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/managedPromptsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedPromptsState.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import { ManagedPromptsState } from "@inspector/core/mcp/state/managedPromptsState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function prompt(name: string): Prompt {
+  return { name };
+}
+
+function waitForPromptsChange(state: ManagedPromptsState): Promise<Prompt[]> {
+  return new Promise((resolve) => {
+    state.addEventListener("promptsChange", (e) => resolve(e.detail), {
+      once: true,
+    });
+  });
+}
+
+describe("ManagedPromptsState", () => {
+  let client: FakeInspectorClient;
+  let state: ManagedPromptsState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new ManagedPromptsState(client);
+  });
+
+  it("starts with empty prompts", () => {
+    expect(state.getPrompts()).toEqual([]);
+  });
+
+  it("getPrompts returns a defensive copy", () => {
+    const a = state.getPrompts();
+    const b = state.getPrompts();
+    expect(a).not.toBe(b);
+  });
+
+  it("refresh returns early and does not call listPrompts when disconnected", async () => {
+    const result = await state.refresh();
+    expect(result).toEqual([]);
+    expect(client.listPrompts).not.toHaveBeenCalled();
+  });
+
+  it("refresh fetches a single page and dispatches promptsChange", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a"), prompt("b")] });
+
+    const changePromise = waitForPromptsChange(state);
+    const result = await state.refresh();
+
+    expect(result.map((p) => p.name)).toEqual(["a", "b"]);
+    expect(await changePromise).toEqual(result);
+    expect(state.getPrompts().map((p) => p.name)).toEqual(["a", "b"]);
+  });
+
+  it("refresh accumulates across multiple paginated pages", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages(
+      { prompts: [prompt("a")], nextCursor: "c1" },
+      { prompts: [prompt("b")], nextCursor: "c2" },
+      { prompts: [prompt("c")] },
+    );
+
+    const result = await state.refresh();
+    expect(result.map((p) => p.name)).toEqual(["a", "b", "c"]);
+    expect(client.listPrompts).toHaveBeenCalledTimes(3);
+  });
+
+  it("refresh passes setMetadata-supplied metadata to listPrompts", async () => {
+    client.setStatus("connected");
+    state.setMetadata({ k: "v" });
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.refresh();
+    expect(client.listPrompts).toHaveBeenCalledWith(undefined, { k: "v" });
+  });
+
+  it("refresh argument overrides setMetadata", async () => {
+    client.setStatus("connected");
+    state.setMetadata({ k: "default" });
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.refresh({ k: "override" });
+    expect(client.listPrompts).toHaveBeenCalledWith(undefined, {
+      k: "override",
+    });
+  });
+
+  it("connect event triggers a refresh", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    const changePromise = waitForPromptsChange(state);
+    client.dispatchTypedEvent("connect");
+    const next = await changePromise;
+    expect(next.map((p) => p.name)).toEqual(["a"]);
+  });
+
+  it("promptsListChanged event triggers a refresh", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a"), prompt("b")] });
+    const changePromise = waitForPromptsChange(state);
+    client.dispatchTypedEvent("promptsListChanged");
+    const next = await changePromise;
+    expect(next.map((p) => p.name)).toEqual(["a", "b"]);
+  });
+
+  it("statusChange to disconnected clears prompts and dispatches promptsChange", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.refresh();
+    expect(state.getPrompts()).toHaveLength(1);
+
+    const changePromise = waitForPromptsChange(state);
+    client.setStatus("disconnected");
+    const next = await changePromise;
+    expect(next).toEqual([]);
+    expect(state.getPrompts()).toEqual([]);
+  });
+
+  it("statusChange to other (non-disconnected) values does not clear prompts", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.refresh();
+    client.setStatus("error");
+    expect(state.getPrompts().map((p) => p.name)).toEqual(["a"]);
+  });
+
+  it("throws when pagination exceeds 100 pages", async () => {
+    client.setStatus("connected");
+    client.listPrompts.mockImplementation(async () => ({
+      prompts: [prompt("a")],
+      nextCursor: "always",
+    }));
+    await expect(state.refresh()).rejects.toThrow(/Maximum pagination limit/);
+  });
+
+  it("destroy unsubscribes from client events and clears state", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.refresh();
+    expect(state.getPrompts()).toHaveLength(1);
+
+    state.destroy();
+    expect(state.getPrompts()).toEqual([]);
+
+    client.queuePromptPages({ prompts: [prompt("b")] });
+    client.dispatchTypedEvent("promptsListChanged");
+    await Promise.resolve();
+    expect(state.getPrompts()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/managedRequestorTasksState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedRequestorTasksState.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Task } from "@modelcontextprotocol/sdk/types.js";
+import { ManagedRequestorTasksState } from "@inspector/core/mcp/state/managedRequestorTasksState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function task(taskId: string, status: Task["status"] = "working"): Task {
+  return {
+    taskId,
+    status,
+    ttl: null,
+    createdAt: "2026-05-13T00:00:00Z",
+    lastUpdatedAt: "2026-05-13T00:00:00Z",
+  };
+}
+
+function waitForChange(state: ManagedRequestorTasksState): Promise<Task[]> {
+  return new Promise((resolve) => {
+    state.addEventListener("tasksChange", (e) => resolve(e.detail), {
+      once: true,
+    });
+  });
+}
+
+describe("ManagedRequestorTasksState", () => {
+  let client: FakeInspectorClient;
+  let state: ManagedRequestorTasksState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new ManagedRequestorTasksState(client);
+  });
+
+  it("starts with empty tasks", () => {
+    expect(state.getTasks()).toEqual([]);
+  });
+
+  it("getTasks returns a defensive copy", () => {
+    const a = state.getTasks();
+    const b = state.getTasks();
+    expect(a).not.toBe(b);
+  });
+
+  it("refresh returns early and does not call listRequestorTasks when disconnected", async () => {
+    const result = await state.refresh();
+    expect(result).toEqual([]);
+    expect(client.listRequestorTasks).not.toHaveBeenCalled();
+  });
+
+  it("refresh fetches a single page and dispatches tasksChange", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1"), task("t2")] });
+
+    const changePromise = waitForChange(state);
+    const result = await state.refresh();
+
+    expect(result.map((t) => t.taskId)).toEqual(["t1", "t2"]);
+    expect(await changePromise).toEqual(result);
+  });
+
+  it("refresh accumulates across multiple paginated pages", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages(
+      { tasks: [task("t1")], nextCursor: "c1" },
+      { tasks: [task("t2")], nextCursor: "c2" },
+      { tasks: [task("t3")] },
+    );
+
+    const result = await state.refresh();
+    expect(result.map((t) => t.taskId)).toEqual(["t1", "t2", "t3"]);
+    expect(client.listRequestorTasks).toHaveBeenCalledTimes(3);
+  });
+
+  it("connect event triggers a refresh", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1")] });
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("connect");
+    const next = await changePromise;
+    expect(next.map((t) => t.taskId)).toEqual(["t1"]);
+  });
+
+  it("tasksListChanged event triggers a refresh", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1"), task("t2")] });
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("tasksListChanged");
+    const next = await changePromise;
+    expect(next.map((t) => t.taskId)).toEqual(["t1", "t2"]);
+  });
+
+  it("statusChange to disconnected clears tasks and dispatches tasksChange", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1")] });
+    await state.refresh();
+    expect(state.getTasks()).toHaveLength(1);
+
+    const changePromise = waitForChange(state);
+    client.setStatus("disconnected");
+    const next = await changePromise;
+    expect(next).toEqual([]);
+    expect(state.getTasks()).toEqual([]);
+  });
+
+  it("statusChange to other values does not clear tasks", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1")] });
+    await state.refresh();
+    client.setStatus("error");
+    expect(state.getTasks().map((t) => t.taskId)).toEqual(["t1"]);
+  });
+
+  it("taskStatusChange inserts a new task when the id is unknown", async () => {
+    client.setStatus("connected");
+    const newTask = task("t1", "working");
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("taskStatusChange", {
+      taskId: "t1",
+      task: newTask,
+    });
+    const next = await changePromise;
+    expect(next.map((t) => t.taskId)).toEqual(["t1"]);
+    expect(next[0]!.status).toBe("working");
+  });
+
+  it("taskStatusChange replaces an existing task in place", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({
+      tasks: [task("t1", "working"), task("t2", "working")],
+    });
+    await state.refresh();
+
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("taskStatusChange", {
+      taskId: "t1",
+      task: task("t1", "completed"),
+    });
+    const next = await changePromise;
+    expect(next.map((t) => t.taskId)).toEqual(["t1", "t2"]);
+    expect(next.find((t) => t.taskId === "t1")!.status).toBe("completed");
+  });
+
+  it("requestorTaskUpdated falls back to lastUpdatedAt when createdAt is missing", async () => {
+    client.setStatus("connected");
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("requestorTaskUpdated", {
+      taskId: "t1",
+      task: {
+        taskId: "t1",
+        status: "working",
+        ttl: null,
+        lastUpdatedAt: "2026-05-13T01:00:00Z",
+      },
+    });
+    const next = await changePromise;
+    expect(next[0]!.createdAt).toBe("2026-05-13T01:00:00Z");
+  });
+
+  it("taskCancelled flips status to cancelled when the task is known", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1", "working")] });
+    await state.refresh();
+
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("taskCancelled", { taskId: "t1" });
+    const next = await changePromise;
+    expect(next[0]!.status).toBe("cancelled");
+  });
+
+  it("taskCancelled is a no-op when the task is unknown", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1")] });
+    await state.refresh();
+
+    let dispatched = false;
+    state.addEventListener("tasksChange", () => {
+      dispatched = true;
+    });
+    client.dispatchTypedEvent("taskCancelled", { taskId: "missing" });
+    expect(dispatched).toBe(false);
+    expect(state.getTasks().map((t) => t.taskId)).toEqual(["t1"]);
+  });
+
+  it("throws when pagination exceeds 100 pages", async () => {
+    client.setStatus("connected");
+    client.listRequestorTasks.mockImplementation(async () => ({
+      tasks: [task("t1")],
+      nextCursor: "always",
+    }));
+    await expect(state.refresh()).rejects.toThrow(/Maximum pagination limit/);
+  });
+
+  it("destroy unsubscribes from client events and clears state", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1")] });
+    await state.refresh();
+    expect(state.getTasks()).toHaveLength(1);
+
+    state.destroy();
+    expect(state.getTasks()).toEqual([]);
+
+    client.queueTaskPages({ tasks: [task("t2")] });
+    client.dispatchTypedEvent("tasksListChanged");
+    await Promise.resolve();
+    expect(state.getTasks()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/managedResourceTemplatesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedResourceTemplatesState.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
+import { ManagedResourceTemplatesState } from "@inspector/core/mcp/state/managedResourceTemplatesState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function template(name: string): ResourceTemplate {
+  return { uriTemplate: `tpl://{${name}}`, name };
+}
+
+function waitForChange(
+  state: ManagedResourceTemplatesState,
+): Promise<ResourceTemplate[]> {
+  return new Promise((resolve) => {
+    state.addEventListener(
+      "resourceTemplatesChange",
+      (e) => resolve(e.detail),
+      { once: true },
+    );
+  });
+}
+
+describe("ManagedResourceTemplatesState", () => {
+  let client: FakeInspectorClient;
+  let state: ManagedResourceTemplatesState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new ManagedResourceTemplatesState(client);
+  });
+
+  it("starts with empty resource templates", () => {
+    expect(state.getResourceTemplates()).toEqual([]);
+  });
+
+  it("getResourceTemplates returns a defensive copy", () => {
+    const a = state.getResourceTemplates();
+    const b = state.getResourceTemplates();
+    expect(a).not.toBe(b);
+  });
+
+  it("refresh returns early and does not call listResourceTemplates when disconnected", async () => {
+    const result = await state.refresh();
+    expect(result).toEqual([]);
+    expect(client.listResourceTemplates).not.toHaveBeenCalled();
+  });
+
+  it("refresh fetches a single page and dispatches resourceTemplatesChange", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({
+      resourceTemplates: [template("a"), template("b")],
+    });
+
+    const changePromise = waitForChange(state);
+    const result = await state.refresh();
+
+    expect(result.map((t) => t.name)).toEqual(["a", "b"]);
+    expect(await changePromise).toEqual(result);
+    expect(state.getResourceTemplates().map((t) => t.name)).toEqual(["a", "b"]);
+  });
+
+  it("refresh accumulates across multiple paginated pages", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages(
+      { resourceTemplates: [template("a")], nextCursor: "c1" },
+      { resourceTemplates: [template("b")], nextCursor: "c2" },
+      { resourceTemplates: [template("c")] },
+    );
+
+    const result = await state.refresh();
+    expect(result.map((t) => t.name)).toEqual(["a", "b", "c"]);
+    expect(client.listResourceTemplates).toHaveBeenCalledTimes(3);
+  });
+
+  it("refresh passes setMetadata-supplied metadata", async () => {
+    client.setStatus("connected");
+    state.setMetadata({ k: "v" });
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.refresh();
+    expect(client.listResourceTemplates).toHaveBeenCalledWith(undefined, {
+      k: "v",
+    });
+  });
+
+  it("refresh argument overrides setMetadata", async () => {
+    client.setStatus("connected");
+    state.setMetadata({ k: "default" });
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.refresh({ k: "override" });
+    expect(client.listResourceTemplates).toHaveBeenCalledWith(undefined, {
+      k: "override",
+    });
+  });
+
+  it("connect event triggers a refresh", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("connect");
+    const next = await changePromise;
+    expect(next.map((t) => t.name)).toEqual(["a"]);
+  });
+
+  it("resourceTemplatesListChanged event triggers a refresh", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({
+      resourceTemplates: [template("a"), template("b")],
+    });
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("resourceTemplatesListChanged");
+    const next = await changePromise;
+    expect(next.map((t) => t.name)).toEqual(["a", "b"]);
+  });
+
+  it("statusChange to disconnected clears templates and dispatches change", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.refresh();
+    expect(state.getResourceTemplates()).toHaveLength(1);
+
+    const changePromise = waitForChange(state);
+    client.setStatus("disconnected");
+    const next = await changePromise;
+    expect(next).toEqual([]);
+    expect(state.getResourceTemplates()).toEqual([]);
+  });
+
+  it("statusChange to other values does not clear templates", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.refresh();
+    client.setStatus("error");
+    expect(state.getResourceTemplates().map((t) => t.name)).toEqual(["a"]);
+  });
+
+  it("throws when pagination exceeds 100 pages", async () => {
+    client.setStatus("connected");
+    client.listResourceTemplates.mockImplementation(async () => ({
+      resourceTemplates: [template("a")],
+      nextCursor: "always",
+    }));
+    await expect(state.refresh()).rejects.toThrow(/Maximum pagination limit/);
+  });
+
+  it("destroy unsubscribes from client events and clears state", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.refresh();
+    expect(state.getResourceTemplates()).toHaveLength(1);
+
+    state.destroy();
+    expect(state.getResourceTemplates()).toEqual([]);
+
+    client.queueResourceTemplatePages({ resourceTemplates: [template("b")] });
+    client.dispatchTypedEvent("resourceTemplatesListChanged");
+    await Promise.resolve();
+    expect(state.getResourceTemplates()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/managedResourcesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedResourcesState.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import { ManagedResourcesState } from "@inspector/core/mcp/state/managedResourcesState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function resource(uri: string): Resource {
+  return { uri, name: uri };
+}
+
+function waitForResourcesChange(
+  state: ManagedResourcesState,
+): Promise<Resource[]> {
+  return new Promise((resolve) => {
+    state.addEventListener("resourcesChange", (e) => resolve(e.detail), {
+      once: true,
+    });
+  });
+}
+
+describe("ManagedResourcesState", () => {
+  let client: FakeInspectorClient;
+  let state: ManagedResourcesState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new ManagedResourcesState(client);
+  });
+
+  it("starts with empty resources", () => {
+    expect(state.getResources()).toEqual([]);
+  });
+
+  it("getResources returns a defensive copy", () => {
+    const a = state.getResources();
+    const b = state.getResources();
+    expect(a).not.toBe(b);
+  });
+
+  it("refresh returns early and does not call listResources when disconnected", async () => {
+    const result = await state.refresh();
+    expect(result).toEqual([]);
+    expect(client.listResources).not.toHaveBeenCalled();
+  });
+
+  it("refresh fetches a single page and dispatches resourcesChange", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({
+      resources: [resource("a://1"), resource("a://2")],
+    });
+
+    const changePromise = waitForResourcesChange(state);
+    const result = await state.refresh();
+
+    expect(result.map((r) => r.uri)).toEqual(["a://1", "a://2"]);
+    expect(await changePromise).toEqual(result);
+    expect(state.getResources().map((r) => r.uri)).toEqual(["a://1", "a://2"]);
+  });
+
+  it("refresh accumulates across multiple paginated pages", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages(
+      { resources: [resource("a://1")], nextCursor: "c1" },
+      { resources: [resource("a://2")], nextCursor: "c2" },
+      { resources: [resource("a://3")] },
+    );
+
+    const result = await state.refresh();
+    expect(result.map((r) => r.uri)).toEqual(["a://1", "a://2", "a://3"]);
+    expect(client.listResources).toHaveBeenCalledTimes(3);
+  });
+
+  it("refresh passes setMetadata-supplied metadata to listResources", async () => {
+    client.setStatus("connected");
+    state.setMetadata({ k: "v" });
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.refresh();
+    expect(client.listResources).toHaveBeenCalledWith(undefined, { k: "v" });
+  });
+
+  it("refresh argument overrides setMetadata", async () => {
+    client.setStatus("connected");
+    state.setMetadata({ k: "default" });
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.refresh({ k: "override" });
+    expect(client.listResources).toHaveBeenCalledWith(undefined, {
+      k: "override",
+    });
+  });
+
+  it("connect event triggers a refresh", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    const changePromise = waitForResourcesChange(state);
+    client.dispatchTypedEvent("connect");
+    const next = await changePromise;
+    expect(next.map((r) => r.uri)).toEqual(["a://1"]);
+  });
+
+  it("resourcesListChanged event triggers a refresh", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({
+      resources: [resource("a://1"), resource("a://2")],
+    });
+    const changePromise = waitForResourcesChange(state);
+    client.dispatchTypedEvent("resourcesListChanged");
+    const next = await changePromise;
+    expect(next.map((r) => r.uri)).toEqual(["a://1", "a://2"]);
+  });
+
+  it("statusChange to disconnected clears resources and dispatches resourcesChange", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.refresh();
+    expect(state.getResources()).toHaveLength(1);
+
+    const changePromise = waitForResourcesChange(state);
+    client.setStatus("disconnected");
+    const next = await changePromise;
+    expect(next).toEqual([]);
+    expect(state.getResources()).toEqual([]);
+  });
+
+  it("statusChange to other (non-disconnected) values does not clear resources", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.refresh();
+    client.setStatus("error");
+    expect(state.getResources().map((r) => r.uri)).toEqual(["a://1"]);
+  });
+
+  it("throws when pagination exceeds 100 pages", async () => {
+    client.setStatus("connected");
+    client.listResources.mockImplementation(async () => ({
+      resources: [resource("a://1")],
+      nextCursor: "always",
+    }));
+    await expect(state.refresh()).rejects.toThrow(/Maximum pagination limit/);
+  });
+
+  it("destroy unsubscribes from client events and clears state", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.refresh();
+    expect(state.getResources()).toHaveLength(1);
+
+    state.destroy();
+    expect(state.getResources()).toEqual([]);
+
+    client.queueResourcePages({ resources: [resource("a://2")] });
+    client.dispatchTypedEvent("resourcesListChanged");
+    await Promise.resolve();
+    expect(state.getResources()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/managedToolsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedToolsState.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { ManagedToolsState } from "@inspector/core/mcp/state/managedToolsState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function tool(name: string): Tool {
+  return { name, inputSchema: { type: "object" } };
+}
+
+function waitForToolsChange(state: ManagedToolsState): Promise<Tool[]> {
+  return new Promise((resolve) => {
+    state.addEventListener("toolsChange", (e) => resolve(e.detail), {
+      once: true,
+    });
+  });
+}
+
+describe("ManagedToolsState", () => {
+  let client: FakeInspectorClient;
+  let state: ManagedToolsState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new ManagedToolsState(client);
+  });
+
+  it("starts with empty tools", () => {
+    expect(state.getTools()).toEqual([]);
+  });
+
+  it("getTools returns a defensive copy", () => {
+    const a = state.getTools();
+    const b = state.getTools();
+    expect(a).not.toBe(b);
+  });
+
+  it("refresh returns early and does not call listTools when disconnected", async () => {
+    const result = await state.refresh();
+    expect(result).toEqual([]);
+    expect(client.listTools).not.toHaveBeenCalled();
+  });
+
+  it("refresh fetches a single page and dispatches toolsChange", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a"), tool("b")] });
+
+    const changePromise = waitForToolsChange(state);
+    const result = await state.refresh();
+
+    expect(result.map((t) => t.name)).toEqual(["a", "b"]);
+    expect(await changePromise).toEqual(result);
+    expect(state.getTools().map((t) => t.name)).toEqual(["a", "b"]);
+  });
+
+  it("refresh accumulates across multiple paginated pages", async () => {
+    client.setStatus("connected");
+    client.queueToolPages(
+      { tools: [tool("a")], nextCursor: "c1" },
+      { tools: [tool("b")], nextCursor: "c2" },
+      { tools: [tool("c")] },
+    );
+
+    const result = await state.refresh();
+    expect(result.map((t) => t.name)).toEqual(["a", "b", "c"]);
+    expect(client.listTools).toHaveBeenCalledTimes(3);
+  });
+
+  it("refresh passes setMetadata-supplied metadata to listTools", async () => {
+    client.setStatus("connected");
+    state.setMetadata({ k: "v" });
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.refresh();
+    expect(client.listTools).toHaveBeenCalledWith(undefined, { k: "v" });
+  });
+
+  it("refresh argument overrides setMetadata", async () => {
+    client.setStatus("connected");
+    state.setMetadata({ k: "default" });
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.refresh({ k: "override" });
+    expect(client.listTools).toHaveBeenCalledWith(undefined, { k: "override" });
+  });
+
+  it("connect event triggers a refresh", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a")] });
+    const changePromise = waitForToolsChange(state);
+    client.dispatchTypedEvent("connect");
+    const next = await changePromise;
+    expect(next.map((t) => t.name)).toEqual(["a"]);
+  });
+
+  it("toolsListChanged event triggers a refresh", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a"), tool("b")] });
+    const changePromise = waitForToolsChange(state);
+    client.dispatchTypedEvent("toolsListChanged");
+    const next = await changePromise;
+    expect(next.map((t) => t.name)).toEqual(["a", "b"]);
+  });
+
+  it("statusChange to disconnected clears tools and dispatches toolsChange", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.refresh();
+    expect(state.getTools()).toHaveLength(1);
+
+    const changePromise = waitForToolsChange(state);
+    client.setStatus("disconnected");
+    const next = await changePromise;
+    expect(next).toEqual([]);
+    expect(state.getTools()).toEqual([]);
+  });
+
+  it("statusChange to other (non-disconnected) values does not clear tools", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.refresh();
+    client.setStatus("error");
+    expect(state.getTools().map((t) => t.name)).toEqual(["a"]);
+  });
+
+  it("throws when pagination exceeds 100 pages", async () => {
+    client.setStatus("connected");
+    // Always returns a non-terminal cursor; refresh should bail out at the cap.
+    client.listTools.mockImplementation(async () => ({
+      tools: [tool("a")],
+      nextCursor: "always",
+    }));
+    await expect(state.refresh()).rejects.toThrow(/Maximum pagination limit/);
+  });
+
+  it("destroy unsubscribes from client events and clears state", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.refresh();
+    expect(state.getTools()).toHaveLength(1);
+
+    state.destroy();
+    expect(state.getTools()).toEqual([]);
+
+    // No further refreshes after destroy(): events on client should be ignored.
+    client.queueToolPages({ tools: [tool("b")] });
+    client.dispatchTypedEvent("toolsListChanged");
+    // Give microtasks a chance to flush so a stray refresh would have landed.
+    await Promise.resolve();
+    expect(state.getTools()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/messageLogState.test.ts
+++ b/clients/web/src/test/core/mcp/state/messageLogState.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { MessageEntry } from "@inspector/core/mcp/types";
+import { MessageLogState } from "@inspector/core/mcp/state/messageLogState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function requestEntry(id: number, method = "tools/list"): MessageEntry {
+  return {
+    id: `req-${id}`,
+    timestamp: new Date(2026, 4, 13, 0, 0, 0, id),
+    direction: "request",
+    message: { jsonrpc: "2.0", id, method, params: {} },
+  };
+}
+
+function responseEntry(id: number): MessageEntry {
+  return {
+    id: `resp-${id}`,
+    timestamp: new Date(2026, 4, 13, 0, 0, 0, id + 100),
+    direction: "response",
+    message: { jsonrpc: "2.0", id, result: {} },
+  };
+}
+
+function notificationEntry(method = "notifications/ping"): MessageEntry {
+  return {
+    id: "notif-1",
+    timestamp: new Date(2026, 4, 13, 0, 0, 1),
+    direction: "notification",
+    message: { jsonrpc: "2.0", method, params: {} },
+  };
+}
+
+describe("MessageLogState", () => {
+  let client: FakeInspectorClient;
+  let state: MessageLogState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new MessageLogState(client);
+  });
+
+  it("starts empty and returns defensive copies", () => {
+    expect(state.getMessages()).toEqual([]);
+    expect(state.getMessages()).not.toBe(state.getMessages());
+  });
+
+  it("appends a request entry and dispatches message + messagesChange", () => {
+    const seenSingle: MessageEntry[] = [];
+    const seenFull: MessageEntry[][] = [];
+    state.addEventListener("message", (e) => seenSingle.push(e.detail));
+    state.addEventListener("messagesChange", (e) => seenFull.push(e.detail));
+
+    client.dispatchTypedEvent("message", requestEntry(1));
+    expect(seenSingle).toHaveLength(1);
+    expect(seenFull).toHaveLength(1);
+    expect(state.getMessages()).toHaveLength(1);
+  });
+
+  it("matches a response to its pending request and updates duration", () => {
+    client.dispatchTypedEvent("message", requestEntry(1));
+    const seen: MessageEntry[][] = [];
+    state.addEventListener("messagesChange", (e) => seen.push(e.detail));
+
+    client.dispatchTypedEvent("message", responseEntry(1));
+    const merged = state.getMessages();
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.response).toBeDefined();
+    expect(merged[0]!.duration).toBe(100);
+  });
+
+  it("appends an unmatched response when no pending request exists", () => {
+    client.dispatchTypedEvent("message", responseEntry(99));
+    expect(state.getMessages()).toHaveLength(1);
+    expect(state.getMessages()[0]!.direction).toBe("response");
+  });
+
+  it("appends notification entries", () => {
+    client.dispatchTypedEvent("message", notificationEntry());
+    expect(state.getMessages()).toHaveLength(1);
+    expect(state.getMessages()[0]!.direction).toBe("notification");
+  });
+
+  it("trims the oldest entries when maxMessages is exceeded", () => {
+    const small = new MessageLogState(client, { maxMessages: 2 });
+    client.dispatchTypedEvent("message", notificationEntry("a"));
+    client.dispatchTypedEvent("message", notificationEntry("b"));
+    client.dispatchTypedEvent("message", notificationEntry("c"));
+    const seen = small
+      .getMessages()
+      .map((m) => (m.message as { method?: string }).method);
+    expect(seen).toEqual(["b", "c"]);
+  });
+
+  it("does not trim when maxMessages is 0", () => {
+    const big = new MessageLogState(client, { maxMessages: 0 });
+    for (let i = 0; i < 5; i++) {
+      client.dispatchTypedEvent("message", notificationEntry(`m${i}`));
+    }
+    expect(big.getMessages()).toHaveLength(5);
+  });
+
+  it("clearMessages with no predicate empties the list and dispatches", () => {
+    client.dispatchTypedEvent("message", notificationEntry());
+    let changeCount = 0;
+    state.addEventListener("messagesChange", () => changeCount++);
+    state.clearMessages();
+    expect(state.getMessages()).toEqual([]);
+    expect(changeCount).toBe(1);
+  });
+
+  it("clearMessages with a predicate filters and dispatches only when changed", () => {
+    client.dispatchTypedEvent("message", notificationEntry("a"));
+    client.dispatchTypedEvent("message", notificationEntry("b"));
+    let changeCount = 0;
+    state.addEventListener("messagesChange", () => changeCount++);
+
+    state.clearMessages(
+      (m) => (m.message as { method?: string }).method === "a",
+    );
+    expect(state.getMessages()).toHaveLength(1);
+    expect(changeCount).toBe(1);
+
+    state.clearMessages(
+      (m) => (m.message as { method?: string }).method === "missing",
+    );
+    expect(changeCount).toBe(1);
+  });
+
+  it("getMessages applies the predicate filter", () => {
+    client.dispatchTypedEvent("message", notificationEntry("keep"));
+    client.dispatchTypedEvent("message", notificationEntry("drop"));
+    const keep = state.getMessages(
+      (m) => (m.message as { method?: string }).method === "keep",
+    );
+    expect(keep).toHaveLength(1);
+  });
+
+  it("clears on connect", () => {
+    client.dispatchTypedEvent("message", notificationEntry());
+    expect(state.getMessages()).toHaveLength(1);
+    let dispatched = false;
+    state.addEventListener("messagesChange", () => (dispatched = true));
+    client.dispatchTypedEvent("connect");
+    expect(state.getMessages()).toEqual([]);
+    expect(dispatched).toBe(true);
+  });
+
+  it("clears on disconnect (statusChange -> disconnected)", () => {
+    client.setStatus("connected");
+    client.dispatchTypedEvent("message", notificationEntry());
+    expect(state.getMessages()).toHaveLength(1);
+    let dispatched = false;
+    state.addEventListener("messagesChange", () => (dispatched = true));
+    client.setStatus("disconnected");
+    expect(state.getMessages()).toEqual([]);
+    expect(dispatched).toBe(true);
+  });
+
+  it("does not clear on non-disconnected status changes", () => {
+    client.dispatchTypedEvent("message", notificationEntry());
+    client.setStatus("error");
+    expect(state.getMessages()).toHaveLength(1);
+  });
+
+  it("destroy stops listening and clears state", () => {
+    client.dispatchTypedEvent("message", notificationEntry());
+    state.destroy();
+    expect(state.getMessages()).toEqual([]);
+    client.dispatchTypedEvent("message", notificationEntry());
+    expect(state.getMessages()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/messageLogState.test.ts
+++ b/clients/web/src/test/core/mcp/state/messageLogState.test.ts
@@ -126,6 +126,27 @@ describe("MessageLogState", () => {
     expect(changeCount).toBe(1);
   });
 
+  it("clearMessages drops pending-request bookkeeping for evicted requests", () => {
+    client.dispatchTypedEvent("message", requestEntry(1));
+    state.clearMessages((m) => m.direction === "request");
+    expect(state.getMessages()).toEqual([]);
+
+    // The matching response should now fall through to the unmatched-response
+    // branch (append) instead of mutating an unreachable pending entry.
+    client.dispatchTypedEvent("message", responseEntry(1));
+    expect(state.getMessages()).toHaveLength(1);
+    expect(state.getMessages()[0]!.direction).toBe("response");
+    expect(state.getMessages()[0]!.duration).toBeUndefined();
+  });
+
+  it("clearMessages without a predicate also drops all pending bookkeeping", () => {
+    client.dispatchTypedEvent("message", requestEntry(1));
+    state.clearMessages();
+    client.dispatchTypedEvent("message", responseEntry(1));
+    expect(state.getMessages()).toHaveLength(1);
+    expect(state.getMessages()[0]!.direction).toBe("response");
+  });
+
   it("getMessages applies the predicate filter", () => {
     client.dispatchTypedEvent("message", notificationEntry("keep"));
     client.dispatchTypedEvent("message", notificationEntry("drop"));

--- a/clients/web/src/test/core/mcp/state/pagedPromptsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/pagedPromptsState.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import { PagedPromptsState } from "@inspector/core/mcp/state/pagedPromptsState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function prompt(name: string): Prompt {
+  return { name };
+}
+
+function waitForChange(state: PagedPromptsState): Promise<Prompt[]> {
+  return new Promise((resolve) => {
+    state.addEventListener("promptsChange", (e) => resolve(e.detail), {
+      once: true,
+    });
+  });
+}
+
+describe("PagedPromptsState", () => {
+  let client: FakeInspectorClient;
+  let state: PagedPromptsState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new PagedPromptsState(client);
+  });
+
+  it("starts empty and returns defensive copies", () => {
+    expect(state.getPrompts()).toEqual([]);
+    expect(state.getPrompts()).not.toBe(state.getPrompts());
+  });
+
+  it("loadPage no-ops when disconnected", async () => {
+    const result = await state.loadPage();
+    expect(result).toEqual({ prompts: [], nextCursor: undefined });
+    expect(client.listPrompts).not.toHaveBeenCalled();
+  });
+
+  it("loadPage without cursor replaces the aggregated list", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a"), prompt("b")] });
+    const changePromise = waitForChange(state);
+    const result = await state.loadPage();
+    expect(result.prompts.map((p) => p.name)).toEqual(["a", "b"]);
+    expect(await changePromise).toEqual(result.prompts);
+  });
+
+  it("loadPage with cursor appends to the aggregated list", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages(
+      { prompts: [prompt("a")], nextCursor: "c1" },
+      { prompts: [prompt("b")] },
+    );
+    await state.loadPage();
+    await state.loadPage("c1");
+    expect(state.getPrompts().map((p) => p.name)).toEqual(["a", "b"]);
+  });
+
+  it("loadPage forwards metadata", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.loadPage(undefined, { k: "v" });
+    expect(client.listPrompts).toHaveBeenCalledWith(undefined, { k: "v" });
+  });
+
+  it("clear empties the aggregated list and dispatches", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.loadPage();
+    const changePromise = waitForChange(state);
+    state.clear();
+    expect(await changePromise).toEqual([]);
+    expect(state.getPrompts()).toEqual([]);
+  });
+
+  it("statusChange to disconnected clears prompts", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.loadPage();
+    const changePromise = waitForChange(state);
+    client.setStatus("disconnected");
+    expect(await changePromise).toEqual([]);
+  });
+
+  it("statusChange to non-disconnected values is a no-op", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.loadPage();
+    client.setStatus("error");
+    expect(state.getPrompts().map((p) => p.name)).toEqual(["a"]);
+  });
+
+  it("destroy stops listening and clears state", async () => {
+    client.setStatus("connected");
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.loadPage();
+    state.destroy();
+    expect(state.getPrompts()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/pagedRequestorTasksState.test.ts
+++ b/clients/web/src/test/core/mcp/state/pagedRequestorTasksState.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Task } from "@modelcontextprotocol/sdk/types.js";
+import { PagedRequestorTasksState } from "@inspector/core/mcp/state/pagedRequestorTasksState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function task(taskId: string, status: Task["status"] = "working"): Task {
+  return {
+    taskId,
+    status,
+    ttl: null,
+    createdAt: "2026-05-13T00:00:00Z",
+    lastUpdatedAt: "2026-05-13T00:00:00Z",
+  };
+}
+
+function waitForChange(state: PagedRequestorTasksState): Promise<Task[]> {
+  return new Promise((resolve) => {
+    state.addEventListener("tasksChange", (e) => resolve(e.detail), {
+      once: true,
+    });
+  });
+}
+
+describe("PagedRequestorTasksState", () => {
+  let client: FakeInspectorClient;
+  let state: PagedRequestorTasksState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new PagedRequestorTasksState(client);
+  });
+
+  it("starts empty and exposes nextCursor", () => {
+    expect(state.getTasks()).toEqual([]);
+    expect(state.getNextCursor()).toBeUndefined();
+  });
+
+  it("loadPage no-ops when disconnected", async () => {
+    const result = await state.loadPage();
+    expect(result).toEqual({ tasks: [], nextCursor: undefined });
+    expect(client.listRequestorTasks).not.toHaveBeenCalled();
+  });
+
+  it("loadPage without cursor replaces tasks and stores nextCursor", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1")], nextCursor: "c1" });
+    const changePromise = waitForChange(state);
+    const result = await state.loadPage();
+    expect(result.tasks.map((t) => t.taskId)).toEqual(["t1"]);
+    expect(result.nextCursor).toBe("c1");
+    expect(state.getNextCursor()).toBe("c1");
+    expect(await changePromise).toEqual(result.tasks);
+  });
+
+  it("loadPage with cursor appends tasks and updates nextCursor", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages(
+      { tasks: [task("t1")], nextCursor: "c1" },
+      { tasks: [task("t2")] },
+    );
+    await state.loadPage();
+    await state.loadPage("c1");
+    expect(state.getTasks().map((t) => t.taskId)).toEqual(["t1", "t2"]);
+    expect(state.getNextCursor()).toBeUndefined();
+  });
+
+  it("clear empties tasks, resets nextCursor, and dispatches", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1")], nextCursor: "c1" });
+    await state.loadPage();
+    const changePromise = waitForChange(state);
+    state.clear();
+    expect(await changePromise).toEqual([]);
+    expect(state.getTasks()).toEqual([]);
+    expect(state.getNextCursor()).toBeUndefined();
+  });
+
+  it("tasksListChanged refetches the first page", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1"), task("t2")] });
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("tasksListChanged");
+    const next = await changePromise;
+    expect(next.map((t) => t.taskId)).toEqual(["t1", "t2"]);
+  });
+
+  it("taskStatusChange merges a known task", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1", "working")] });
+    await state.loadPage();
+
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("taskStatusChange", {
+      taskId: "t1",
+      task: task("t1", "completed"),
+    });
+    const next = await changePromise;
+    expect(next[0]!.status).toBe("completed");
+  });
+
+  it("requestorTaskUpdated inserts an unknown task at the front", async () => {
+    client.setStatus("connected");
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("requestorTaskUpdated", {
+      taskId: "tx",
+      task: {
+        taskId: "tx",
+        status: "working",
+        ttl: null,
+        lastUpdatedAt: "2026-05-13T03:00:00Z",
+      },
+    });
+    const next = await changePromise;
+    expect(next.map((t) => t.taskId)).toEqual(["tx"]);
+    expect(next[0]!.createdAt).toBe("2026-05-13T03:00:00Z");
+  });
+
+  it("taskCancelled flips status when the task is known", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1", "working")] });
+    await state.loadPage();
+    const changePromise = waitForChange(state);
+    client.dispatchTypedEvent("taskCancelled", { taskId: "t1" });
+    const next = await changePromise;
+    expect(next[0]!.status).toBe("cancelled");
+  });
+
+  it("taskCancelled is a no-op when the task is unknown", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1")] });
+    await state.loadPage();
+    let dispatched = false;
+    state.addEventListener("tasksChange", () => {
+      dispatched = true;
+    });
+    client.dispatchTypedEvent("taskCancelled", { taskId: "missing" });
+    expect(dispatched).toBe(false);
+    expect(state.getTasks().map((t) => t.taskId)).toEqual(["t1"]);
+  });
+
+  it("statusChange to disconnected clears tasks and nextCursor", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1")], nextCursor: "c1" });
+    await state.loadPage();
+    const changePromise = waitForChange(state);
+    client.setStatus("disconnected");
+    expect(await changePromise).toEqual([]);
+    expect(state.getNextCursor()).toBeUndefined();
+  });
+
+  it("destroy stops listening and clears state", async () => {
+    client.setStatus("connected");
+    client.queueTaskPages({ tasks: [task("t1")] });
+    await state.loadPage();
+    state.destroy();
+    expect(state.getTasks()).toEqual([]);
+    expect(state.getNextCursor()).toBeUndefined();
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/pagedResourceTemplatesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/pagedResourceTemplatesState.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
+import { PagedResourceTemplatesState } from "@inspector/core/mcp/state/pagedResourceTemplatesState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function template(name: string): ResourceTemplate {
+  return { uriTemplate: `tpl://{${name}}`, name };
+}
+
+function waitForChange(
+  state: PagedResourceTemplatesState,
+): Promise<ResourceTemplate[]> {
+  return new Promise((resolve) => {
+    state.addEventListener(
+      "resourceTemplatesChange",
+      (e) => resolve(e.detail),
+      { once: true },
+    );
+  });
+}
+
+describe("PagedResourceTemplatesState", () => {
+  let client: FakeInspectorClient;
+  let state: PagedResourceTemplatesState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new PagedResourceTemplatesState(client);
+  });
+
+  it("starts empty and returns defensive copies", () => {
+    expect(state.getResourceTemplates()).toEqual([]);
+    expect(state.getResourceTemplates()).not.toBe(state.getResourceTemplates());
+  });
+
+  it("loadPage no-ops when disconnected", async () => {
+    const result = await state.loadPage();
+    expect(result).toEqual({ resourceTemplates: [], nextCursor: undefined });
+    expect(client.listResourceTemplates).not.toHaveBeenCalled();
+  });
+
+  it("loadPage without cursor replaces the aggregated list", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({
+      resourceTemplates: [template("a"), template("b")],
+    });
+    const changePromise = waitForChange(state);
+    const result = await state.loadPage();
+    expect(result.resourceTemplates.map((t) => t.name)).toEqual(["a", "b"]);
+    expect(await changePromise).toEqual(result.resourceTemplates);
+  });
+
+  it("loadPage with cursor appends to the aggregated list", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages(
+      { resourceTemplates: [template("a")], nextCursor: "c1" },
+      { resourceTemplates: [template("b")] },
+    );
+    await state.loadPage();
+    await state.loadPage("c1");
+    expect(state.getResourceTemplates().map((t) => t.name)).toEqual(["a", "b"]);
+  });
+
+  it("loadPage forwards metadata", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.loadPage(undefined, { k: "v" });
+    expect(client.listResourceTemplates).toHaveBeenCalledWith(undefined, {
+      k: "v",
+    });
+  });
+
+  it("clear empties the aggregated list and dispatches", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.loadPage();
+    const changePromise = waitForChange(state);
+    state.clear();
+    expect(await changePromise).toEqual([]);
+    expect(state.getResourceTemplates()).toEqual([]);
+  });
+
+  it("statusChange to disconnected clears templates", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.loadPage();
+    const changePromise = waitForChange(state);
+    client.setStatus("disconnected");
+    expect(await changePromise).toEqual([]);
+  });
+
+  it("statusChange to non-disconnected values is a no-op", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.loadPage();
+    client.setStatus("error");
+    expect(state.getResourceTemplates().map((t) => t.name)).toEqual(["a"]);
+  });
+
+  it("destroy stops listening and clears state", async () => {
+    client.setStatus("connected");
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.loadPage();
+    state.destroy();
+    expect(state.getResourceTemplates()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/pagedResourcesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/pagedResourcesState.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import { PagedResourcesState } from "@inspector/core/mcp/state/pagedResourcesState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function resource(uri: string): Resource {
+  return { uri, name: uri };
+}
+
+function waitForChange(state: PagedResourcesState): Promise<Resource[]> {
+  return new Promise((resolve) => {
+    state.addEventListener("resourcesChange", (e) => resolve(e.detail), {
+      once: true,
+    });
+  });
+}
+
+describe("PagedResourcesState", () => {
+  let client: FakeInspectorClient;
+  let state: PagedResourcesState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new PagedResourcesState(client);
+  });
+
+  it("starts empty and returns defensive copies", () => {
+    expect(state.getResources()).toEqual([]);
+    expect(state.getResources()).not.toBe(state.getResources());
+  });
+
+  it("loadPage no-ops when disconnected", async () => {
+    const result = await state.loadPage();
+    expect(result).toEqual({ resources: [], nextCursor: undefined });
+    expect(client.listResources).not.toHaveBeenCalled();
+  });
+
+  it("loadPage without cursor replaces the aggregated list", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({
+      resources: [resource("a://1"), resource("a://2")],
+    });
+    const changePromise = waitForChange(state);
+    const result = await state.loadPage();
+    expect(result.resources.map((r) => r.uri)).toEqual(["a://1", "a://2"]);
+    expect(await changePromise).toEqual(result.resources);
+  });
+
+  it("loadPage with cursor appends to the aggregated list", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages(
+      { resources: [resource("a://1")], nextCursor: "c1" },
+      { resources: [resource("a://2")] },
+    );
+    await state.loadPage();
+    await state.loadPage("c1");
+    expect(state.getResources().map((r) => r.uri)).toEqual(["a://1", "a://2"]);
+  });
+
+  it("loadPage forwards metadata", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.loadPage(undefined, { k: "v" });
+    expect(client.listResources).toHaveBeenCalledWith(undefined, { k: "v" });
+  });
+
+  it("clear empties the aggregated list and dispatches", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.loadPage();
+    const changePromise = waitForChange(state);
+    state.clear();
+    expect(await changePromise).toEqual([]);
+    expect(state.getResources()).toEqual([]);
+  });
+
+  it("statusChange to disconnected clears resources", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.loadPage();
+    const changePromise = waitForChange(state);
+    client.setStatus("disconnected");
+    expect(await changePromise).toEqual([]);
+  });
+
+  it("statusChange to non-disconnected values is a no-op", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.loadPage();
+    client.setStatus("error");
+    expect(state.getResources().map((r) => r.uri)).toEqual(["a://1"]);
+  });
+
+  it("destroy stops listening and clears state", async () => {
+    client.setStatus("connected");
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.loadPage();
+    state.destroy();
+    expect(state.getResources()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/pagedToolsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/pagedToolsState.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { PagedToolsState } from "@inspector/core/mcp/state/pagedToolsState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function tool(name: string): Tool {
+  return { name, inputSchema: { type: "object" } };
+}
+
+function waitForChange(state: PagedToolsState): Promise<Tool[]> {
+  return new Promise((resolve) => {
+    state.addEventListener("toolsChange", (e) => resolve(e.detail), {
+      once: true,
+    });
+  });
+}
+
+describe("PagedToolsState", () => {
+  let client: FakeInspectorClient;
+  let state: PagedToolsState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new PagedToolsState(client);
+  });
+
+  it("starts empty and returns defensive copies", () => {
+    expect(state.getTools()).toEqual([]);
+    expect(state.getTools()).not.toBe(state.getTools());
+  });
+
+  it("loadPage no-ops when disconnected", async () => {
+    const result = await state.loadPage();
+    expect(result).toEqual({ tools: [], nextCursor: undefined });
+    expect(client.listTools).not.toHaveBeenCalled();
+  });
+
+  it("loadPage without cursor replaces the aggregated list", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a"), tool("b")] });
+    const changePromise = waitForChange(state);
+    const result = await state.loadPage();
+    expect(result.tools.map((t) => t.name)).toEqual(["a", "b"]);
+    expect(await changePromise).toEqual(result.tools);
+  });
+
+  it("loadPage with cursor appends to the aggregated list", async () => {
+    client.setStatus("connected");
+    client.queueToolPages(
+      { tools: [tool("a")], nextCursor: "c1" },
+      { tools: [tool("b")] },
+    );
+    const first = await state.loadPage();
+    expect(first.nextCursor).toBe("c1");
+    const second = await state.loadPage("c1");
+    expect(second.nextCursor).toBeUndefined();
+    expect(state.getTools().map((t) => t.name)).toEqual(["a", "b"]);
+  });
+
+  it("clear empties the aggregated list and dispatches", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.loadPage();
+    const changePromise = waitForChange(state);
+    state.clear();
+    expect(await changePromise).toEqual([]);
+    expect(state.getTools()).toEqual([]);
+  });
+
+  it("statusChange to disconnected clears tools", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.loadPage();
+    const changePromise = waitForChange(state);
+    client.setStatus("disconnected");
+    expect(await changePromise).toEqual([]);
+    expect(state.getTools()).toEqual([]);
+  });
+
+  it("statusChange to non-disconnected values is a no-op", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.loadPage();
+    client.setStatus("error");
+    expect(state.getTools().map((t) => t.name)).toEqual(["a"]);
+  });
+
+  it("does not subscribe to toolsListChanged (paged is caller-driven)", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a")] });
+    client.dispatchTypedEvent("toolsListChanged");
+    await Promise.resolve();
+    expect(state.getTools()).toEqual([]);
+    expect(client.listTools).not.toHaveBeenCalled();
+  });
+
+  it("destroy stops listening and clears state", async () => {
+    client.setStatus("connected");
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.loadPage();
+    state.destroy();
+    expect(state.getTools()).toEqual([]);
+
+    client.setStatus("disconnected");
+    await Promise.resolve();
+    expect(state.getTools()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/mcp/state/stderrLogState.test.ts
+++ b/clients/web/src/test/core/mcp/state/stderrLogState.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { StderrLogEntry } from "@inspector/core/mcp/types";
+import { StderrLogState } from "@inspector/core/mcp/state/stderrLogState";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+
+function entry(message: string): StderrLogEntry {
+  return { message, timestamp: new Date(2026, 4, 13) };
+}
+
+describe("StderrLogState", () => {
+  let client: FakeInspectorClient;
+  let state: StderrLogState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new StderrLogState(client);
+  });
+
+  it("starts empty and returns defensive copies", () => {
+    expect(state.getStderrLogs()).toEqual([]);
+    expect(state.getStderrLogs()).not.toBe(state.getStderrLogs());
+  });
+
+  it("appends entries and dispatches stderrLog + stderrLogsChange", () => {
+    const seenSingle: StderrLogEntry[] = [];
+    const seenFull: StderrLogEntry[][] = [];
+    state.addEventListener("stderrLog", (e) => seenSingle.push(e.detail));
+    state.addEventListener("stderrLogsChange", (e) => seenFull.push(e.detail));
+
+    client.dispatchTypedEvent("stderrLog", entry("a"));
+    client.dispatchTypedEvent("stderrLog", entry("b"));
+
+    expect(state.getStderrLogs().map((e) => e.message)).toEqual(["a", "b"]);
+    expect(seenSingle).toHaveLength(2);
+    expect(seenFull).toHaveLength(2);
+  });
+
+  it("trims the oldest entries when maxStderrLogEvents is exceeded", () => {
+    const small = new StderrLogState(client, { maxStderrLogEvents: 2 });
+    client.dispatchTypedEvent("stderrLog", entry("a"));
+    client.dispatchTypedEvent("stderrLog", entry("b"));
+    client.dispatchTypedEvent("stderrLog", entry("c"));
+    expect(small.getStderrLogs().map((e) => e.message)).toEqual(["b", "c"]);
+  });
+
+  it("does not trim when maxStderrLogEvents is 0", () => {
+    const big = new StderrLogState(client, { maxStderrLogEvents: 0 });
+    for (let i = 0; i < 5; i++) {
+      client.dispatchTypedEvent("stderrLog", entry(`m${i}`));
+    }
+    expect(big.getStderrLogs()).toHaveLength(5);
+  });
+
+  it("clearStderrLogs dispatches when the list was non-empty", () => {
+    client.dispatchTypedEvent("stderrLog", entry("a"));
+    let dispatched = false;
+    state.addEventListener("stderrLogsChange", () => (dispatched = true));
+    state.clearStderrLogs();
+    expect(dispatched).toBe(true);
+    expect(state.getStderrLogs()).toEqual([]);
+  });
+
+  it("clearStderrLogs is a no-op when the list is empty", () => {
+    let dispatched = false;
+    state.addEventListener("stderrLogsChange", () => (dispatched = true));
+    state.clearStderrLogs();
+    expect(dispatched).toBe(false);
+  });
+
+  it("does NOT clear on connect or disconnect", () => {
+    client.dispatchTypedEvent("stderrLog", entry("a"));
+    client.dispatchTypedEvent("connect");
+    expect(state.getStderrLogs().map((e) => e.message)).toEqual(["a"]);
+    client.setStatus("disconnected");
+    expect(state.getStderrLogs().map((e) => e.message)).toEqual(["a"]);
+  });
+
+  it("destroy stops listening and clears state", () => {
+    client.dispatchTypedEvent("stderrLog", entry("a"));
+    state.destroy();
+    expect(state.getStderrLogs()).toEqual([]);
+    client.dispatchTypedEvent("stderrLog", entry("b"));
+    expect(state.getStderrLogs()).toEqual([]);
+  });
+
+  it("destroy is idempotent", () => {
+    state.destroy();
+    expect(() => state.destroy()).not.toThrow();
+  });
+});

--- a/clients/web/src/test/core/react/useFetchRequestLog.test.tsx
+++ b/clients/web/src/test/core/react/useFetchRequestLog.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { FetchRequestEntry } from "@inspector/core/mcp/types";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { FetchRequestLogState } from "@inspector/core/mcp/state/fetchRequestLogState";
+import { useFetchRequestLog } from "@inspector/core/react/useFetchRequestLog";
+
+function entry(id: string): FetchRequestEntry {
+  return {
+    id,
+    timestamp: new Date(2026, 4, 13),
+    method: "GET",
+    url: `https://x/${id}`,
+    requestHeaders: {},
+    category: "transport",
+  };
+}
+
+describe("useFetchRequestLog", () => {
+  let client: FakeInspectorClient;
+  let state: FetchRequestLogState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new FetchRequestLogState(client);
+  });
+
+  it("returns the initial snapshot from the state", () => {
+    client.dispatchTypedEvent("fetchRequest", entry("a"));
+    const { result } = renderHook(() => useFetchRequestLog(state));
+    expect(result.current.fetchRequests.map((e) => e.id)).toEqual(["a"]);
+  });
+
+  it("returns empty when state is null", () => {
+    const { result } = renderHook(() => useFetchRequestLog(null));
+    expect(result.current.fetchRequests).toEqual([]);
+  });
+
+  it("updates when state dispatches fetchRequestsChange", async () => {
+    const { result } = renderHook(() => useFetchRequestLog(state));
+    act(() => {
+      client.dispatchTypedEvent("fetchRequest", entry("a"));
+    });
+    await waitFor(() => {
+      expect(result.current.fetchRequests).toHaveLength(1);
+    });
+  });
+
+  it("resets to empty when the state prop becomes null", async () => {
+    client.dispatchTypedEvent("fetchRequest", entry("a"));
+    const { result, rerender } = renderHook(
+      ({ s }: { s: FetchRequestLogState | null }) => useFetchRequestLog(s),
+      { initialProps: { s: state as FetchRequestLogState | null } },
+    );
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.fetchRequests).toEqual([]);
+    });
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { result, unmount } = renderHook(() => useFetchRequestLog(state));
+    unmount();
+    client.dispatchTypedEvent("fetchRequest", entry("a"));
+    expect(result.current.fetchRequests).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/useInspectorClient.test.tsx
+++ b/clients/web/src/test/core/react/useInspectorClient.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type {
+  Implementation,
+  ServerCapabilities,
+} from "@modelcontextprotocol/sdk/types.js";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { useInspectorClient } from "@inspector/core/react/useInspectorClient";
+import type { InspectorClientProtocol } from "@inspector/core/mcp/inspectorClientProtocol";
+
+const CAPABILITIES: ServerCapabilities = { tools: { listChanged: true } };
+const SERVER_INFO: Implementation = { name: "srv", version: "1.0" };
+
+describe("useInspectorClient", () => {
+  it("returns initial accessors from the client", () => {
+    const client = new FakeInspectorClient({
+      status: "connected",
+      capabilities: CAPABILITIES,
+      serverInfo: SERVER_INFO,
+      instructions: "hello",
+    });
+    const { result } = renderHook(() => useInspectorClient(client));
+    expect(result.current.status).toBe("connected");
+    expect(result.current.capabilities).toEqual(CAPABILITIES);
+    expect(result.current.serverInfo).toEqual(SERVER_INFO);
+    expect(result.current.instructions).toBe("hello");
+    expect(result.current.appRendererClient).toBeNull();
+  });
+
+  it("returns disconnected defaults when client is null", () => {
+    const { result } = renderHook(() => useInspectorClient(null));
+    expect(result.current.status).toBe("disconnected");
+    expect(result.current.capabilities).toBeUndefined();
+    expect(result.current.serverInfo).toBeUndefined();
+    expect(result.current.instructions).toBeUndefined();
+    expect(result.current.appRendererClient).toBeNull();
+  });
+
+  it("subscribes to statusChange and updates", () => {
+    const client = new FakeInspectorClient();
+    const { result } = renderHook(() => useInspectorClient(client));
+    expect(result.current.status).toBe("disconnected");
+    act(() => {
+      client.setStatus("connecting");
+    });
+    expect(result.current.status).toBe("connecting");
+    act(() => {
+      client.setStatus("connected");
+    });
+    expect(result.current.status).toBe("connected");
+  });
+
+  it("subscribes to capabilities/serverInfo/instructions changes", () => {
+    const client = new FakeInspectorClient();
+    const { result } = renderHook(() => useInspectorClient(client));
+    act(() => {
+      client.setCapabilities(CAPABILITIES);
+      client.setServerInfo(SERVER_INFO);
+      client.setInstructions("after");
+    });
+    expect(result.current.capabilities).toEqual(CAPABILITIES);
+    expect(result.current.serverInfo).toEqual(SERVER_INFO);
+    expect(result.current.instructions).toBe("after");
+  });
+
+  it("connect() and disconnect() proxy to the client and update status", async () => {
+    const client = new FakeInspectorClient();
+    const { result } = renderHook(() => useInspectorClient(client));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    expect(result.current.status).toBe("connected");
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.status).toBe("disconnected");
+  });
+
+  it("connect() and disconnect() are no-ops when client is null", async () => {
+    const { result } = renderHook(() => useInspectorClient(null));
+    await expect(result.current.connect()).resolves.toBeUndefined();
+    await expect(result.current.disconnect()).resolves.toBeUndefined();
+  });
+
+  it("resets to defaults when client becomes null", () => {
+    const client = new FakeInspectorClient({
+      status: "connected",
+      capabilities: CAPABILITIES,
+    });
+    const { result, rerender } = renderHook(
+      ({ c }: { c: InspectorClientProtocol | null }) => useInspectorClient(c),
+      { initialProps: { c: client as InspectorClientProtocol | null } },
+    );
+    expect(result.current.status).toBe("connected");
+    rerender({ c: null });
+    expect(result.current.status).toBe("disconnected");
+    expect(result.current.capabilities).toBeUndefined();
+  });
+
+  it("re-subscribes when the client prop changes", () => {
+    const a = new FakeInspectorClient({ status: "connected" });
+    const b = new FakeInspectorClient({ status: "disconnected" });
+    const { result, rerender } = renderHook(
+      ({ c }: { c: InspectorClientProtocol }) => useInspectorClient(c),
+      { initialProps: { c: a as InspectorClientProtocol } },
+    );
+    expect(result.current.status).toBe("connected");
+
+    rerender({ c: b });
+    expect(result.current.status).toBe("disconnected");
+
+    // After rerender, events on the OLD client should be ignored.
+    act(() => {
+      a.setStatus("error");
+    });
+    expect(result.current.status).toBe("disconnected");
+
+    // Events on the NEW client should be observed.
+    act(() => {
+      b.setStatus("connecting");
+    });
+    expect(result.current.status).toBe("connecting");
+  });
+
+  it("unsubscribes on unmount", () => {
+    const client = new FakeInspectorClient({ status: "connected" });
+    const { result, unmount } = renderHook(() => useInspectorClient(client));
+    unmount();
+    act(() => {
+      client.setStatus("error");
+    });
+    // The hook is unmounted; result.current still reads the last rendered
+    // value ("connected") rather than the post-unmount event.
+    expect(result.current.status).toBe("connected");
+  });
+
+  it("reads appRendererClient lazily from the client on each render", () => {
+    const client = new FakeInspectorClient({ status: "connected" });
+    const { result, rerender } = renderHook(() => useInspectorClient(client));
+    expect(result.current.appRendererClient).toBeNull();
+
+    const sentinel = { iam: "renderer" };
+    client.setAppRendererClient(sentinel);
+    rerender();
+    expect(result.current.appRendererClient).toBe(sentinel);
+  });
+});

--- a/clients/web/src/test/core/react/useManagedPrompts.test.tsx
+++ b/clients/web/src/test/core/react/useManagedPrompts.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { ManagedPromptsState } from "@inspector/core/mcp/state/managedPromptsState";
+import { useManagedPrompts } from "@inspector/core/react/useManagedPrompts";
+
+function prompt(name: string): Prompt {
+  return { name };
+}
+
+describe("useManagedPrompts", () => {
+  let client: FakeInspectorClient;
+  let state: ManagedPromptsState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient({ status: "connected" });
+    state = new ManagedPromptsState(client);
+  });
+
+  it("returns the initial prompts snapshot from the state", async () => {
+    client.queuePromptPages({ prompts: [prompt("a"), prompt("b")] });
+    await state.refresh();
+
+    const { result } = renderHook(() => useManagedPrompts(client, state));
+    expect(result.current.prompts.map((p) => p.name)).toEqual(["a", "b"]);
+  });
+
+  it("returns empty prompts when state is null", () => {
+    const { result } = renderHook(() => useManagedPrompts(client, null));
+    expect(result.current.prompts).toEqual([]);
+  });
+
+  it("updates when state dispatches promptsChange", async () => {
+    const { result } = renderHook(() => useManagedPrompts(client, state));
+    expect(result.current.prompts).toEqual([]);
+
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await act(async () => {
+      await state.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.prompts.map((p) => p.name)).toEqual(["a"]);
+    });
+  });
+
+  it("refresh() calls through to state and returns the next prompts", async () => {
+    client.queuePromptPages({ prompts: [prompt("x")] });
+    const { result } = renderHook(() => useManagedPrompts(client, state));
+
+    let next: Prompt[] = [];
+    await act(async () => {
+      next = await result.current.refresh();
+    });
+
+    expect(next.map((p) => p.name)).toEqual(["x"]);
+    expect(result.current.prompts.map((p) => p.name)).toEqual(["x"]);
+  });
+
+  it("refresh() returns [] when state or client is null", async () => {
+    const { result } = renderHook(() => useManagedPrompts(null, state));
+    await expect(result.current.refresh()).resolves.toEqual([]);
+
+    const { result: result2 } = renderHook(() =>
+      useManagedPrompts(client, null),
+    );
+    await expect(result2.current.refresh()).resolves.toEqual([]);
+  });
+
+  it("resets to empty prompts when the state prop becomes null", async () => {
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.refresh();
+
+    const { result, rerender } = renderHook(
+      ({ s }: { s: ManagedPromptsState | null }) =>
+        useManagedPrompts(client, s),
+      { initialProps: { s: state as ManagedPromptsState | null } },
+    );
+    await waitFor(() => {
+      expect(result.current.prompts.map((p) => p.name)).toEqual(["a"]);
+    });
+
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.prompts).toEqual([]);
+    });
+  });
+
+  it("unsubscribes from the state on unmount", async () => {
+    const { result, unmount } = renderHook(() =>
+      useManagedPrompts(client, state),
+    );
+
+    unmount();
+
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.refresh();
+
+    expect(result.current.prompts).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/useManagedRequestorTasks.test.tsx
+++ b/clients/web/src/test/core/react/useManagedRequestorTasks.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Task } from "@modelcontextprotocol/sdk/types.js";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { ManagedRequestorTasksState } from "@inspector/core/mcp/state/managedRequestorTasksState";
+import { useManagedRequestorTasks } from "@inspector/core/react/useManagedRequestorTasks";
+
+function task(taskId: string, status: Task["status"] = "working"): Task {
+  return {
+    taskId,
+    status,
+    ttl: null,
+    createdAt: "2026-05-13T00:00:00Z",
+    lastUpdatedAt: "2026-05-13T00:00:00Z",
+  };
+}
+
+describe("useManagedRequestorTasks", () => {
+  let client: FakeInspectorClient;
+  let state: ManagedRequestorTasksState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient({ status: "connected" });
+    state = new ManagedRequestorTasksState(client);
+  });
+
+  it("returns the initial tasks snapshot from the state", async () => {
+    client.queueTaskPages({ tasks: [task("t1"), task("t2")] });
+    await state.refresh();
+
+    const { result } = renderHook(() =>
+      useManagedRequestorTasks(client, state),
+    );
+    expect(result.current.tasks.map((t) => t.taskId)).toEqual(["t1", "t2"]);
+  });
+
+  it("returns empty tasks when state is null", () => {
+    const { result } = renderHook(() => useManagedRequestorTasks(client, null));
+    expect(result.current.tasks).toEqual([]);
+  });
+
+  it("updates when state dispatches tasksChange", async () => {
+    const { result } = renderHook(() =>
+      useManagedRequestorTasks(client, state),
+    );
+    expect(result.current.tasks).toEqual([]);
+
+    client.queueTaskPages({ tasks: [task("t1")] });
+    await act(async () => {
+      await state.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.tasks.map((t) => t.taskId)).toEqual(["t1"]);
+    });
+  });
+
+  it("refresh() calls through to state and returns the next tasks", async () => {
+    client.queueTaskPages({ tasks: [task("tx")] });
+    const { result } = renderHook(() =>
+      useManagedRequestorTasks(client, state),
+    );
+
+    let next: Task[] = [];
+    await act(async () => {
+      next = await result.current.refresh();
+    });
+
+    expect(next.map((t) => t.taskId)).toEqual(["tx"]);
+    expect(result.current.tasks.map((t) => t.taskId)).toEqual(["tx"]);
+  });
+
+  it("refresh() returns [] when state or client is null", async () => {
+    const { result } = renderHook(() => useManagedRequestorTasks(null, state));
+    await expect(result.current.refresh()).resolves.toEqual([]);
+
+    const { result: result2 } = renderHook(() =>
+      useManagedRequestorTasks(client, null),
+    );
+    await expect(result2.current.refresh()).resolves.toEqual([]);
+  });
+
+  it("resets to empty tasks when the state prop becomes null", async () => {
+    client.queueTaskPages({ tasks: [task("t1")] });
+    await state.refresh();
+
+    const { result, rerender } = renderHook(
+      ({ s }: { s: ManagedRequestorTasksState | null }) =>
+        useManagedRequestorTasks(client, s),
+      { initialProps: { s: state as ManagedRequestorTasksState | null } },
+    );
+    await waitFor(() => {
+      expect(result.current.tasks.map((t) => t.taskId)).toEqual(["t1"]);
+    });
+
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.tasks).toEqual([]);
+    });
+  });
+
+  it("unsubscribes from the state on unmount", async () => {
+    const { result, unmount } = renderHook(() =>
+      useManagedRequestorTasks(client, state),
+    );
+
+    unmount();
+
+    client.queueTaskPages({ tasks: [task("t1")] });
+    await state.refresh();
+
+    expect(result.current.tasks).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/useManagedResourceTemplates.test.tsx
+++ b/clients/web/src/test/core/react/useManagedResourceTemplates.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { ManagedResourceTemplatesState } from "@inspector/core/mcp/state/managedResourceTemplatesState";
+import { useManagedResourceTemplates } from "@inspector/core/react/useManagedResourceTemplates";
+
+function template(name: string): ResourceTemplate {
+  return { uriTemplate: `tpl://{${name}}`, name };
+}
+
+describe("useManagedResourceTemplates", () => {
+  let client: FakeInspectorClient;
+  let state: ManagedResourceTemplatesState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient({ status: "connected" });
+    state = new ManagedResourceTemplatesState(client);
+  });
+
+  it("returns the initial templates snapshot from the state", async () => {
+    client.queueResourceTemplatePages({
+      resourceTemplates: [template("a"), template("b")],
+    });
+    await state.refresh();
+
+    const { result } = renderHook(() =>
+      useManagedResourceTemplates(client, state),
+    );
+    expect(result.current.resourceTemplates.map((t) => t.name)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("returns empty templates when state is null", () => {
+    const { result } = renderHook(() =>
+      useManagedResourceTemplates(client, null),
+    );
+    expect(result.current.resourceTemplates).toEqual([]);
+  });
+
+  it("updates when state dispatches resourceTemplatesChange", async () => {
+    const { result } = renderHook(() =>
+      useManagedResourceTemplates(client, state),
+    );
+    expect(result.current.resourceTemplates).toEqual([]);
+
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await act(async () => {
+      await state.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.resourceTemplates.map((t) => t.name)).toEqual([
+        "a",
+      ]);
+    });
+  });
+
+  it("refresh() calls through to state and returns the next templates", async () => {
+    client.queueResourceTemplatePages({ resourceTemplates: [template("x")] });
+    const { result } = renderHook(() =>
+      useManagedResourceTemplates(client, state),
+    );
+
+    let next: ResourceTemplate[] = [];
+    await act(async () => {
+      next = await result.current.refresh();
+    });
+
+    expect(next.map((t) => t.name)).toEqual(["x"]);
+    expect(result.current.resourceTemplates.map((t) => t.name)).toEqual(["x"]);
+  });
+
+  it("refresh() returns [] when state or client is null", async () => {
+    const { result } = renderHook(() =>
+      useManagedResourceTemplates(null, state),
+    );
+    await expect(result.current.refresh()).resolves.toEqual([]);
+
+    const { result: result2 } = renderHook(() =>
+      useManagedResourceTemplates(client, null),
+    );
+    await expect(result2.current.refresh()).resolves.toEqual([]);
+  });
+
+  it("resets to empty when state becomes null", async () => {
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.refresh();
+
+    const { result, rerender } = renderHook(
+      ({ s }: { s: ManagedResourceTemplatesState | null }) =>
+        useManagedResourceTemplates(client, s),
+      { initialProps: { s: state as ManagedResourceTemplatesState | null } },
+    );
+    await waitFor(() => {
+      expect(result.current.resourceTemplates.map((t) => t.name)).toEqual([
+        "a",
+      ]);
+    });
+
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.resourceTemplates).toEqual([]);
+    });
+  });
+
+  it("unsubscribes from the state on unmount", async () => {
+    const { result, unmount } = renderHook(() =>
+      useManagedResourceTemplates(client, state),
+    );
+
+    unmount();
+
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.refresh();
+
+    expect(result.current.resourceTemplates).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/useManagedResources.test.tsx
+++ b/clients/web/src/test/core/react/useManagedResources.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { ManagedResourcesState } from "@inspector/core/mcp/state/managedResourcesState";
+import { useManagedResources } from "@inspector/core/react/useManagedResources";
+
+function resource(uri: string): Resource {
+  return { uri, name: uri };
+}
+
+describe("useManagedResources", () => {
+  let client: FakeInspectorClient;
+  let state: ManagedResourcesState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient({ status: "connected" });
+    state = new ManagedResourcesState(client);
+  });
+
+  it("returns the initial resources snapshot from the state", async () => {
+    client.queueResourcePages({
+      resources: [resource("a://1"), resource("a://2")],
+    });
+    await state.refresh();
+
+    const { result } = renderHook(() => useManagedResources(client, state));
+    expect(result.current.resources.map((r) => r.uri)).toEqual([
+      "a://1",
+      "a://2",
+    ]);
+  });
+
+  it("returns empty resources when state is null", () => {
+    const { result } = renderHook(() => useManagedResources(client, null));
+    expect(result.current.resources).toEqual([]);
+  });
+
+  it("updates when state dispatches resourcesChange", async () => {
+    const { result } = renderHook(() => useManagedResources(client, state));
+    expect(result.current.resources).toEqual([]);
+
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await act(async () => {
+      await state.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.resources.map((r) => r.uri)).toEqual(["a://1"]);
+    });
+  });
+
+  it("refresh() calls through to state and returns the next resources", async () => {
+    client.queueResourcePages({ resources: [resource("x://1")] });
+    const { result } = renderHook(() => useManagedResources(client, state));
+
+    let next: Resource[] = [];
+    await act(async () => {
+      next = await result.current.refresh();
+    });
+
+    expect(next.map((r) => r.uri)).toEqual(["x://1"]);
+    expect(result.current.resources.map((r) => r.uri)).toEqual(["x://1"]);
+  });
+
+  it("refresh() returns [] when state or client is null", async () => {
+    const { result } = renderHook(() => useManagedResources(null, state));
+    await expect(result.current.refresh()).resolves.toEqual([]);
+
+    const { result: result2 } = renderHook(() =>
+      useManagedResources(client, null),
+    );
+    await expect(result2.current.refresh()).resolves.toEqual([]);
+  });
+
+  it("resets to empty resources when the state prop becomes null", async () => {
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.refresh();
+
+    const { result, rerender } = renderHook(
+      ({ s }: { s: ManagedResourcesState | null }) =>
+        useManagedResources(client, s),
+      { initialProps: { s: state as ManagedResourcesState | null } },
+    );
+    await waitFor(() => {
+      expect(result.current.resources.map((r) => r.uri)).toEqual(["a://1"]);
+    });
+
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.resources).toEqual([]);
+    });
+  });
+
+  it("unsubscribes from the state on unmount", async () => {
+    const { result, unmount } = renderHook(() =>
+      useManagedResources(client, state),
+    );
+
+    unmount();
+
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.refresh();
+
+    expect(result.current.resources).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/useManagedTools.test.tsx
+++ b/clients/web/src/test/core/react/useManagedTools.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { ManagedToolsState } from "@inspector/core/mcp/state/managedToolsState";
+import { useManagedTools } from "@inspector/core/react/useManagedTools";
+
+function tool(name: string): Tool {
+  return { name, inputSchema: { type: "object" } };
+}
+
+describe("useManagedTools", () => {
+  let client: FakeInspectorClient;
+  let state: ManagedToolsState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient({ status: "connected" });
+    state = new ManagedToolsState(client);
+  });
+
+  it("returns the initial tools snapshot from the state", async () => {
+    client.queueToolPages({ tools: [tool("a"), tool("b")] });
+    await state.refresh();
+
+    const { result } = renderHook(() => useManagedTools(client, state));
+    expect(result.current.tools.map((t) => t.name)).toEqual(["a", "b"]);
+  });
+
+  it("returns empty tools when state is null", () => {
+    const { result } = renderHook(() => useManagedTools(client, null));
+    expect(result.current.tools).toEqual([]);
+  });
+
+  it("updates when state dispatches toolsChange", async () => {
+    const { result } = renderHook(() => useManagedTools(client, state));
+    expect(result.current.tools).toEqual([]);
+
+    client.queueToolPages({ tools: [tool("a")] });
+    await act(async () => {
+      await state.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.tools.map((t) => t.name)).toEqual(["a"]);
+    });
+  });
+
+  it("refresh() calls through to state and returns the next tools", async () => {
+    client.queueToolPages({ tools: [tool("x")] });
+    const { result } = renderHook(() => useManagedTools(client, state));
+
+    let next: Tool[] = [];
+    await act(async () => {
+      next = await result.current.refresh();
+    });
+
+    expect(next.map((t) => t.name)).toEqual(["x"]);
+    expect(result.current.tools.map((t) => t.name)).toEqual(["x"]);
+  });
+
+  it("refresh() returns [] when state or client is null", async () => {
+    const { result } = renderHook(() => useManagedTools(null, state));
+    await expect(result.current.refresh()).resolves.toEqual([]);
+
+    const { result: result2 } = renderHook(() => useManagedTools(client, null));
+    await expect(result2.current.refresh()).resolves.toEqual([]);
+  });
+
+  it("resets to empty tools when the state prop becomes null", async () => {
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.refresh();
+
+    const { result, rerender } = renderHook(
+      ({ s }: { s: ManagedToolsState | null }) => useManagedTools(client, s),
+      { initialProps: { s: state as ManagedToolsState | null } },
+    );
+    await waitFor(() => {
+      expect(result.current.tools.map((t) => t.name)).toEqual(["a"]);
+    });
+
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.tools).toEqual([]);
+    });
+  });
+
+  it("unsubscribes from the state on unmount", async () => {
+    const { result, unmount } = renderHook(() =>
+      useManagedTools(client, state),
+    );
+
+    unmount();
+
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.refresh();
+
+    // After unmount the hook should not be receiving updates — the last
+    // observed value is the empty snapshot captured before the refresh.
+    expect(result.current.tools).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/useMessageLog.test.tsx
+++ b/clients/web/src/test/core/react/useMessageLog.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { MessageEntry } from "@inspector/core/mcp/types";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { MessageLogState } from "@inspector/core/mcp/state/messageLogState";
+import { useMessageLog } from "@inspector/core/react/useMessageLog";
+
+function notif(method: string): MessageEntry {
+  return {
+    id: `n-${method}`,
+    timestamp: new Date(2026, 4, 13),
+    direction: "notification",
+    message: { jsonrpc: "2.0", method, params: {} },
+  };
+}
+
+describe("useMessageLog", () => {
+  let client: FakeInspectorClient;
+  let state: MessageLogState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new MessageLogState(client);
+  });
+
+  it("returns the initial snapshot from the state", () => {
+    client.dispatchTypedEvent("message", notif("a"));
+    const { result } = renderHook(() => useMessageLog(state));
+    expect(result.current.messages).toHaveLength(1);
+  });
+
+  it("returns empty when state is null", () => {
+    const { result } = renderHook(() => useMessageLog(null));
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("updates when state dispatches messagesChange", async () => {
+    const { result } = renderHook(() => useMessageLog(state));
+    expect(result.current.messages).toEqual([]);
+    act(() => {
+      client.dispatchTypedEvent("message", notif("a"));
+    });
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(1);
+    });
+  });
+
+  it("resets to empty when the state prop becomes null", async () => {
+    client.dispatchTypedEvent("message", notif("a"));
+    const { result, rerender } = renderHook(
+      ({ s }: { s: MessageLogState | null }) => useMessageLog(s),
+      { initialProps: { s: state as MessageLogState | null } },
+    );
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([]);
+    });
+  });
+
+  it("unsubscribes on unmount", async () => {
+    const { result, unmount } = renderHook(() => useMessageLog(state));
+    unmount();
+    client.dispatchTypedEvent("message", notif("a"));
+    expect(result.current.messages).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/usePagedPrompts.test.tsx
+++ b/clients/web/src/test/core/react/usePagedPrompts.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { PagedPromptsState } from "@inspector/core/mcp/state/pagedPromptsState";
+import { usePagedPrompts } from "@inspector/core/react/usePagedPrompts";
+
+function prompt(name: string): Prompt {
+  return { name };
+}
+
+describe("usePagedPrompts", () => {
+  let client: FakeInspectorClient;
+  let state: PagedPromptsState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient({ status: "connected" });
+    state = new PagedPromptsState(client);
+  });
+
+  it("returns the initial snapshot from the state", async () => {
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.loadPage();
+    const { result } = renderHook(() => usePagedPrompts(client, state));
+    expect(result.current.prompts.map((p) => p.name)).toEqual(["a"]);
+  });
+
+  it("returns empty when state is null", () => {
+    const { result } = renderHook(() => usePagedPrompts(client, null));
+    expect(result.current.prompts).toEqual([]);
+  });
+
+  it("updates when state dispatches promptsChange", async () => {
+    const { result } = renderHook(() => usePagedPrompts(client, state));
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await act(async () => {
+      await state.loadPage();
+    });
+    await waitFor(() => {
+      expect(result.current.prompts.map((p) => p.name)).toEqual(["a"]);
+    });
+  });
+
+  it("loadPage proxies to the state and forwards metadata", async () => {
+    client.queuePromptPages({ prompts: [prompt("x")] });
+    const { result } = renderHook(() => usePagedPrompts(client, state));
+    let next;
+    await act(async () => {
+      next = await result.current.loadPage(undefined, { k: "v" });
+    });
+    expect(next).toEqual({ prompts: [prompt("x")], nextCursor: undefined });
+    expect(client.listPrompts).toHaveBeenCalledWith(undefined, { k: "v" });
+  });
+
+  it("loadPage returns empty payload when state or client is null", async () => {
+    const { result } = renderHook(() => usePagedPrompts(null, state));
+    await expect(result.current.loadPage()).resolves.toEqual({
+      prompts: [],
+      nextCursor: undefined,
+    });
+    const { result: r2 } = renderHook(() => usePagedPrompts(client, null));
+    await expect(r2.current.loadPage()).resolves.toEqual({
+      prompts: [],
+      nextCursor: undefined,
+    });
+  });
+
+  it("clear() proxies to the state", async () => {
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.loadPage();
+    const { result } = renderHook(() => usePagedPrompts(client, state));
+    act(() => {
+      result.current.clear();
+    });
+    await waitFor(() => {
+      expect(result.current.prompts).toEqual([]);
+    });
+  });
+
+  it("clear() is a no-op when state is null", () => {
+    const { result } = renderHook(() => usePagedPrompts(client, null));
+    expect(() => result.current.clear()).not.toThrow();
+  });
+
+  it("resets to empty when the state prop becomes null", async () => {
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.loadPage();
+    const { result, rerender } = renderHook(
+      ({ s }: { s: PagedPromptsState | null }) => usePagedPrompts(client, s),
+      { initialProps: { s: state as PagedPromptsState | null } },
+    );
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.prompts).toEqual([]);
+    });
+  });
+
+  it("unsubscribes on unmount", async () => {
+    const { result, unmount } = renderHook(() =>
+      usePagedPrompts(client, state),
+    );
+    unmount();
+    client.queuePromptPages({ prompts: [prompt("a")] });
+    await state.loadPage();
+    expect(result.current.prompts).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/usePagedRequestorTasks.test.tsx
+++ b/clients/web/src/test/core/react/usePagedRequestorTasks.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Task } from "@modelcontextprotocol/sdk/types.js";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { PagedRequestorTasksState } from "@inspector/core/mcp/state/pagedRequestorTasksState";
+import { usePagedRequestorTasks } from "@inspector/core/react/usePagedRequestorTasks";
+
+function task(taskId: string, status: Task["status"] = "working"): Task {
+  return {
+    taskId,
+    status,
+    ttl: null,
+    createdAt: "2026-05-13T00:00:00Z",
+    lastUpdatedAt: "2026-05-13T00:00:00Z",
+  };
+}
+
+describe("usePagedRequestorTasks", () => {
+  let client: FakeInspectorClient;
+  let state: PagedRequestorTasksState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient({ status: "connected" });
+    state = new PagedRequestorTasksState(client);
+  });
+
+  it("returns the initial snapshot and nextCursor", async () => {
+    client.queueTaskPages({ tasks: [task("t1")], nextCursor: "c1" });
+    await state.loadPage();
+    const { result } = renderHook(() => usePagedRequestorTasks(client, state));
+    expect(result.current.tasks.map((t) => t.taskId)).toEqual(["t1"]);
+    expect(result.current.nextCursor).toBe("c1");
+  });
+
+  it("returns empty + undefined cursor when state is null", () => {
+    const { result } = renderHook(() => usePagedRequestorTasks(client, null));
+    expect(result.current.tasks).toEqual([]);
+    expect(result.current.nextCursor).toBeUndefined();
+  });
+
+  it("updates tasks and nextCursor when state dispatches tasksChange", async () => {
+    const { result } = renderHook(() => usePagedRequestorTasks(client, state));
+    client.queueTaskPages({ tasks: [task("t1")], nextCursor: "c1" });
+    await act(async () => {
+      await state.loadPage();
+    });
+    await waitFor(() => {
+      expect(result.current.tasks.map((t) => t.taskId)).toEqual(["t1"]);
+    });
+    expect(result.current.nextCursor).toBe("c1");
+  });
+
+  it("loadPage proxies to the state and returns the result", async () => {
+    client.queueTaskPages({ tasks: [task("tx")], nextCursor: "cx" });
+    const { result } = renderHook(() => usePagedRequestorTasks(client, state));
+    let next;
+    await act(async () => {
+      next = await result.current.loadPage();
+    });
+    expect(next).toEqual({ tasks: [task("tx")], nextCursor: "cx" });
+    expect(result.current.nextCursor).toBe("cx");
+  });
+
+  it("loadPage returns empty when state or client is null", async () => {
+    const { result } = renderHook(() => usePagedRequestorTasks(null, state));
+    await expect(result.current.loadPage()).resolves.toEqual({
+      tasks: [],
+      nextCursor: undefined,
+    });
+    const { result: r2 } = renderHook(() =>
+      usePagedRequestorTasks(client, null),
+    );
+    await expect(r2.current.loadPage()).resolves.toEqual({
+      tasks: [],
+      nextCursor: undefined,
+    });
+  });
+
+  it("clear() proxies to the state", async () => {
+    client.queueTaskPages({ tasks: [task("t1")], nextCursor: "c1" });
+    await state.loadPage();
+    const { result } = renderHook(() => usePagedRequestorTasks(client, state));
+    act(() => {
+      result.current.clear();
+    });
+    await waitFor(() => {
+      expect(result.current.tasks).toEqual([]);
+      expect(result.current.nextCursor).toBeUndefined();
+    });
+  });
+
+  it("clear() is a no-op when state is null", () => {
+    const { result } = renderHook(() => usePagedRequestorTasks(client, null));
+    expect(() => result.current.clear()).not.toThrow();
+  });
+
+  it("resets to empty when the state prop becomes null", async () => {
+    client.queueTaskPages({ tasks: [task("t1")] });
+    await state.loadPage();
+    const { result, rerender } = renderHook(
+      ({ s }: { s: PagedRequestorTasksState | null }) =>
+        usePagedRequestorTasks(client, s),
+      { initialProps: { s: state as PagedRequestorTasksState | null } },
+    );
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.tasks).toEqual([]);
+      expect(result.current.nextCursor).toBeUndefined();
+    });
+  });
+
+  it("unsubscribes on unmount", async () => {
+    const { result, unmount } = renderHook(() =>
+      usePagedRequestorTasks(client, state),
+    );
+    unmount();
+    client.queueTaskPages({ tasks: [task("t1")] });
+    await state.loadPage();
+    expect(result.current.tasks).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/usePagedResourceTemplates.test.tsx
+++ b/clients/web/src/test/core/react/usePagedResourceTemplates.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { PagedResourceTemplatesState } from "@inspector/core/mcp/state/pagedResourceTemplatesState";
+import { usePagedResourceTemplates } from "@inspector/core/react/usePagedResourceTemplates";
+
+function template(name: string): ResourceTemplate {
+  return { uriTemplate: `tpl://{${name}}`, name };
+}
+
+describe("usePagedResourceTemplates", () => {
+  let client: FakeInspectorClient;
+  let state: PagedResourceTemplatesState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient({ status: "connected" });
+    state = new PagedResourceTemplatesState(client);
+  });
+
+  it("returns the initial snapshot from the state", async () => {
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.loadPage();
+    const { result } = renderHook(() =>
+      usePagedResourceTemplates(client, state),
+    );
+    expect(result.current.resourceTemplates.map((t) => t.name)).toEqual(["a"]);
+  });
+
+  it("returns empty when state is null", () => {
+    const { result } = renderHook(() =>
+      usePagedResourceTemplates(client, null),
+    );
+    expect(result.current.resourceTemplates).toEqual([]);
+  });
+
+  it("updates when state dispatches resourceTemplatesChange", async () => {
+    const { result } = renderHook(() =>
+      usePagedResourceTemplates(client, state),
+    );
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await act(async () => {
+      await state.loadPage();
+    });
+    await waitFor(() => {
+      expect(result.current.resourceTemplates.map((t) => t.name)).toEqual([
+        "a",
+      ]);
+    });
+  });
+
+  it("loadPage proxies to the state and forwards metadata", async () => {
+    client.queueResourceTemplatePages({ resourceTemplates: [template("x")] });
+    const { result } = renderHook(() =>
+      usePagedResourceTemplates(client, state),
+    );
+    let next;
+    await act(async () => {
+      next = await result.current.loadPage(undefined, { k: "v" });
+    });
+    expect(next).toEqual({
+      resourceTemplates: [template("x")],
+      nextCursor: undefined,
+    });
+    expect(client.listResourceTemplates).toHaveBeenCalledWith(undefined, {
+      k: "v",
+    });
+  });
+
+  it("loadPage returns empty payload when state or client is null", async () => {
+    const { result } = renderHook(() => usePagedResourceTemplates(null, state));
+    await expect(result.current.loadPage()).resolves.toEqual({
+      resourceTemplates: [],
+      nextCursor: undefined,
+    });
+    const { result: r2 } = renderHook(() =>
+      usePagedResourceTemplates(client, null),
+    );
+    await expect(r2.current.loadPage()).resolves.toEqual({
+      resourceTemplates: [],
+      nextCursor: undefined,
+    });
+  });
+
+  it("clear() proxies to the state", async () => {
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.loadPage();
+    const { result } = renderHook(() =>
+      usePagedResourceTemplates(client, state),
+    );
+    act(() => {
+      result.current.clear();
+    });
+    await waitFor(() => {
+      expect(result.current.resourceTemplates).toEqual([]);
+    });
+  });
+
+  it("clear() is a no-op when state is null", () => {
+    const { result } = renderHook(() =>
+      usePagedResourceTemplates(client, null),
+    );
+    expect(() => result.current.clear()).not.toThrow();
+  });
+
+  it("resets to empty when the state prop becomes null", async () => {
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.loadPage();
+    const { result, rerender } = renderHook(
+      ({ s }: { s: PagedResourceTemplatesState | null }) =>
+        usePagedResourceTemplates(client, s),
+      { initialProps: { s: state as PagedResourceTemplatesState | null } },
+    );
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.resourceTemplates).toEqual([]);
+    });
+  });
+
+  it("unsubscribes on unmount", async () => {
+    const { result, unmount } = renderHook(() =>
+      usePagedResourceTemplates(client, state),
+    );
+    unmount();
+    client.queueResourceTemplatePages({ resourceTemplates: [template("a")] });
+    await state.loadPage();
+    expect(result.current.resourceTemplates).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/usePagedResources.test.tsx
+++ b/clients/web/src/test/core/react/usePagedResources.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { PagedResourcesState } from "@inspector/core/mcp/state/pagedResourcesState";
+import { usePagedResources } from "@inspector/core/react/usePagedResources";
+
+function resource(uri: string): Resource {
+  return { uri, name: uri };
+}
+
+describe("usePagedResources", () => {
+  let client: FakeInspectorClient;
+  let state: PagedResourcesState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient({ status: "connected" });
+    state = new PagedResourcesState(client);
+  });
+
+  it("returns the initial snapshot from the state", async () => {
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.loadPage();
+    const { result } = renderHook(() => usePagedResources(client, state));
+    expect(result.current.resources.map((r) => r.uri)).toEqual(["a://1"]);
+  });
+
+  it("returns empty when state is null", () => {
+    const { result } = renderHook(() => usePagedResources(client, null));
+    expect(result.current.resources).toEqual([]);
+  });
+
+  it("updates when state dispatches resourcesChange", async () => {
+    const { result } = renderHook(() => usePagedResources(client, state));
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await act(async () => {
+      await state.loadPage();
+    });
+    await waitFor(() => {
+      expect(result.current.resources.map((r) => r.uri)).toEqual(["a://1"]);
+    });
+  });
+
+  it("loadPage proxies to the state and forwards metadata", async () => {
+    client.queueResourcePages({ resources: [resource("x://1")] });
+    const { result } = renderHook(() => usePagedResources(client, state));
+    let next;
+    await act(async () => {
+      next = await result.current.loadPage(undefined, { k: "v" });
+    });
+    expect(next).toEqual({
+      resources: [resource("x://1")],
+      nextCursor: undefined,
+    });
+    expect(client.listResources).toHaveBeenCalledWith(undefined, { k: "v" });
+  });
+
+  it("loadPage returns empty payload when state or client is null", async () => {
+    const { result } = renderHook(() => usePagedResources(null, state));
+    await expect(result.current.loadPage()).resolves.toEqual({
+      resources: [],
+      nextCursor: undefined,
+    });
+    const { result: r2 } = renderHook(() => usePagedResources(client, null));
+    await expect(r2.current.loadPage()).resolves.toEqual({
+      resources: [],
+      nextCursor: undefined,
+    });
+  });
+
+  it("clear() proxies to the state", async () => {
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.loadPage();
+    const { result } = renderHook(() => usePagedResources(client, state));
+    act(() => {
+      result.current.clear();
+    });
+    await waitFor(() => {
+      expect(result.current.resources).toEqual([]);
+    });
+  });
+
+  it("clear() is a no-op when state is null", () => {
+    const { result } = renderHook(() => usePagedResources(client, null));
+    expect(() => result.current.clear()).not.toThrow();
+  });
+
+  it("resets to empty when the state prop becomes null", async () => {
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.loadPage();
+    const { result, rerender } = renderHook(
+      ({ s }: { s: PagedResourcesState | null }) =>
+        usePagedResources(client, s),
+      { initialProps: { s: state as PagedResourcesState | null } },
+    );
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.resources).toEqual([]);
+    });
+  });
+
+  it("unsubscribes on unmount", async () => {
+    const { result, unmount } = renderHook(() =>
+      usePagedResources(client, state),
+    );
+    unmount();
+    client.queueResourcePages({ resources: [resource("a://1")] });
+    await state.loadPage();
+    expect(result.current.resources).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/usePagedTools.test.tsx
+++ b/clients/web/src/test/core/react/usePagedTools.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { PagedToolsState } from "@inspector/core/mcp/state/pagedToolsState";
+import { usePagedTools } from "@inspector/core/react/usePagedTools";
+
+function tool(name: string): Tool {
+  return { name, inputSchema: { type: "object" } };
+}
+
+describe("usePagedTools", () => {
+  let client: FakeInspectorClient;
+  let state: PagedToolsState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient({ status: "connected" });
+    state = new PagedToolsState(client);
+  });
+
+  it("returns the initial snapshot from the state", async () => {
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.loadPage();
+    const { result } = renderHook(() => usePagedTools(client, state));
+    expect(result.current.tools.map((t) => t.name)).toEqual(["a"]);
+  });
+
+  it("returns empty when state is null", () => {
+    const { result } = renderHook(() => usePagedTools(client, null));
+    expect(result.current.tools).toEqual([]);
+  });
+
+  it("updates when state dispatches toolsChange", async () => {
+    const { result } = renderHook(() => usePagedTools(client, state));
+    client.queueToolPages({ tools: [tool("a")] });
+    await act(async () => {
+      await state.loadPage();
+    });
+    await waitFor(() => {
+      expect(result.current.tools.map((t) => t.name)).toEqual(["a"]);
+    });
+  });
+
+  it("loadPage proxies to the state and returns the result", async () => {
+    client.queueToolPages({ tools: [tool("x")], nextCursor: "c1" });
+    const { result } = renderHook(() => usePagedTools(client, state));
+    let next;
+    await act(async () => {
+      next = await result.current.loadPage();
+    });
+    expect(next).toEqual({ tools: [tool("x")], nextCursor: "c1" });
+    expect(result.current.tools.map((t) => t.name)).toEqual(["x"]);
+  });
+
+  it("loadPage returns empty payload when state or client is null", async () => {
+    const { result } = renderHook(() => usePagedTools(null, state));
+    await expect(result.current.loadPage()).resolves.toEqual({
+      tools: [],
+      nextCursor: undefined,
+    });
+
+    const { result: r2 } = renderHook(() => usePagedTools(client, null));
+    await expect(r2.current.loadPage()).resolves.toEqual({
+      tools: [],
+      nextCursor: undefined,
+    });
+  });
+
+  it("clear() proxies to the state", async () => {
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.loadPage();
+    const { result } = renderHook(() => usePagedTools(client, state));
+    act(() => {
+      result.current.clear();
+    });
+    await waitFor(() => {
+      expect(result.current.tools).toEqual([]);
+    });
+  });
+
+  it("clear() is a no-op when state is null", () => {
+    const { result } = renderHook(() => usePagedTools(client, null));
+    expect(() => result.current.clear()).not.toThrow();
+  });
+
+  it("resets to empty when the state prop becomes null", async () => {
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.loadPage();
+    const { result, rerender } = renderHook(
+      ({ s }: { s: PagedToolsState | null }) => usePagedTools(client, s),
+      { initialProps: { s: state as PagedToolsState | null } },
+    );
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.tools).toEqual([]);
+    });
+  });
+
+  it("unsubscribes on unmount", async () => {
+    const { result, unmount } = renderHook(() => usePagedTools(client, state));
+    unmount();
+    client.queueToolPages({ tools: [tool("a")] });
+    await state.loadPage();
+    expect(result.current.tools).toEqual([]);
+  });
+});

--- a/clients/web/src/test/core/react/useStderrLog.test.tsx
+++ b/clients/web/src/test/core/react/useStderrLog.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { StderrLogEntry } from "@inspector/core/mcp/types";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { StderrLogState } from "@inspector/core/mcp/state/stderrLogState";
+import { useStderrLog } from "@inspector/core/react/useStderrLog";
+
+function entry(message: string): StderrLogEntry {
+  return { message, timestamp: new Date(2026, 4, 13) };
+}
+
+describe("useStderrLog", () => {
+  let client: FakeInspectorClient;
+  let state: StderrLogState;
+
+  beforeEach(() => {
+    client = new FakeInspectorClient();
+    state = new StderrLogState(client);
+  });
+
+  it("returns the initial snapshot from the state", () => {
+    client.dispatchTypedEvent("stderrLog", entry("a"));
+    const { result } = renderHook(() => useStderrLog(state));
+    expect(result.current.stderrLogs.map((e) => e.message)).toEqual(["a"]);
+  });
+
+  it("returns empty when state is null", () => {
+    const { result } = renderHook(() => useStderrLog(null));
+    expect(result.current.stderrLogs).toEqual([]);
+  });
+
+  it("updates when state dispatches stderrLogsChange", async () => {
+    const { result } = renderHook(() => useStderrLog(state));
+    act(() => {
+      client.dispatchTypedEvent("stderrLog", entry("a"));
+    });
+    await waitFor(() => {
+      expect(result.current.stderrLogs).toHaveLength(1);
+    });
+  });
+
+  it("resets to empty when the state prop becomes null", async () => {
+    client.dispatchTypedEvent("stderrLog", entry("a"));
+    const { result, rerender } = renderHook(
+      ({ s }: { s: StderrLogState | null }) => useStderrLog(s),
+      { initialProps: { s: state as StderrLogState | null } },
+    );
+    rerender({ s: null });
+    await waitFor(() => {
+      expect(result.current.stderrLogs).toEqual([]);
+    });
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { result, unmount } = renderHook(() => useStderrLog(state));
+    unmount();
+    client.dispatchTypedEvent("stderrLog", entry("a"));
+    expect(result.current.stderrLogs).toEqual([]);
+  });
+});

--- a/clients/web/tsconfig.app.json
+++ b/clients/web/tsconfig.app.json
@@ -24,10 +24,18 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
 
-    /* Path aliases */
+    /* Path aliases. `react` / `react-dom` redirects let core/ source files
+     * (which live above clients/web/node_modules) resolve those bare imports
+     * during `tsc -b`. We point at the @types declaration packages so the
+     * imports type-check; Vite's `dedupe` handles the runtime resolution —
+     * see vite.config.ts.
+     */
     "baseUrl": ".",
     "paths": {
-      "@inspector/core/*": ["../../core/*"]
+      "@inspector/core/*": ["../../core/*"],
+      "react": ["./node_modules/@types/react"],
+      "react-dom": ["./node_modules/@types/react-dom"],
+      "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime"]
     }
   },
   "include": ["src", "../../core/**/*.ts"],
@@ -38,6 +46,7 @@
     "src/**/*.test.ts",
     "src/test/**",
     "../../core/**/*.test.ts",
-    "../../core/**/*.test.tsx"
+    "../../core/**/*.test.tsx",
+    "../../core/**/__tests__/**"
   ]
 }

--- a/clients/web/tsconfig.test.json
+++ b/clients/web/tsconfig.test.json
@@ -2,13 +2,22 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
-    "types": ["vite/client", "@testing-library/jest-dom"]
+    "types": ["vite/client", "@testing-library/jest-dom"],
+    "paths": {
+      "@inspector/core/*": ["../../core/*"],
+      "react": ["./node_modules/@types/react"],
+      "react-dom": ["./node_modules/@types/react-dom"],
+      "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime"],
+      "vitest": ["./node_modules/vitest"]
+    }
   },
   "include": [
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/test/**/*.ts",
-    "src/test/**/*.tsx"
+    "src/test/**/*.tsx",
+    "../../core/**/__tests__/**/*.ts",
+    "../../core/**/__tests__/**/*.tsx"
   ],
   "exclude": []
 }

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -16,6 +16,11 @@ export default defineConfig({
     alias: {
       '@inspector/core': path.resolve(dirname, '../../core'),
     },
+    // Source files in core/ import bare modules (react, @testing-library/react,
+    // etc.) that only exist in clients/web/node_modules. Dedupe ensures Vite
+    // resolves them from this package rather than walking up from core/'s
+    // location (which has no node_modules of its own yet).
+    dedupe: ['react', 'react-dom'],
   },
   server: {
     fs: {
@@ -30,6 +35,7 @@ export default defineConfig({
         'src/components/**/*.{ts,tsx}',
         'src/utils/**/*.{ts,tsx}',
         '../../core/mcp/**/*.{ts,tsx}',
+        '../../core/react/**/*.{ts,tsx}',
       ],
       exclude: [
         '**/*.stories.{ts,tsx}',
@@ -39,6 +45,7 @@ export default defineConfig({
         'src/components/**/types.ts',
         '../../core/mcp/types.ts',
         '../../core/mcp/elicitationCreateMessage.ts',
+        '../../core/mcp/__tests__/**',
       ],
       thresholds: {
         perFile: true,

--- a/core/mcp/__tests__/fakeInspectorClient.ts
+++ b/core/mcp/__tests__/fakeInspectorClient.ts
@@ -1,0 +1,219 @@
+/**
+ * Test-only fake InspectorClient: an InspectorClientEventTarget subclass
+ * implementing InspectorClientProtocol with stubbed methods. State and hook
+ * tests inject this so they can drive events, queue paginated list responses,
+ * and assert subscriber wiring without a real transport or SDK client.
+ */
+
+import { vi } from "vitest";
+import type {
+  Implementation,
+  LoggingLevel,
+  Prompt,
+  Resource,
+  ResourceTemplate,
+  ServerCapabilities,
+  Task,
+  Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import { InspectorClientEventTarget } from "../inspectorClientEventTarget.js";
+import type {
+  AppRendererClient,
+  InspectorClientProtocol,
+} from "../inspectorClientProtocol.js";
+import type {
+  ConnectionStatus,
+  PromptGetInvocation,
+  ResourceReadInvocation,
+  ResourceTemplateReadInvocation,
+  ToolCallInvocation,
+} from "../types.js";
+import type { JsonValue } from "../../json/jsonUtils.js";
+
+type ListResult<TKey extends string, TItem> = {
+  [K in TKey]: TItem[];
+} & { nextCursor?: string };
+
+export interface FakeInspectorClientOptions {
+  status?: ConnectionStatus;
+  capabilities?: ServerCapabilities;
+  serverInfo?: Implementation;
+  instructions?: string;
+}
+
+export class FakeInspectorClient
+  extends InspectorClientEventTarget
+  implements InspectorClientProtocol
+{
+  private status: ConnectionStatus;
+  private capabilities: ServerCapabilities | undefined;
+  private serverInfo: Implementation | undefined;
+  private instructions: string | undefined;
+  private appRendererClient: AppRendererClient | null = null;
+  private sessionId: string | undefined;
+
+  // Each paginated method pulls from a queue of pre-canned pages. Tests push
+  // pages with `queueToolPages(...)` etc. so they can assert pagination
+  // accumulation without wiring a real server.
+  toolPages: Array<ListResult<"tools", Tool>> = [];
+  promptPages: Array<ListResult<"prompts", Prompt>> = [];
+  resourcePages: Array<ListResult<"resources", Resource>> = [];
+  resourceTemplatePages: Array<
+    ListResult<"resourceTemplates", ResourceTemplate>
+  > = [];
+  taskPages: Array<ListResult<"tasks", Task>> = [];
+
+  listTools = vi.fn(async () => this.toolPages.shift() ?? { tools: [] });
+  listPrompts = vi.fn(async () => this.promptPages.shift() ?? { prompts: [] });
+  listResources = vi.fn(
+    async () => this.resourcePages.shift() ?? { resources: [] },
+  );
+  listResourceTemplates = vi.fn(
+    async () =>
+      this.resourceTemplatePages.shift() ?? { resourceTemplates: [] },
+  );
+  listRequestorTasks = vi.fn(
+    async () => this.taskPages.shift() ?? { tasks: [] },
+  );
+
+  callTool = vi.fn(
+    async (
+      tool: Tool,
+      params: Record<string, JsonValue>,
+    ): Promise<ToolCallInvocation> => ({
+      toolName: tool.name,
+      params,
+      result: null,
+      timestamp: new Date(),
+      success: true,
+    }),
+  );
+
+  readResource = vi.fn(
+    async (uri: string): Promise<ResourceReadInvocation> => ({
+      result: { contents: [] },
+      timestamp: new Date(),
+      uri,
+    }),
+  );
+
+  readResourceFromTemplate = vi.fn(
+    async (
+      uriTemplate: string,
+      params: Record<string, string>,
+    ): Promise<ResourceTemplateReadInvocation> => ({
+      uriTemplate,
+      expandedUri: uriTemplate,
+      result: { contents: [] },
+      timestamp: new Date(),
+      params,
+    }),
+  );
+
+  getPrompt = vi.fn(
+    async (name: string): Promise<PromptGetInvocation> => ({
+      result: { messages: [] },
+      timestamp: new Date(),
+      name,
+    }),
+  );
+
+  setLoggingLevel = vi.fn(async (_level: LoggingLevel) => {});
+
+  constructor(options: FakeInspectorClientOptions = {}) {
+    super();
+    this.status = options.status ?? "disconnected";
+    this.capabilities = options.capabilities;
+    this.serverInfo = options.serverInfo;
+    this.instructions = options.instructions;
+  }
+
+  getStatus(): ConnectionStatus {
+    return this.status;
+  }
+
+  getCapabilities(): ServerCapabilities | undefined {
+    return this.capabilities;
+  }
+
+  getServerInfo(): Implementation | undefined {
+    return this.serverInfo;
+  }
+
+  getInstructions(): string | undefined {
+    return this.instructions;
+  }
+
+  getAppRendererClient(): AppRendererClient | null {
+    return this.appRendererClient;
+  }
+
+  async connect(): Promise<void> {
+    this.setStatus("connecting");
+    this.setStatus("connected");
+    this.dispatchTypedEvent("connect");
+  }
+
+  async disconnect(): Promise<void> {
+    this.setStatus("disconnected");
+    this.dispatchTypedEvent("disconnect");
+  }
+
+  getSessionId(): string | undefined {
+    return this.sessionId;
+  }
+
+  // ---- test helpers ----
+
+  setStatus(status: ConnectionStatus): void {
+    this.status = status;
+    this.dispatchTypedEvent("statusChange", status);
+  }
+
+  setCapabilities(capabilities: ServerCapabilities | undefined): void {
+    this.capabilities = capabilities;
+    this.dispatchTypedEvent("capabilitiesChange", capabilities);
+  }
+
+  setServerInfo(info: Implementation | undefined): void {
+    this.serverInfo = info;
+    this.dispatchTypedEvent("serverInfoChange", info);
+  }
+
+  setInstructions(instructions: string | undefined): void {
+    this.instructions = instructions;
+    this.dispatchTypedEvent("instructionsChange", instructions);
+  }
+
+  setAppRendererClient(client: AppRendererClient | null): void {
+    this.appRendererClient = client;
+  }
+
+  setSessionId(id: string | undefined): void {
+    this.sessionId = id;
+  }
+
+  queueToolPages(...pages: Array<ListResult<"tools", Tool>>): void {
+    this.toolPages.push(...pages);
+  }
+
+  queuePromptPages(...pages: Array<ListResult<"prompts", Prompt>>): void {
+    this.promptPages.push(...pages);
+  }
+
+  queueResourcePages(
+    ...pages: Array<ListResult<"resources", Resource>>
+  ): void {
+    this.resourcePages.push(...pages);
+  }
+
+  queueResourceTemplatePages(
+    ...pages: Array<ListResult<"resourceTemplates", ResourceTemplate>>
+  ): void {
+    this.resourceTemplatePages.push(...pages);
+  }
+
+  queueTaskPages(...pages: Array<ListResult<"tasks", Task>>): void {
+    this.taskPages.push(...pages);
+  }
+}

--- a/core/mcp/inspectorClientEventTarget.ts
+++ b/core/mcp/inspectorClientEventTarget.ts
@@ -1,0 +1,134 @@
+/**
+ * Type-safe EventTarget for InspectorClient events.
+ * Extends the generic TypedEventTarget with InspectorClientEventMap; TypedEvent
+ * is provided as a type alias for use in listener signatures.
+ *
+ * v2 note: the v1.5 event map referenced SamplingCreateMessage / ElicitationCreateMessage
+ * classes (with embedded promise resolvers) and OAuth events from the auth subsystem.
+ * The auth subsystem and the runtime promise-based pending classes are not yet ported to
+ * v2 — see #1243 scope. Pending requests are typed with the v2 wrapper types
+ * (InspectorPendingSampling / InspectorPendingElicitation); OAuth events are deliberately
+ * omitted here and will be added when the auth subsystem is ported.
+ */
+
+import {
+  TypedEventTarget,
+  type TypedEventGeneric,
+} from "./typedEventTarget.js";
+import type {
+  ConnectionStatus,
+  MessageEntry,
+  StderrLogEntry,
+  FetchRequestEntry,
+  PromptGetInvocation,
+  ResourceReadInvocation,
+  ResourceTemplateReadInvocation,
+} from "./types.js";
+import type {
+  Tool,
+  ServerCapabilities,
+  Implementation,
+  Root,
+  Progress,
+  ProgressToken,
+  Task,
+  CallToolResult,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { InspectorPendingSampling } from "./samplingCreateMessage.js";
+import type { InspectorPendingElicitation } from "./elicitationCreateMessage.js";
+import type { JsonValue } from "../json/jsonUtils.js";
+
+/** Task with createdAt optional so we can emit synthetic tasks (e.g. on result/error) that omit it. */
+export type TaskWithOptionalCreatedAt = Omit<Task, "createdAt"> & {
+  createdAt?: string;
+};
+
+/**
+ * Maps event names to their detail types for CustomEvents
+ */
+export interface InspectorClientEventMap {
+  statusChange: ConnectionStatus;
+  toolsChange: Tool[];
+  capabilitiesChange: ServerCapabilities | undefined;
+  serverInfoChange: Implementation | undefined;
+  instructionsChange: string | undefined;
+  message: MessageEntry;
+  stderrLog: StderrLogEntry;
+  fetchRequest: FetchRequestEntry;
+  error: Error;
+  resourceUpdated: { uri: string };
+  progressNotification: Progress & { progressToken?: ProgressToken };
+  toolCallResultChange: {
+    toolName: string;
+    params: Record<string, JsonValue>;
+    result: CallToolResult | null;
+    timestamp: Date;
+    success: boolean;
+    error?: string;
+    metadata?: Record<string, string>;
+  };
+  resourceContentChange: {
+    uri: string;
+    content: ResourceReadInvocation;
+    timestamp: Date;
+  };
+  resourceTemplateContentChange: {
+    uriTemplate: string;
+    content: ResourceTemplateReadInvocation;
+    params: Record<string, string>;
+    timestamp: Date;
+  };
+  promptContentChange: {
+    name: string;
+    content: PromptGetInvocation;
+    timestamp: Date;
+  };
+  pendingSamplesChange: InspectorPendingSampling[];
+  newPendingSample: InspectorPendingSampling;
+  pendingElicitationsChange: InspectorPendingElicitation[];
+  newPendingElicitation: InspectorPendingElicitation;
+  rootsChange: Root[];
+  resourceSubscriptionsChange: string[];
+  // Task events
+  /** Fired only from server notification notifications/tasks/status. */
+  taskStatusChange: { taskId: string; task: Task };
+  /** Fired from callToolStream for each task update. */
+  toolCallTaskUpdated: {
+    taskId: string;
+    task: TaskWithOptionalCreatedAt;
+    result?: CallToolResult;
+    error?: McpError;
+  };
+  /** Fired from getRequestorTask() and callToolStream (client-origin task updates). */
+  requestorTaskUpdated: {
+    taskId: string;
+    task: TaskWithOptionalCreatedAt;
+    result?: CallToolResult;
+    error?: McpError;
+  };
+  taskCancelled: { taskId: string };
+  tasksChange: Task[];
+  // Signal events (no payload)
+  connect: void;
+  disconnect: void;
+  // List changed notification events
+  toolsListChanged: void;
+  resourcesListChanged: void;
+  resourceTemplatesListChanged: void;
+  promptsListChanged: void;
+  tasksListChanged: void;
+  // Session persistence (dispatched by client; FetchRequestLogState listens and saves)
+  saveSession: { sessionId: string };
+}
+
+/**
+ * Type alias for InspectorClient typed events (for listener signatures).
+ */
+export type TypedEvent<K extends keyof InspectorClientEventMap> =
+  TypedEventGeneric<InspectorClientEventMap, K>;
+
+/**
+ * Type-safe EventTarget for InspectorClient events.
+ */
+export class InspectorClientEventTarget extends TypedEventTarget<InspectorClientEventMap> {}

--- a/core/mcp/inspectorClientProtocol.ts
+++ b/core/mcp/inspectorClientProtocol.ts
@@ -1,0 +1,105 @@
+/**
+ * InspectorClientProtocol: the minimal surface that state managers (core/mcp/state/)
+ * and React hooks (core/react/) consume.
+ *
+ * v1.5 has a single concrete `InspectorClient` class (~2k LOC) bundling the transport,
+ * SDK client, OAuth flow, pending-request queues, and fetch tracking. Porting the full
+ * class requires first porting the auth subsystem (core/auth/, ~12 files) — that's
+ * deferred to a follow-up issue.
+ *
+ * This interface captures just what the state+hooks layer needs to function,
+ * so the layer is decoupled from how (or whether) the runtime is wired up.
+ * The real `InspectorClient` will implement this interface in the follow-up port.
+ */
+
+import type {
+  ConnectionStatus,
+  ResourceReadInvocation,
+  ResourceTemplateReadInvocation,
+  PromptGetInvocation,
+  ToolCallInvocation,
+} from "./types.js";
+import type {
+  Implementation,
+  LoggingLevel,
+  Prompt,
+  Resource,
+  ResourceTemplate,
+  ServerCapabilities,
+  Task,
+  Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { JsonValue } from "../json/jsonUtils.js";
+import type { InspectorClientEventTarget } from "./inspectorClientEventTarget.js";
+
+/**
+ * Opaque type representing the AppRendererClient surface used by @mcp-ui.
+ * v1.5 aliases this to the SDK `Client` type; v2 leaves it opaque until the
+ * real InspectorClient (or a focused App-renderer port) lands.
+ */
+export type AppRendererClient = unknown;
+
+/**
+ * The contract every state manager and hook depends on. Anything that holds
+ * a reference to "an Inspector client" — including tests and fixtures —
+ * should depend on this protocol rather than the concrete class.
+ */
+export interface InspectorClientProtocol extends InspectorClientEventTarget {
+  // Connection state accessors
+  getStatus(): ConnectionStatus;
+  getCapabilities(): ServerCapabilities | undefined;
+  getServerInfo(): Implementation | undefined;
+  getInstructions(): string | undefined;
+  getAppRendererClient(): AppRendererClient | null;
+
+  // Connection control
+  connect(): Promise<void>;
+  disconnect(safeDisconnectTimeout?: number): Promise<void>;
+
+  // Paginated list methods used by managed/paged state stores
+  listTools(
+    cursor?: string,
+    metadata?: Record<string, string>,
+  ): Promise<{ tools: Tool[]; nextCursor?: string }>;
+  listPrompts(
+    cursor?: string,
+    metadata?: Record<string, string>,
+  ): Promise<{ prompts: Prompt[]; nextCursor?: string }>;
+  listResources(
+    cursor?: string,
+    metadata?: Record<string, string>,
+  ): Promise<{ resources: Resource[]; nextCursor?: string }>;
+  listResourceTemplates(
+    cursor?: string,
+    metadata?: Record<string, string>,
+  ): Promise<{ resourceTemplates: ResourceTemplate[]; nextCursor?: string }>;
+  listRequestorTasks(
+    cursor?: string,
+  ): Promise<{ tasks: Task[]; nextCursor?: string }>;
+
+  // Invocation methods used by paged result panels
+  callTool(
+    tool: Tool,
+    args: Record<string, JsonValue>,
+    generalMetadata?: Record<string, string>,
+    toolSpecificMetadata?: Record<string, string>,
+  ): Promise<ToolCallInvocation>;
+  readResource(
+    uri: string,
+    metadata?: Record<string, string>,
+  ): Promise<ResourceReadInvocation>;
+  readResourceFromTemplate(
+    uriTemplate: string,
+    params: Record<string, string>,
+    metadata?: Record<string, string>,
+  ): Promise<ResourceTemplateReadInvocation>;
+  getPrompt(
+    name: string,
+    params?: Record<string, string>,
+    metadata?: Record<string, string>,
+  ): Promise<PromptGetInvocation>;
+
+  // Misc surface required by hooks/state
+  setLoggingLevel(level: LoggingLevel): Promise<void>;
+  getSessionId(): string | undefined;
+}

--- a/core/mcp/samplingCreateMessage.ts
+++ b/core/mcp/samplingCreateMessage.ts
@@ -1,0 +1,20 @@
+import type {
+  CreateMessageRequest,
+  CreateMessageResult,
+} from "@modelcontextprotocol/sdk/types.js";
+
+export type { CreateMessageRequest, CreateMessageResult };
+
+/**
+ * Shape of a pending sampling request tracked by the Inspector client.
+ * v1.5 implements this as a class with a resolver/reject closure; v2 will
+ * materialize the runtime when the core hook layer is wired to the
+ * (yet-to-be-ported) InspectorClient class. For now we keep the interface so
+ * screens/groups can type the pending-sampling queue.
+ */
+export interface InspectorPendingSampling {
+  id: string;
+  timestamp: Date;
+  request: CreateMessageRequest;
+  taskId?: string;
+}

--- a/core/mcp/sessionStorage.ts
+++ b/core/mcp/sessionStorage.ts
@@ -1,0 +1,30 @@
+import type { FetchRequestEntry } from "./types.js";
+
+/**
+ * Serialized session state for InspectorClient.
+ * Contains data that should persist across page navigations (e.g., OAuth redirects).
+ */
+export interface InspectorClientSessionState {
+  /** Fetch requests tracked during the session */
+  fetchRequests: FetchRequestEntry[];
+  /** Timestamp when session was created */
+  createdAt: number;
+  /** Timestamp when session was last updated */
+  updatedAt: number;
+}
+
+/**
+ * Storage interface for persisting InspectorClient session state.
+ * Used to maintain session data (e.g., fetch requests) across page navigations
+ * during OAuth flows.
+ */
+export interface InspectorClientStorage {
+  saveSession(
+    sessionId: string,
+    state: InspectorClientSessionState,
+  ): Promise<void>;
+  loadSession(
+    sessionId: string,
+  ): Promise<InspectorClientSessionState | undefined>;
+  deleteSession(sessionId: string): Promise<void>;
+}

--- a/core/mcp/state/fetchRequestLogState.ts
+++ b/core/mcp/state/fetchRequestLogState.ts
@@ -1,0 +1,149 @@
+/**
+ * FetchRequestLogState: holds the fetch request log, subscribes to the protocol
+ * "fetchRequest" event. Protocol emits per-entry; this manager owns the list and
+ * emits both `fetchRequest` (single entry) and `fetchRequestsChange` (full list)
+ * on append, and `fetchRequestsChange` on clear. Does not clear on connect or
+ * disconnect.
+ *
+ * When `sessionStorage` and `sessionId` are provided, restores fetch requests
+ * from storage on creation and listens for the client's `saveSession` event to
+ * persist before OAuth redirect.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { FetchRequestEntry } from "../types.js";
+import type {
+  InspectorClientStorage,
+  InspectorClientSessionState,
+} from "../sessionStorage.js";
+import type { InspectorClientEventMap } from "../inspectorClientEventTarget.js";
+import {
+  TypedEventTarget,
+  type TypedEventGeneric,
+} from "../typedEventTarget.js";
+
+export interface FetchRequestLogStateEventMap {
+  fetchRequest: FetchRequestEntry;
+  fetchRequestsChange: FetchRequestEntry[];
+}
+
+export interface FetchRequestLogStateOptions {
+  /**
+   * Maximum number of fetch requests to store (0 = unlimited, not recommended).
+   * When exceeded, oldest entries are dropped. Default 1000.
+   */
+  maxFetchRequests?: number;
+  /**
+   * When provided with sessionId, fetch requests are restored from storage on
+   * creation and saved when the client dispatches `saveSession` (e.g. before
+   * OAuth redirect).
+   */
+  sessionStorage?: InspectorClientStorage;
+  /** Session ID for load/save; required for sessionStorage to have effect. */
+  sessionId?: string;
+}
+
+export class FetchRequestLogState extends TypedEventTarget<FetchRequestLogStateEventMap> {
+  private fetchRequests: FetchRequestEntry[] = [];
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private readonly maxFetchRequests: number;
+
+  constructor(
+    client: InspectorClientProtocol,
+    options: FetchRequestLogStateOptions = {},
+  ) {
+    super();
+    this.maxFetchRequests = options.maxFetchRequests ?? 1000;
+    this.client = client;
+
+    const onFetchRequest = (
+      event: TypedEventGeneric<InspectorClientEventMap, "fetchRequest">,
+    ): void => {
+      const entry = event.detail;
+      if (
+        this.maxFetchRequests > 0 &&
+        this.fetchRequests.length >= this.maxFetchRequests
+      ) {
+        this.fetchRequests.shift();
+      }
+      this.fetchRequests.push(entry);
+      this.dispatchTypedEvent("fetchRequest", entry);
+      this.dispatchTypedEvent("fetchRequestsChange", this.getFetchRequests());
+    };
+    this.client.addEventListener("fetchRequest", onFetchRequest);
+
+    const sessionStorage = options.sessionStorage;
+    const sessionId = options.sessionId;
+
+    if (sessionStorage) {
+      const onSaveSession = (
+        event: TypedEventGeneric<InspectorClientEventMap, "saveSession">,
+      ): void => {
+        const { sessionId: id } = event.detail;
+        const state: InspectorClientSessionState = {
+          fetchRequests: this.getFetchRequests(),
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        };
+        sessionStorage.saveSession(id, state).catch(() => {
+          // fire-and-forget; storage may log internally
+        });
+      };
+      this.client.addEventListener("saveSession", onSaveSession);
+      this.unsubscribe = () => {
+        if (this.client) {
+          this.client.removeEventListener("fetchRequest", onFetchRequest);
+          this.client.removeEventListener("saveSession", onSaveSession);
+        }
+        this.client = null;
+      };
+      if (sessionId) {
+        sessionStorage.loadSession(sessionId).then((state) => {
+          if (this.client && state?.fetchRequests?.length) {
+            this.hydrateFetchRequests(state.fetchRequests);
+          }
+        });
+      }
+    } else {
+      this.unsubscribe = () => {
+        if (this.client) {
+          this.client.removeEventListener("fetchRequest", onFetchRequest);
+        }
+        this.client = null;
+      };
+    }
+  }
+
+  private hydrateFetchRequests(entries: FetchRequestEntry[]): void {
+    const trimmed =
+      this.maxFetchRequests > 0
+        ? entries.slice(-this.maxFetchRequests)
+        : entries;
+    this.fetchRequests = trimmed;
+    this.dispatchTypedEvent("fetchRequestsChange", this.getFetchRequests());
+  }
+
+  getFetchRequests(): FetchRequestEntry[] {
+    return [...this.fetchRequests];
+  }
+
+  /**
+   * Clear all fetch requests. Dispatches fetchRequestsChange only if the list
+   * was non-empty.
+   */
+  clearFetchRequests(): void {
+    if (this.fetchRequests.length === 0) return;
+    this.fetchRequests = [];
+    this.dispatchTypedEvent("fetchRequestsChange", []);
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.fetchRequests = [];
+  }
+}

--- a/core/mcp/state/fetchRequestLogState.ts
+++ b/core/mcp/state/fetchRequestLogState.ts
@@ -102,11 +102,18 @@ export class FetchRequestLogState extends TypedEventTarget<FetchRequestLogStateE
         this.client = null;
       };
       if (sessionId) {
-        sessionStorage.loadSession(sessionId).then((state) => {
-          if (this.client && state?.fetchRequests?.length) {
-            this.hydrateFetchRequests(state.fetchRequests);
-          }
-        });
+        sessionStorage
+          .loadSession(sessionId)
+          .then((state) => {
+            if (this.client && state?.fetchRequests?.length) {
+              this.hydrateFetchRequests(state.fetchRequests);
+            }
+          })
+          .catch(() => {
+            // fire-and-forget; storage may log internally. Matches the
+            // saveSession swallow above so a corrupt or unreadable session
+            // doesn't surface as an unhandled rejection.
+          });
       }
     } else {
       this.unsubscribe = () => {

--- a/core/mcp/state/managedPromptsState.ts
+++ b/core/mcp/state/managedPromptsState.ts
@@ -1,0 +1,97 @@
+/**
+ * ManagedPromptsState: holds full prompt list, syncs on promptsListChanged.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import { TypedEventTarget } from "../typedEventTarget.js";
+
+const MAX_PAGES = 100;
+
+export interface ManagedPromptsStateEventMap {
+  promptsChange: Prompt[];
+}
+
+/**
+ * State manager that keeps a full prompt list in sync with the server.
+ * Subscribes to connect, promptsListChanged, and statusChange; fetches all
+ * pages on refresh.
+ */
+export class ManagedPromptsState extends TypedEventTarget<ManagedPromptsStateEventMap> {
+  private prompts: Prompt[] = [];
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private _metadata: Record<string, string> | undefined = undefined;
+
+  constructor(client: InspectorClientProtocol) {
+    super();
+    this.client = client;
+    const onConnect = (): void => {
+      void this.refresh();
+    };
+    const onPromptsListChanged = (): void => {
+      void this.refresh();
+    };
+    const onStatusChange = (): void => {
+      if (this.client?.getStatus() === "disconnected") {
+        this.prompts = [];
+        this.dispatchTypedEvent("promptsChange", []);
+      }
+    };
+    this.client.addEventListener("connect", onConnect);
+    this.client.addEventListener("promptsListChanged", onPromptsListChanged);
+    this.client.addEventListener("statusChange", onStatusChange);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("connect", onConnect);
+        this.client.removeEventListener(
+          "promptsListChanged",
+          onPromptsListChanged,
+        );
+        this.client.removeEventListener("statusChange", onStatusChange);
+      }
+      this.client = null;
+    };
+  }
+
+  getPrompts(): Prompt[] {
+    return [...this.prompts];
+  }
+
+  setMetadata(metadata?: Record<string, string>): void {
+    this._metadata = metadata;
+  }
+
+  async refresh(metadata?: Record<string, string>): Promise<Prompt[]> {
+    const client = this.client;
+    if (!client || client.getStatus() !== "connected") {
+      return this.getPrompts();
+    }
+    const effectiveMetadata = metadata ?? this._metadata;
+    this.prompts = [];
+    let cursor: string | undefined;
+    let pageCount = 0;
+    do {
+      const result = await client.listPrompts(cursor, effectiveMetadata);
+      this.prompts = cursor ? [...this.prompts, ...result.prompts] : result.prompts;
+      cursor = result.nextCursor;
+      pageCount++;
+      if (pageCount >= MAX_PAGES) {
+        throw new Error(
+          `Maximum pagination limit (${MAX_PAGES} pages) reached while listing prompts`,
+        );
+      }
+    } while (cursor);
+    this.dispatchTypedEvent("promptsChange", this.prompts);
+    return this.getPrompts();
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.prompts = [];
+  }
+}

--- a/core/mcp/state/managedRequestorTasksState.ts
+++ b/core/mcp/state/managedRequestorTasksState.ts
@@ -1,0 +1,160 @@
+/**
+ * ManagedRequestorTasksState: holds full requestor task list, syncs on
+ * tasksListChanged. Subscribes to taskStatusChange (server) and
+ * requestorTaskUpdated (client) to merge per-task updates.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { Task } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  InspectorClientEventMap,
+  TaskWithOptionalCreatedAt,
+} from "../inspectorClientEventTarget.js";
+import {
+  TypedEventTarget,
+  type TypedEventGeneric,
+} from "../typedEventTarget.js";
+
+const MAX_PAGES = 100;
+
+export interface ManagedRequestorTasksStateEventMap {
+  tasksChange: Task[];
+}
+
+function mergeTaskIntoList(
+  tasks: Task[],
+  taskId: string,
+  task: Task | TaskWithOptionalCreatedAt,
+): Task[] {
+  const normalized: Task = {
+    ...task,
+    taskId,
+    createdAt:
+      (task as Task).createdAt ??
+      (task as TaskWithOptionalCreatedAt).lastUpdatedAt ??
+      "",
+  };
+  const idx = tasks.findIndex((t) => t.taskId === taskId);
+  if (idx < 0) {
+    return [normalized, ...tasks];
+  }
+  const next = [...tasks];
+  next[idx] = normalized;
+  return next;
+}
+
+/**
+ * State manager that keeps the full requestor task list in sync with the
+ * server. Subscribes to connect, tasksListChanged, statusChange,
+ * taskStatusChange (server), requestorTaskUpdated (client), and taskCancelled.
+ */
+export class ManagedRequestorTasksState extends TypedEventTarget<ManagedRequestorTasksStateEventMap> {
+  private tasks: Task[] = [];
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(client: InspectorClientProtocol) {
+    super();
+    this.client = client;
+    const onConnect = (): void => {
+      void this.refresh();
+    };
+    const onTasksListChanged = (): void => {
+      void this.refresh();
+    };
+    const onStatusChange = (): void => {
+      if (this.client?.getStatus() === "disconnected") {
+        this.tasks = [];
+        this.dispatchTypedEvent("tasksChange", []);
+      }
+    };
+    const onTaskStatusChange = (
+      e: TypedEventGeneric<InspectorClientEventMap, "taskStatusChange">,
+    ): void => {
+      const { taskId, task } = e.detail;
+      this.tasks = mergeTaskIntoList(this.tasks, taskId, task);
+      this.dispatchTypedEvent("tasksChange", this.tasks);
+    };
+    const onRequestorTaskUpdated = (
+      e: TypedEventGeneric<InspectorClientEventMap, "requestorTaskUpdated">,
+    ): void => {
+      const { taskId, task } = e.detail;
+      this.tasks = mergeTaskIntoList(this.tasks, taskId, task);
+      this.dispatchTypedEvent("tasksChange", this.tasks);
+    };
+    const onTaskCancelled = (
+      e: TypedEventGeneric<InspectorClientEventMap, "taskCancelled">,
+    ): void => {
+      const { taskId } = e.detail;
+      const idx = this.tasks.findIndex((t) => t.taskId === taskId);
+      if (idx >= 0) {
+        const next = [...this.tasks];
+        const prev = next[idx]!;
+        next[idx] = { ...prev, status: "cancelled" as const };
+        this.tasks = next;
+        this.dispatchTypedEvent("tasksChange", this.tasks);
+      }
+    };
+    this.client.addEventListener("connect", onConnect);
+    this.client.addEventListener("tasksListChanged", onTasksListChanged);
+    this.client.addEventListener("statusChange", onStatusChange);
+    this.client.addEventListener("taskStatusChange", onTaskStatusChange);
+    this.client.addEventListener(
+      "requestorTaskUpdated",
+      onRequestorTaskUpdated,
+    );
+    this.client.addEventListener("taskCancelled", onTaskCancelled);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("connect", onConnect);
+        this.client.removeEventListener("tasksListChanged", onTasksListChanged);
+        this.client.removeEventListener("statusChange", onStatusChange);
+        this.client.removeEventListener("taskStatusChange", onTaskStatusChange);
+        this.client.removeEventListener(
+          "requestorTaskUpdated",
+          onRequestorTaskUpdated,
+        );
+        this.client.removeEventListener("taskCancelled", onTaskCancelled);
+      }
+      this.client = null;
+    };
+  }
+
+  getTasks(): Task[] {
+    return [...this.tasks];
+  }
+
+  async refresh(): Promise<Task[]> {
+    const client = this.client;
+    if (!client || client.getStatus() !== "connected") {
+      return this.getTasks();
+    }
+    this.tasks = [];
+    let cursor: string | undefined;
+    let pageCount = 0;
+    do {
+      const result = await client.listRequestorTasks(cursor);
+      this.tasks = cursor
+        ? [...this.tasks, ...result.tasks]
+        : result.tasks;
+      cursor = result.nextCursor;
+      pageCount++;
+      if (pageCount >= MAX_PAGES) {
+        throw new Error(
+          `Maximum pagination limit (${MAX_PAGES} pages) reached while listing requestor tasks`,
+        );
+      }
+    } while (cursor);
+    this.dispatchTypedEvent("tasksChange", this.tasks);
+    return this.getTasks();
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.tasks = [];
+  }
+}

--- a/core/mcp/state/managedRequestorTasksState.ts
+++ b/core/mcp/state/managedRequestorTasksState.ts
@@ -9,41 +9,17 @@
 
 import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
 import type { Task } from "@modelcontextprotocol/sdk/types.js";
-import type {
-  InspectorClientEventMap,
-  TaskWithOptionalCreatedAt,
-} from "../inspectorClientEventTarget.js";
+import type { InspectorClientEventMap } from "../inspectorClientEventTarget.js";
 import {
   TypedEventTarget,
   type TypedEventGeneric,
 } from "../typedEventTarget.js";
+import { mergeTaskIntoList } from "./mergeTaskIntoList.js";
 
 const MAX_PAGES = 100;
 
 export interface ManagedRequestorTasksStateEventMap {
   tasksChange: Task[];
-}
-
-function mergeTaskIntoList(
-  tasks: Task[],
-  taskId: string,
-  task: Task | TaskWithOptionalCreatedAt,
-): Task[] {
-  const normalized: Task = {
-    ...task,
-    taskId,
-    createdAt:
-      (task as Task).createdAt ??
-      (task as TaskWithOptionalCreatedAt).lastUpdatedAt ??
-      "",
-  };
-  const idx = tasks.findIndex((t) => t.taskId === taskId);
-  if (idx < 0) {
-    return [normalized, ...tasks];
-  }
-  const next = [...tasks];
-  next[idx] = normalized;
-  return next;
 }
 
 /**

--- a/core/mcp/state/managedResourceTemplatesState.ts
+++ b/core/mcp/state/managedResourceTemplatesState.ts
@@ -1,0 +1,108 @@
+/**
+ * ManagedResourceTemplatesState: holds full resource template list, syncs on
+ * resourceTemplatesListChanged.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
+import { TypedEventTarget } from "../typedEventTarget.js";
+
+const MAX_PAGES = 100;
+
+export interface ManagedResourceTemplatesStateEventMap {
+  resourceTemplatesChange: ResourceTemplate[];
+}
+
+/**
+ * State manager that keeps a full resource template list in sync with the server.
+ * Subscribes to connect, resourceTemplatesListChanged, and statusChange;
+ * fetches all pages on refresh.
+ */
+export class ManagedResourceTemplatesState extends TypedEventTarget<ManagedResourceTemplatesStateEventMap> {
+  private resourceTemplates: ResourceTemplate[] = [];
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private _metadata: Record<string, string> | undefined = undefined;
+
+  constructor(client: InspectorClientProtocol) {
+    super();
+    this.client = client;
+    const onConnect = (): void => {
+      void this.refresh();
+    };
+    const onResourceTemplatesListChanged = (): void => {
+      void this.refresh();
+    };
+    const onStatusChange = (): void => {
+      if (this.client?.getStatus() === "disconnected") {
+        this.resourceTemplates = [];
+        this.dispatchTypedEvent("resourceTemplatesChange", []);
+      }
+    };
+    this.client.addEventListener("connect", onConnect);
+    this.client.addEventListener(
+      "resourceTemplatesListChanged",
+      onResourceTemplatesListChanged,
+    );
+    this.client.addEventListener("statusChange", onStatusChange);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("connect", onConnect);
+        this.client.removeEventListener(
+          "resourceTemplatesListChanged",
+          onResourceTemplatesListChanged,
+        );
+        this.client.removeEventListener("statusChange", onStatusChange);
+      }
+      this.client = null;
+    };
+  }
+
+  getResourceTemplates(): ResourceTemplate[] {
+    return [...this.resourceTemplates];
+  }
+
+  setMetadata(metadata?: Record<string, string>): void {
+    this._metadata = metadata;
+  }
+
+  async refresh(
+    metadata?: Record<string, string>,
+  ): Promise<ResourceTemplate[]> {
+    const client = this.client;
+    if (!client || client.getStatus() !== "connected") {
+      return this.getResourceTemplates();
+    }
+    const effectiveMetadata = metadata ?? this._metadata;
+    this.resourceTemplates = [];
+    let cursor: string | undefined;
+    let pageCount = 0;
+    do {
+      const result = await client.listResourceTemplates(
+        cursor,
+        effectiveMetadata,
+      );
+      this.resourceTemplates = cursor
+        ? [...this.resourceTemplates, ...result.resourceTemplates]
+        : result.resourceTemplates;
+      cursor = result.nextCursor;
+      pageCount++;
+      if (pageCount >= MAX_PAGES) {
+        throw new Error(
+          `Maximum pagination limit (${MAX_PAGES} pages) reached while listing resource templates`,
+        );
+      }
+    } while (cursor);
+    this.dispatchTypedEvent("resourceTemplatesChange", this.resourceTemplates);
+    return this.getResourceTemplates();
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.resourceTemplates = [];
+  }
+}

--- a/core/mcp/state/managedResourcesState.ts
+++ b/core/mcp/state/managedResourcesState.ts
@@ -1,0 +1,102 @@
+/**
+ * ManagedResourcesState: holds full resource list, syncs on resourcesListChanged.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import { TypedEventTarget } from "../typedEventTarget.js";
+
+const MAX_PAGES = 100;
+
+export interface ManagedResourcesStateEventMap {
+  resourcesChange: Resource[];
+}
+
+/**
+ * State manager that keeps a full resource list in sync with the server.
+ * Subscribes to connect, resourcesListChanged, and statusChange; fetches all
+ * pages on refresh.
+ */
+export class ManagedResourcesState extends TypedEventTarget<ManagedResourcesStateEventMap> {
+  private resources: Resource[] = [];
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private _metadata: Record<string, string> | undefined = undefined;
+
+  constructor(client: InspectorClientProtocol) {
+    super();
+    this.client = client;
+    const onConnect = (): void => {
+      void this.refresh();
+    };
+    const onResourcesListChanged = (): void => {
+      void this.refresh();
+    };
+    const onStatusChange = (): void => {
+      if (this.client?.getStatus() === "disconnected") {
+        this.resources = [];
+        this.dispatchTypedEvent("resourcesChange", []);
+      }
+    };
+    this.client.addEventListener("connect", onConnect);
+    this.client.addEventListener(
+      "resourcesListChanged",
+      onResourcesListChanged,
+    );
+    this.client.addEventListener("statusChange", onStatusChange);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("connect", onConnect);
+        this.client.removeEventListener(
+          "resourcesListChanged",
+          onResourcesListChanged,
+        );
+        this.client.removeEventListener("statusChange", onStatusChange);
+      }
+      this.client = null;
+    };
+  }
+
+  getResources(): Resource[] {
+    return [...this.resources];
+  }
+
+  setMetadata(metadata?: Record<string, string>): void {
+    this._metadata = metadata;
+  }
+
+  async refresh(metadata?: Record<string, string>): Promise<Resource[]> {
+    const client = this.client;
+    if (!client || client.getStatus() !== "connected") {
+      return this.getResources();
+    }
+    const effectiveMetadata = metadata ?? this._metadata;
+    this.resources = [];
+    let cursor: string | undefined;
+    let pageCount = 0;
+    do {
+      const result = await client.listResources(cursor, effectiveMetadata);
+      this.resources = cursor
+        ? [...this.resources, ...result.resources]
+        : result.resources;
+      cursor = result.nextCursor;
+      pageCount++;
+      if (pageCount >= MAX_PAGES) {
+        throw new Error(
+          `Maximum pagination limit (${MAX_PAGES} pages) reached while listing resources`,
+        );
+      }
+    } while (cursor);
+    this.dispatchTypedEvent("resourcesChange", this.resources);
+    return this.getResources();
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.resources = [];
+  }
+}

--- a/core/mcp/state/managedToolsState.ts
+++ b/core/mcp/state/managedToolsState.ts
@@ -1,0 +1,94 @@
+/**
+ * ManagedToolsState: holds full tool list, syncs on toolsListChanged.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { TypedEventTarget } from "../typedEventTarget.js";
+
+const MAX_PAGES = 100;
+
+export interface ManagedToolsStateEventMap {
+  toolsChange: Tool[];
+}
+
+/**
+ * State manager that keeps a full tool list in sync with the server.
+ * Subscribes to client's connect (initial load), toolsListChanged, and
+ * statusChange; fetches all pages on refresh.
+ */
+export class ManagedToolsState extends TypedEventTarget<ManagedToolsStateEventMap> {
+  private tools: Tool[] = [];
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private _metadata: Record<string, string> | undefined = undefined;
+
+  constructor(client: InspectorClientProtocol) {
+    super();
+    this.client = client;
+    const onConnect = (): void => {
+      void this.refresh();
+    };
+    const onToolsListChanged = (): void => {
+      void this.refresh();
+    };
+    const onStatusChange = (): void => {
+      if (this.client?.getStatus() === "disconnected") {
+        this.tools = [];
+        this.dispatchTypedEvent("toolsChange", []);
+      }
+    };
+    this.client.addEventListener("connect", onConnect);
+    this.client.addEventListener("toolsListChanged", onToolsListChanged);
+    this.client.addEventListener("statusChange", onStatusChange);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("connect", onConnect);
+        this.client.removeEventListener("toolsListChanged", onToolsListChanged);
+        this.client.removeEventListener("statusChange", onStatusChange);
+      }
+      this.client = null;
+    };
+  }
+
+  getTools(): Tool[] {
+    return [...this.tools];
+  }
+
+  setMetadata(metadata?: Record<string, string>): void {
+    this._metadata = metadata;
+  }
+
+  async refresh(metadata?: Record<string, string>): Promise<Tool[]> {
+    const client = this.client;
+    if (!client || client.getStatus() !== "connected") {
+      return this.getTools();
+    }
+    const effectiveMetadata = metadata ?? this._metadata;
+    this.tools = [];
+    let cursor: string | undefined;
+    let pageCount = 0;
+    do {
+      const result = await client.listTools(cursor, effectiveMetadata);
+      this.tools = cursor ? [...this.tools, ...result.tools] : result.tools;
+      cursor = result.nextCursor;
+      pageCount++;
+      if (pageCount >= MAX_PAGES) {
+        throw new Error(
+          `Maximum pagination limit (${MAX_PAGES} pages) reached while listing tools`,
+        );
+      }
+    } while (cursor);
+    this.dispatchTypedEvent("toolsChange", this.tools);
+    return this.getTools();
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.tools = [];
+  }
+}

--- a/core/mcp/state/mergeTaskIntoList.ts
+++ b/core/mcp/state/mergeTaskIntoList.ts
@@ -1,0 +1,33 @@
+import type { Task } from "@modelcontextprotocol/sdk/types.js";
+import type { TaskWithOptionalCreatedAt } from "../inspectorClientEventTarget.js";
+
+/**
+ * Insert or replace a task in a list keyed by `taskId`. Inserts at the front
+ * when the id is new (so most-recent updates surface first); replaces in place
+ * when the id is already present.
+ *
+ * The SDK `Task` requires `createdAt`, but client-origin task updates
+ * (`requestorTaskUpdated`) carry `TaskWithOptionalCreatedAt` — fall back to
+ * `lastUpdatedAt` so synthetic updates still satisfy the `Task` shape.
+ */
+export function mergeTaskIntoList(
+  tasks: Task[],
+  taskId: string,
+  task: Task | TaskWithOptionalCreatedAt,
+): Task[] {
+  const normalized: Task = {
+    ...task,
+    taskId,
+    createdAt:
+      (task as Task).createdAt ??
+      (task as TaskWithOptionalCreatedAt).lastUpdatedAt ??
+      "",
+  };
+  const idx = tasks.findIndex((t) => t.taskId === taskId);
+  if (idx < 0) {
+    return [normalized, ...tasks];
+  }
+  const next = [...tasks];
+  next[idx] = normalized;
+  return next;
+}

--- a/core/mcp/state/messageLogState.ts
+++ b/core/mcp/state/messageLogState.ts
@@ -1,0 +1,148 @@
+/**
+ * MessageLogState: holds the message log, subscribes to the protocol "message"
+ * event. Protocol emits per-entry; this manager owns the list and emits both
+ * `message` (single entry) and `messagesChange` (full list) on append/update,
+ * and `messagesChange` on clear. Clears on connect (new session) and on
+ * disconnect.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { MessageEntry } from "../types.js";
+import type { InspectorClientEventMap } from "../inspectorClientEventTarget.js";
+import {
+  TypedEventTarget,
+  type TypedEventGeneric,
+} from "../typedEventTarget.js";
+
+export interface MessageLogStateEventMap {
+  message: MessageEntry;
+  messagesChange: MessageEntry[];
+}
+
+export interface MessageLogStateOptions {
+  /**
+   * Maximum number of messages to store (0 = unlimited, not recommended).
+   * When exceeded, oldest entries are dropped. Default 1000.
+   */
+  maxMessages?: number;
+}
+
+export class MessageLogState extends TypedEventTarget<MessageLogStateEventMap> {
+  private messages: MessageEntry[] = [];
+  /** Pending request entries by JSON-RPC message id for matching responses. */
+  private pendingRequestEntries = new Map<string | number, MessageEntry>();
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private readonly maxMessages: number;
+
+  constructor(
+    client: InspectorClientProtocol,
+    options: MessageLogStateOptions = {},
+  ) {
+    super();
+    this.maxMessages = options.maxMessages ?? 1000;
+    this.client = client;
+
+    const pushEntry = (entry: MessageEntry): void => {
+      if (this.maxMessages > 0 && this.messages.length >= this.maxMessages) {
+        this.messages.shift();
+      }
+      this.messages.push(entry);
+      this.dispatchTypedEvent("message", entry);
+      this.dispatchTypedEvent("messagesChange", this.getMessages());
+    };
+
+    const onMessage = (
+      event: TypedEventGeneric<InspectorClientEventMap, "message">,
+    ): void => {
+      const entry = event.detail;
+      if (entry.direction === "request") {
+        const reqId =
+          "id" in entry.message
+            ? (entry.message as { id?: string | number }).id
+            : undefined;
+        if (reqId !== undefined) {
+          this.pendingRequestEntries.set(reqId, entry);
+        }
+        pushEntry(entry);
+        return;
+      }
+      if (entry.direction === "response") {
+        const messageId =
+          "id" in entry.message
+            ? (entry.message as { id?: string | number }).id
+            : undefined;
+        const requestEntry =
+          messageId !== undefined
+            ? this.pendingRequestEntries.get(messageId)
+            : undefined;
+        if (requestEntry) {
+          this.pendingRequestEntries.delete(messageId!);
+          requestEntry.response = entry.message as MessageEntry["response"];
+          requestEntry.duration =
+            entry.timestamp.getTime() - requestEntry.timestamp.getTime();
+          this.dispatchTypedEvent("message", requestEntry);
+          this.dispatchTypedEvent("messagesChange", this.getMessages());
+          return;
+        }
+      }
+      pushEntry(entry);
+    };
+
+    const onStatusChange = (): void => {
+      if (this.client?.getStatus() === "disconnected") {
+        this.messages = [];
+        this.pendingRequestEntries.clear();
+        this.dispatchTypedEvent("messagesChange", []);
+      }
+    };
+    const onConnect = (): void => {
+      this.messages = [];
+      this.pendingRequestEntries.clear();
+      this.dispatchTypedEvent("messagesChange", []);
+    };
+    this.client.addEventListener("message", onMessage);
+    this.client.addEventListener("statusChange", onStatusChange);
+    this.client.addEventListener("connect", onConnect);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("message", onMessage);
+        this.client.removeEventListener("statusChange", onStatusChange);
+        this.client.removeEventListener("connect", onConnect);
+      }
+      this.client = null;
+    };
+  }
+
+  getMessages(predicate?: (entry: MessageEntry) => boolean): MessageEntry[] {
+    if (predicate) {
+      return this.messages.filter(predicate);
+    }
+    return [...this.messages];
+  }
+
+  /**
+   * Remove messages from history. When `predicate` is provided, removes only
+   * entries for which predicate returns true. When omitted, clears all messages.
+   * Dispatches messagesChange only if the list actually changed.
+   */
+  clearMessages(predicate?: (entry: MessageEntry) => boolean): void {
+    const before = this.messages.length;
+    this.messages = predicate
+      ? this.messages.filter((m) => !predicate(m))
+      : [];
+    if (this.messages.length !== before) {
+      this.dispatchTypedEvent("messagesChange", this.getMessages());
+    }
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.messages = [];
+    this.pendingRequestEntries.clear();
+  }
+}

--- a/core/mcp/state/messageLogState.ts
+++ b/core/mcp/state/messageLogState.ts
@@ -134,6 +134,20 @@ export class MessageLogState extends TypedEventTarget<MessageLogStateEventMap> {
     this.messages = predicate
       ? this.messages.filter((m) => !predicate(m))
       : [];
+    // Drop pending-request bookkeeping for any entry that was just removed.
+    // Without this, a later response matching an evicted request id would
+    // mutate a Map-only entry that is no longer reachable from `messages`,
+    // silently dropping the response.
+    if (predicate) {
+      const survivors = new Set(this.messages);
+      for (const [id, entry] of this.pendingRequestEntries) {
+        if (!survivors.has(entry)) {
+          this.pendingRequestEntries.delete(id);
+        }
+      }
+    } else {
+      this.pendingRequestEntries.clear();
+    }
     if (this.messages.length !== before) {
       this.dispatchTypedEvent("messagesChange", this.getMessages());
     }

--- a/core/mcp/state/pagedPromptsState.ts
+++ b/core/mcp/state/pagedPromptsState.ts
@@ -2,6 +2,10 @@
  * PagedPromptsState: holds an aggregated list of prompts loaded via loadPage(cursor).
  * Does not load on connect; caller drives loading. Clears on disconnect.
  *
+ * Intentionally does NOT subscribe to `promptsListChanged`: cursors are tied
+ * to the server's prior list, so a list change mid-pagination would invalidate
+ * them. The caller decides how to react.
+ *
  * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
  * concrete `InspectorClient` since the runtime class is not yet ported.
  */

--- a/core/mcp/state/pagedPromptsState.ts
+++ b/core/mcp/state/pagedPromptsState.ts
@@ -1,0 +1,76 @@
+/**
+ * PagedPromptsState: holds an aggregated list of prompts loaded via loadPage(cursor).
+ * Does not load on connect; caller drives loading. Clears on disconnect.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import { TypedEventTarget } from "../typedEventTarget.js";
+
+export interface PagedPromptsStateEventMap {
+  promptsChange: Prompt[];
+}
+
+export interface LoadPageResult {
+  prompts: Prompt[];
+  nextCursor?: string;
+}
+
+export class PagedPromptsState extends TypedEventTarget<PagedPromptsStateEventMap> {
+  private prompts: Prompt[] = [];
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(client: InspectorClientProtocol) {
+    super();
+    this.client = client;
+    const onStatusChange = (): void => {
+      if (this.client?.getStatus() === "disconnected") {
+        this.prompts = [];
+        this.dispatchTypedEvent("promptsChange", []);
+      }
+    };
+    this.client.addEventListener("statusChange", onStatusChange);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("statusChange", onStatusChange);
+      }
+      this.client = null;
+    };
+  }
+
+  getPrompts(): Prompt[] {
+    return [...this.prompts];
+  }
+
+  clear(): void {
+    this.prompts = [];
+    this.dispatchTypedEvent("promptsChange", this.prompts);
+  }
+
+  async loadPage(
+    cursor?: string,
+    metadata?: Record<string, string>,
+  ): Promise<LoadPageResult> {
+    const c = this.client;
+    if (!c || c.getStatus() !== "connected") {
+      return { prompts: [], nextCursor: undefined };
+    }
+    const result = await c.listPrompts(cursor, metadata);
+    this.prompts =
+      cursor === undefined
+        ? [...result.prompts]
+        : [...this.prompts, ...result.prompts];
+    this.dispatchTypedEvent("promptsChange", this.prompts);
+    return { prompts: result.prompts, nextCursor: result.nextCursor };
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.prompts = [];
+  }
+}

--- a/core/mcp/state/pagedRequestorTasksState.ts
+++ b/core/mcp/state/pagedRequestorTasksState.ts
@@ -1,0 +1,156 @@
+/**
+ * PagedRequestorTasksState: holds an aggregated list of requestor tasks loaded
+ * via loadPage(cursor). Subscribes to tasksListChanged (refetch first page),
+ * taskStatusChange, requestorTaskUpdated, and taskCancelled. Clears on disconnect.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { Task } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  InspectorClientEventMap,
+  TaskWithOptionalCreatedAt,
+} from "../inspectorClientEventTarget.js";
+import {
+  TypedEventTarget,
+  type TypedEventGeneric,
+} from "../typedEventTarget.js";
+
+export interface PagedRequestorTasksStateEventMap {
+  tasksChange: Task[];
+}
+
+export interface LoadPageResult {
+  tasks: Task[];
+  nextCursor?: string;
+}
+
+function mergeTaskIntoList(
+  tasks: Task[],
+  taskId: string,
+  task: Task | TaskWithOptionalCreatedAt,
+): Task[] {
+  const normalized: Task = {
+    ...task,
+    taskId,
+    createdAt:
+      (task as Task).createdAt ??
+      (task as TaskWithOptionalCreatedAt).lastUpdatedAt ??
+      "",
+  };
+  const idx = tasks.findIndex((t) => t.taskId === taskId);
+  if (idx < 0) {
+    return [normalized, ...tasks];
+  }
+  const next = [...tasks];
+  next[idx] = normalized;
+  return next;
+}
+
+export class PagedRequestorTasksState extends TypedEventTarget<PagedRequestorTasksStateEventMap> {
+  private tasks: Task[] = [];
+  private nextCursor: string | undefined = undefined;
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(client: InspectorClientProtocol) {
+    super();
+    this.client = client;
+    const onStatusChange = (): void => {
+      if (this.client?.getStatus() === "disconnected") {
+        this.tasks = [];
+        this.nextCursor = undefined;
+        this.dispatchTypedEvent("tasksChange", []);
+      }
+    };
+    const onTasksListChanged = (): void => {
+      void this.loadPage(undefined);
+    };
+    const onTaskStatusChange = (
+      e: TypedEventGeneric<InspectorClientEventMap, "taskStatusChange">,
+    ): void => {
+      const { taskId, task } = e.detail;
+      this.tasks = mergeTaskIntoList(this.tasks, taskId, task);
+      this.dispatchTypedEvent("tasksChange", this.tasks);
+    };
+    const onRequestorTaskUpdated = (
+      e: TypedEventGeneric<InspectorClientEventMap, "requestorTaskUpdated">,
+    ): void => {
+      const { taskId, task } = e.detail;
+      this.tasks = mergeTaskIntoList(this.tasks, taskId, task);
+      this.dispatchTypedEvent("tasksChange", this.tasks);
+    };
+    const onTaskCancelled = (
+      e: TypedEventGeneric<InspectorClientEventMap, "taskCancelled">,
+    ): void => {
+      const { taskId } = e.detail;
+      const idx = this.tasks.findIndex((t) => t.taskId === taskId);
+      if (idx >= 0) {
+        const next = [...this.tasks];
+        const prev = next[idx]!;
+        next[idx] = { ...prev, status: "cancelled" as const };
+        this.tasks = next;
+        this.dispatchTypedEvent("tasksChange", this.tasks);
+      }
+    };
+    this.client.addEventListener("statusChange", onStatusChange);
+    this.client.addEventListener("tasksListChanged", onTasksListChanged);
+    this.client.addEventListener("taskStatusChange", onTaskStatusChange);
+    this.client.addEventListener(
+      "requestorTaskUpdated",
+      onRequestorTaskUpdated,
+    );
+    this.client.addEventListener("taskCancelled", onTaskCancelled);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("statusChange", onStatusChange);
+        this.client.removeEventListener("tasksListChanged", onTasksListChanged);
+        this.client.removeEventListener("taskStatusChange", onTaskStatusChange);
+        this.client.removeEventListener(
+          "requestorTaskUpdated",
+          onRequestorTaskUpdated,
+        );
+        this.client.removeEventListener("taskCancelled", onTaskCancelled);
+      }
+      this.client = null;
+    };
+  }
+
+  getTasks(): Task[] {
+    return [...this.tasks];
+  }
+
+  getNextCursor(): string | undefined {
+    return this.nextCursor;
+  }
+
+  clear(): void {
+    this.tasks = [];
+    this.nextCursor = undefined;
+    this.dispatchTypedEvent("tasksChange", this.tasks);
+  }
+
+  async loadPage(cursor?: string): Promise<LoadPageResult> {
+    const c = this.client;
+    if (!c || c.getStatus() !== "connected") {
+      return { tasks: [], nextCursor: undefined };
+    }
+    const result = await c.listRequestorTasks(cursor);
+    this.tasks =
+      cursor === undefined
+        ? [...result.tasks]
+        : [...this.tasks, ...result.tasks];
+    this.nextCursor = result.nextCursor;
+    this.dispatchTypedEvent("tasksChange", this.tasks);
+    return { tasks: result.tasks, nextCursor: result.nextCursor };
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.tasks = [];
+    this.nextCursor = undefined;
+  }
+}

--- a/core/mcp/state/pagedRequestorTasksState.ts
+++ b/core/mcp/state/pagedRequestorTasksState.ts
@@ -9,14 +9,12 @@
 
 import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
 import type { Task } from "@modelcontextprotocol/sdk/types.js";
-import type {
-  InspectorClientEventMap,
-  TaskWithOptionalCreatedAt,
-} from "../inspectorClientEventTarget.js";
+import type { InspectorClientEventMap } from "../inspectorClientEventTarget.js";
 import {
   TypedEventTarget,
   type TypedEventGeneric,
 } from "../typedEventTarget.js";
+import { mergeTaskIntoList } from "./mergeTaskIntoList.js";
 
 export interface PagedRequestorTasksStateEventMap {
   tasksChange: Task[];
@@ -25,28 +23,6 @@ export interface PagedRequestorTasksStateEventMap {
 export interface LoadPageResult {
   tasks: Task[];
   nextCursor?: string;
-}
-
-function mergeTaskIntoList(
-  tasks: Task[],
-  taskId: string,
-  task: Task | TaskWithOptionalCreatedAt,
-): Task[] {
-  const normalized: Task = {
-    ...task,
-    taskId,
-    createdAt:
-      (task as Task).createdAt ??
-      (task as TaskWithOptionalCreatedAt).lastUpdatedAt ??
-      "",
-  };
-  const idx = tasks.findIndex((t) => t.taskId === taskId);
-  if (idx < 0) {
-    return [normalized, ...tasks];
-  }
-  const next = [...tasks];
-  next[idx] = normalized;
-  return next;
 }
 
 export class PagedRequestorTasksState extends TypedEventTarget<PagedRequestorTasksStateEventMap> {

--- a/core/mcp/state/pagedResourceTemplatesState.ts
+++ b/core/mcp/state/pagedResourceTemplatesState.ts
@@ -3,6 +3,10 @@
  * loaded via loadPage(cursor). Does not load on connect; caller drives loading.
  * Clears on disconnect.
  *
+ * Intentionally does NOT subscribe to `resourceTemplatesListChanged`: cursors
+ * are tied to the server's prior list, so a list change mid-pagination would
+ * invalidate them. The caller decides how to react.
+ *
  * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
  * concrete `InspectorClient` since the runtime class is not yet ported.
  */

--- a/core/mcp/state/pagedResourceTemplatesState.ts
+++ b/core/mcp/state/pagedResourceTemplatesState.ts
@@ -1,0 +1,80 @@
+/**
+ * PagedResourceTemplatesState: holds an aggregated list of resource templates
+ * loaded via loadPage(cursor). Does not load on connect; caller drives loading.
+ * Clears on disconnect.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
+import { TypedEventTarget } from "../typedEventTarget.js";
+
+export interface PagedResourceTemplatesStateEventMap {
+  resourceTemplatesChange: ResourceTemplate[];
+}
+
+export interface LoadPageResult {
+  resourceTemplates: ResourceTemplate[];
+  nextCursor?: string;
+}
+
+export class PagedResourceTemplatesState extends TypedEventTarget<PagedResourceTemplatesStateEventMap> {
+  private resourceTemplates: ResourceTemplate[] = [];
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(client: InspectorClientProtocol) {
+    super();
+    this.client = client;
+    const onStatusChange = (): void => {
+      if (this.client?.getStatus() === "disconnected") {
+        this.resourceTemplates = [];
+        this.dispatchTypedEvent("resourceTemplatesChange", []);
+      }
+    };
+    this.client.addEventListener("statusChange", onStatusChange);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("statusChange", onStatusChange);
+      }
+      this.client = null;
+    };
+  }
+
+  getResourceTemplates(): ResourceTemplate[] {
+    return [...this.resourceTemplates];
+  }
+
+  clear(): void {
+    this.resourceTemplates = [];
+    this.dispatchTypedEvent("resourceTemplatesChange", this.resourceTemplates);
+  }
+
+  async loadPage(
+    cursor?: string,
+    metadata?: Record<string, string>,
+  ): Promise<LoadPageResult> {
+    const c = this.client;
+    if (!c || c.getStatus() !== "connected") {
+      return { resourceTemplates: [], nextCursor: undefined };
+    }
+    const result = await c.listResourceTemplates(cursor, metadata);
+    this.resourceTemplates =
+      cursor === undefined
+        ? [...result.resourceTemplates]
+        : [...this.resourceTemplates, ...result.resourceTemplates];
+    this.dispatchTypedEvent("resourceTemplatesChange", this.resourceTemplates);
+    return {
+      resourceTemplates: result.resourceTemplates,
+      nextCursor: result.nextCursor,
+    };
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.resourceTemplates = [];
+  }
+}

--- a/core/mcp/state/pagedResourcesState.ts
+++ b/core/mcp/state/pagedResourcesState.ts
@@ -1,0 +1,76 @@
+/**
+ * PagedResourcesState: holds an aggregated list of resources loaded via loadPage(cursor).
+ * Does not load on connect; caller drives loading. Clears on disconnect.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import { TypedEventTarget } from "../typedEventTarget.js";
+
+export interface PagedResourcesStateEventMap {
+  resourcesChange: Resource[];
+}
+
+export interface LoadPageResult {
+  resources: Resource[];
+  nextCursor?: string;
+}
+
+export class PagedResourcesState extends TypedEventTarget<PagedResourcesStateEventMap> {
+  private resources: Resource[] = [];
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(client: InspectorClientProtocol) {
+    super();
+    this.client = client;
+    const onStatusChange = (): void => {
+      if (this.client?.getStatus() === "disconnected") {
+        this.resources = [];
+        this.dispatchTypedEvent("resourcesChange", []);
+      }
+    };
+    this.client.addEventListener("statusChange", onStatusChange);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("statusChange", onStatusChange);
+      }
+      this.client = null;
+    };
+  }
+
+  getResources(): Resource[] {
+    return [...this.resources];
+  }
+
+  clear(): void {
+    this.resources = [];
+    this.dispatchTypedEvent("resourcesChange", this.resources);
+  }
+
+  async loadPage(
+    cursor?: string,
+    metadata?: Record<string, string>,
+  ): Promise<LoadPageResult> {
+    const c = this.client;
+    if (!c || c.getStatus() !== "connected") {
+      return { resources: [], nextCursor: undefined };
+    }
+    const result = await c.listResources(cursor, metadata);
+    this.resources =
+      cursor === undefined
+        ? [...result.resources]
+        : [...this.resources, ...result.resources];
+    this.dispatchTypedEvent("resourcesChange", this.resources);
+    return { resources: result.resources, nextCursor: result.nextCursor };
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.resources = [];
+  }
+}

--- a/core/mcp/state/pagedResourcesState.ts
+++ b/core/mcp/state/pagedResourcesState.ts
@@ -2,6 +2,10 @@
  * PagedResourcesState: holds an aggregated list of resources loaded via loadPage(cursor).
  * Does not load on connect; caller drives loading. Clears on disconnect.
  *
+ * Intentionally does NOT subscribe to `resourcesListChanged`: cursors are
+ * tied to the server's prior list, so a list change mid-pagination would
+ * invalidate them. The caller decides how to react.
+ *
  * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
  * concrete `InspectorClient` since the runtime class is not yet ported.
  */

--- a/core/mcp/state/pagedToolsState.ts
+++ b/core/mcp/state/pagedToolsState.ts
@@ -1,0 +1,73 @@
+/**
+ * PagedToolsState: holds an aggregated list of tools loaded via loadPage(cursor).
+ * Does not load on connect; caller drives loading. Clears on disconnect.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { TypedEventTarget } from "../typedEventTarget.js";
+
+export interface PagedToolsStateEventMap {
+  toolsChange: Tool[];
+}
+
+export interface LoadPageResult {
+  tools: Tool[];
+  nextCursor?: string;
+}
+
+export class PagedToolsState extends TypedEventTarget<PagedToolsStateEventMap> {
+  private tools: Tool[] = [];
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(client: InspectorClientProtocol) {
+    super();
+    this.client = client;
+    const onStatusChange = (): void => {
+      if (this.client?.getStatus() === "disconnected") {
+        this.tools = [];
+        this.dispatchTypedEvent("toolsChange", []);
+      }
+    };
+    this.client.addEventListener("statusChange", onStatusChange);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("statusChange", onStatusChange);
+      }
+      this.client = null;
+    };
+  }
+
+  getTools(): Tool[] {
+    return [...this.tools];
+  }
+
+  clear(): void {
+    this.tools = [];
+    this.dispatchTypedEvent("toolsChange", this.tools);
+  }
+
+  async loadPage(cursor?: string): Promise<LoadPageResult> {
+    const c = this.client;
+    if (!c || c.getStatus() !== "connected") {
+      return { tools: [], nextCursor: undefined };
+    }
+    const result = await c.listTools(cursor, undefined);
+    this.tools =
+      cursor === undefined
+        ? [...result.tools]
+        : [...this.tools, ...result.tools];
+    this.dispatchTypedEvent("toolsChange", this.tools);
+    return { tools: result.tools, nextCursor: result.nextCursor };
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.tools = [];
+  }
+}

--- a/core/mcp/state/pagedToolsState.ts
+++ b/core/mcp/state/pagedToolsState.ts
@@ -2,6 +2,11 @@
  * PagedToolsState: holds an aggregated list of tools loaded via loadPage(cursor).
  * Does not load on connect; caller drives loading. Clears on disconnect.
  *
+ * Intentionally does NOT subscribe to `toolsListChanged`: cursors are tied to
+ * the server's prior list, so a list change mid-pagination would invalidate
+ * them. The caller decides how to react (typically by `clear()` + reload
+ * page 1) — see the managed variant for the auto-refresh shape.
+ *
  * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
  * concrete `InspectorClient` since the runtime class is not yet ported.
  */

--- a/core/mcp/state/stderrLogState.ts
+++ b/core/mcp/state/stderrLogState.ts
@@ -1,0 +1,88 @@
+/**
+ * StderrLogState: holds the stderr log, subscribes to the protocol "stderrLog"
+ * event. Protocol emits per-entry; this manager owns the list and emits both
+ * `stderrLog` (single entry) and `stderrLogsChange` (full list) on append,
+ * and `stderrLogsChange` on clear. Does not clear on connect/disconnect —
+ * pre-connect and post-connect entries both remain.
+ *
+ * Ported from v1.5/main. v2 substitutes `InspectorClientProtocol` for the
+ * concrete `InspectorClient` since the runtime class is not yet ported.
+ */
+
+import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type { StderrLogEntry } from "../types.js";
+import type { InspectorClientEventMap } from "../inspectorClientEventTarget.js";
+import {
+  TypedEventTarget,
+  type TypedEventGeneric,
+} from "../typedEventTarget.js";
+
+export interface StderrLogStateEventMap {
+  stderrLog: StderrLogEntry;
+  stderrLogsChange: StderrLogEntry[];
+}
+
+export interface StderrLogStateOptions {
+  /**
+   * Maximum number of stderr log entries to store (0 = unlimited, not recommended).
+   * When exceeded, oldest entries are dropped. Default 1000.
+   */
+  maxStderrLogEvents?: number;
+}
+
+export class StderrLogState extends TypedEventTarget<StderrLogStateEventMap> {
+  private stderrLogs: StderrLogEntry[] = [];
+  private client: InspectorClientProtocol | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private readonly maxStderrLogEvents: number;
+
+  constructor(
+    client: InspectorClientProtocol,
+    options: StderrLogStateOptions = {},
+  ) {
+    super();
+    this.maxStderrLogEvents = options.maxStderrLogEvents ?? 1000;
+    this.client = client;
+    const onStderrLog = (
+      event: TypedEventGeneric<InspectorClientEventMap, "stderrLog">,
+    ): void => {
+      const entry = event.detail;
+      if (
+        this.maxStderrLogEvents > 0 &&
+        this.stderrLogs.length >= this.maxStderrLogEvents
+      ) {
+        this.stderrLogs.shift();
+      }
+      this.stderrLogs.push(entry);
+      this.dispatchTypedEvent("stderrLog", entry);
+      this.dispatchTypedEvent("stderrLogsChange", this.getStderrLogs());
+    };
+    this.client.addEventListener("stderrLog", onStderrLog);
+    this.unsubscribe = () => {
+      if (this.client) {
+        this.client.removeEventListener("stderrLog", onStderrLog);
+      }
+      this.client = null;
+    };
+  }
+
+  getStderrLogs(): StderrLogEntry[] {
+    return [...this.stderrLogs];
+  }
+
+  /**
+   * Clear all stderr log entries. Dispatches stderrLogsChange only if the
+   * list was non-empty.
+   */
+  clearStderrLogs(): void {
+    if (this.stderrLogs.length === 0) return;
+    this.stderrLogs = [];
+    this.dispatchTypedEvent("stderrLogsChange", []);
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.stderrLogs = [];
+  }
+}

--- a/core/mcp/typedEventTarget.ts
+++ b/core/mcp/typedEventTarget.ts
@@ -1,0 +1,85 @@
+/**
+ * Generic type-safe EventTarget for any domain (InspectorClient, state managers, etc.).
+ * Extends EventTarget so instances are valid EventTargets; uses overloads to preserve
+ * base-class assignability while providing typed addEventListener/removeEventListener.
+ */
+
+/**
+ * Typed event class that extends CustomEvent with type-safe detail.
+ * For void events, detail is undefined.
+ */
+export class TypedEventGeneric<
+  EventMap extends object,
+  K extends keyof EventMap,
+> extends CustomEvent<EventMap[K]> {
+  constructor(type: K, detail?: EventMap[K]) {
+    super(type as string, { detail });
+  }
+}
+
+/**
+ * Type-safe EventTarget parameterized by an event map (event name → detail type).
+ * Extends EventTarget so instances are assignable to EventTarget. Uses the same
+ * overload pattern as the DOM: typed overloads for our API plus a base-compatible
+ * implementation so the subclass remains assignable to EventTarget.
+ */
+export class TypedEventTarget<EventMap extends object> extends EventTarget {
+  dispatchTypedEvent<K extends keyof EventMap>(
+    type: K,
+    ...args: EventMap[K] extends void ? [] : [detail: EventMap[K]]
+  ): void {
+    const detail =
+      (args[0] as EventMap[K] | undefined) ?? (undefined as EventMap[K]);
+    this.dispatchEvent(new TypedEventGeneric<EventMap, K>(type, detail));
+  }
+
+  addEventListener<K extends keyof EventMap>(
+    type: K,
+    listener: (event: TypedEventGeneric<EventMap, K>) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  addEventListener(
+    type: string,
+    listener:
+      | ((event: TypedEventGeneric<EventMap, keyof EventMap>) => void)
+      | EventListenerOrEventListenerObject
+      | null,
+    options?: boolean | AddEventListenerOptions,
+  ): void {
+    super.addEventListener(
+      type,
+      listener as EventListenerOrEventListenerObject | null,
+      options,
+    );
+  }
+
+  removeEventListener<K extends keyof EventMap>(
+    type: K,
+    listener: (event: TypedEventGeneric<EventMap, K>) => void,
+    options?: boolean | EventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+    options?: boolean | EventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener:
+      | ((event: TypedEventGeneric<EventMap, keyof EventMap>) => void)
+      | EventListenerOrEventListenerObject
+      | null,
+    options?: boolean | EventListenerOptions,
+  ): void {
+    super.removeEventListener(
+      type,
+      listener as EventListenerOrEventListenerObject | null,
+      options,
+    );
+  }
+}

--- a/core/mcp/types.ts
+++ b/core/mcp/types.ts
@@ -206,6 +206,54 @@ export interface InspectorResourceSubscription {
 }
 
 /**
+ * Wraps a URL-based elicit request from the server. v1.5 only supports
+ * form elicitation; v2 introduces URL elicitation as a discriminated variant
+ * of the inline elicitation panel. The wrapper carries the request payload
+ * plus the URL the user must visit to satisfy it.
+ */
+export interface InspectorUrlElicitRequest {
+  id: string;
+  timestamp: Date;
+  /** Free-form prompt shown alongside the URL (server-supplied). */
+  message: string;
+  /** Authorization or interaction URL the user must visit. */
+  url: string;
+  /** Optional task association for grouping in the tasks view. */
+  taskId?: string;
+}
+
+/**
+ * Generic envelope for pending server-originated requests surfaced to
+ * dumb components. Used by the pending-request panel to list anything
+ * the user must act on before the protocol can proceed (sampling, elicitation,
+ * URL elicitation, roots list, etc.).
+ */
+export interface InspectorPendingRequest {
+  id: string;
+  timestamp: Date;
+  kind: "sampling" | "elicitation" | "urlElicitation" | "rootsList";
+  /** Display label rendered on the queue row. */
+  label: string;
+  /** Optional task association so panels can group/route. */
+  taskId?: string;
+}
+
+/**
+ * Single entry rendered in the history view. v2 extracts this from the
+ * message log so the HistoryScreen can filter/group entries without needing
+ * to re-derive direction or method from raw JSON-RPC frames.
+ */
+export interface InspectorRequestHistoryItem {
+  id: string;
+  timestamp: Date;
+  direction: "request" | "response" | "notification";
+  method: string;
+  durationMs?: number;
+  /** Surfaces the original log entry for detail panes. */
+  messageId: MessageEntry["id"];
+}
+
+/**
  * OAuth credentials surfaced by the settings form. The form callback
  * passes this whole object so callers don't have to thread per-field
  * dispatches through stringly-typed key arguments.

--- a/core/react/useFetchRequestLog.ts
+++ b/core/react/useFetchRequestLog.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react";
+import type { FetchRequestEntry } from "../mcp/types.js";
+import type {
+  FetchRequestLogState,
+  FetchRequestLogStateEventMap,
+} from "../mcp/state/fetchRequestLogState.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UseFetchRequestLogResult {
+  fetchRequests: FetchRequestEntry[];
+}
+
+/**
+ * React hook that subscribes to FetchRequestLogState and returns the fetch
+ * request list.
+ */
+export function useFetchRequestLog(
+  fetchRequestLogState: FetchRequestLogState | null,
+): UseFetchRequestLogResult {
+  const [fetchRequests, setFetchRequests] = useState<FetchRequestEntry[]>(
+    fetchRequestLogState?.getFetchRequests() ?? [],
+  );
+
+  useEffect(() => {
+    if (!fetchRequestLogState) {
+      setFetchRequests([]);
+      return;
+    }
+    setFetchRequests(fetchRequestLogState.getFetchRequests());
+    const onFetchRequestsChange = (
+      event: TypedEventGeneric<
+        FetchRequestLogStateEventMap,
+        "fetchRequestsChange"
+      >,
+    ) => {
+      setFetchRequests(event.detail);
+    };
+    fetchRequestLogState.addEventListener(
+      "fetchRequestsChange",
+      onFetchRequestsChange,
+    );
+    return () => {
+      fetchRequestLogState.removeEventListener(
+        "fetchRequestsChange",
+        onFetchRequestsChange,
+      );
+    };
+  }, [fetchRequestLogState]);
+
+  return { fetchRequests };
+}

--- a/core/react/useInspectorClient.ts
+++ b/core/react/useInspectorClient.ts
@@ -22,6 +22,14 @@ export interface UseInspectorClientResult {
  * React hook that subscribes to InspectorClient events and provides reactive
  * connection state. Log lists (message / stderr / fetch) live in dedicated
  * state managers consumed via useMessageLog / useStderrLog / useFetchRequestLog.
+ *
+ * Note: `appRendererClient` is read lazily from the client on every render
+ * and is NOT subscribed. It changes once at connect time and is not expected
+ * to change again during a session, so callers will see the current value
+ * on any rerender triggered by status / capabilities / serverInfo / instructions.
+ * If a future use case requires autonomous updates when the renderer attaches,
+ * add an `appRendererClientChange` event to `InspectorClientEventMap` and
+ * subscribe here.
  */
 export function useInspectorClient(
   inspectorClient: InspectorClientProtocol | null,

--- a/core/react/useInspectorClient.ts
+++ b/core/react/useInspectorClient.ts
@@ -1,0 +1,116 @@
+import { useState, useEffect, useCallback } from "react";
+import type { InspectorClientProtocol } from "../mcp/inspectorClientProtocol.js";
+import type { AppRendererClient } from "../mcp/inspectorClientProtocol.js";
+import type { TypedEvent } from "../mcp/inspectorClientEventTarget.js";
+import type { ConnectionStatus } from "../mcp/types.js";
+import type {
+  ServerCapabilities,
+  Implementation,
+} from "@modelcontextprotocol/sdk/types.js";
+
+export interface UseInspectorClientResult {
+  status: ConnectionStatus;
+  capabilities?: ServerCapabilities;
+  serverInfo?: Implementation;
+  instructions?: string;
+  appRendererClient: AppRendererClient | null;
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+}
+
+/**
+ * React hook that subscribes to InspectorClient events and provides reactive
+ * connection state. Log lists (message / stderr / fetch) live in dedicated
+ * state managers consumed via useMessageLog / useStderrLog / useFetchRequestLog.
+ */
+export function useInspectorClient(
+  inspectorClient: InspectorClientProtocol | null,
+): UseInspectorClientResult {
+  const [status, setStatus] = useState<ConnectionStatus>(
+    inspectorClient?.getStatus() ?? "disconnected",
+  );
+  const [capabilities, setCapabilities] = useState<
+    ServerCapabilities | undefined
+  >(inspectorClient?.getCapabilities());
+  const [serverInfo, setServerInfo] = useState<Implementation | undefined>(
+    inspectorClient?.getServerInfo(),
+  );
+  const [instructions, setInstructions] = useState<string | undefined>(
+    inspectorClient?.getInstructions(),
+  );
+
+  useEffect(() => {
+    if (!inspectorClient) {
+      setStatus("disconnected");
+      setCapabilities(undefined);
+      setServerInfo(undefined);
+      setInstructions(undefined);
+      return;
+    }
+
+    setStatus(inspectorClient.getStatus());
+    setCapabilities(inspectorClient.getCapabilities());
+    setServerInfo(inspectorClient.getServerInfo());
+    setInstructions(inspectorClient.getInstructions());
+
+    const onStatusChange = (event: TypedEvent<"statusChange">) => {
+      setStatus(event.detail);
+    };
+    const onCapabilitiesChange = (event: TypedEvent<"capabilitiesChange">) => {
+      setCapabilities(event.detail);
+    };
+    const onServerInfoChange = (event: TypedEvent<"serverInfoChange">) => {
+      setServerInfo(event.detail);
+    };
+    const onInstructionsChange = (event: TypedEvent<"instructionsChange">) => {
+      setInstructions(event.detail);
+    };
+
+    inspectorClient.addEventListener("statusChange", onStatusChange);
+    inspectorClient.addEventListener(
+      "capabilitiesChange",
+      onCapabilitiesChange,
+    );
+    inspectorClient.addEventListener("serverInfoChange", onServerInfoChange);
+    inspectorClient.addEventListener(
+      "instructionsChange",
+      onInstructionsChange,
+    );
+
+    return () => {
+      inspectorClient.removeEventListener("statusChange", onStatusChange);
+      inspectorClient.removeEventListener(
+        "capabilitiesChange",
+        onCapabilitiesChange,
+      );
+      inspectorClient.removeEventListener(
+        "serverInfoChange",
+        onServerInfoChange,
+      );
+      inspectorClient.removeEventListener(
+        "instructionsChange",
+        onInstructionsChange,
+      );
+    };
+  }, [inspectorClient]);
+
+  const connect = useCallback(async () => {
+    if (!inspectorClient) return;
+    await inspectorClient.connect();
+  }, [inspectorClient]);
+
+  const disconnect = useCallback(async () => {
+    if (!inspectorClient) return;
+    await inspectorClient.disconnect();
+  }, [inspectorClient]);
+
+  return {
+    status,
+    capabilities,
+    serverInfo,
+    instructions,
+    appRendererClient: inspectorClient?.getAppRendererClient() ?? null,
+    connect,
+    disconnect,
+  };
+}

--- a/core/react/useManagedPrompts.ts
+++ b/core/react/useManagedPrompts.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect, useCallback } from "react";
+import type { InspectorClientProtocol } from "../mcp/inspectorClientProtocol.js";
+import type {
+  ManagedPromptsState,
+  ManagedPromptsStateEventMap,
+} from "../mcp/state/managedPromptsState.js";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UseManagedPromptsResult {
+  prompts: Prompt[];
+  refresh: () => Promise<Prompt[]>;
+}
+
+/**
+ * React hook that subscribes to ManagedPromptsState and returns prompts + refresh.
+ */
+export function useManagedPrompts(
+  client: InspectorClientProtocol | null,
+  managedPromptsState: ManagedPromptsState | null,
+): UseManagedPromptsResult {
+  const [prompts, setPrompts] = useState<Prompt[]>(
+    managedPromptsState?.getPrompts() ?? [],
+  );
+
+  useEffect(() => {
+    if (!managedPromptsState) {
+      setPrompts([]);
+      return;
+    }
+    setPrompts(managedPromptsState.getPrompts());
+    const onPromptsChange = (
+      event: TypedEventGeneric<ManagedPromptsStateEventMap, "promptsChange">,
+    ) => {
+      setPrompts(event.detail);
+    };
+    managedPromptsState.addEventListener("promptsChange", onPromptsChange);
+    return () => {
+      managedPromptsState.removeEventListener(
+        "promptsChange",
+        onPromptsChange,
+      );
+    };
+  }, [managedPromptsState]);
+
+  const refresh = useCallback(async (): Promise<Prompt[]> => {
+    if (!managedPromptsState || !client) return [];
+    const next = await managedPromptsState.refresh();
+    setPrompts(next);
+    return next;
+  }, [client, managedPromptsState]);
+
+  return { prompts, refresh };
+}

--- a/core/react/useManagedRequestorTasks.ts
+++ b/core/react/useManagedRequestorTasks.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useCallback } from "react";
+import type { InspectorClientProtocol } from "../mcp/inspectorClientProtocol.js";
+import type {
+  ManagedRequestorTasksState,
+  ManagedRequestorTasksStateEventMap,
+} from "../mcp/state/managedRequestorTasksState.js";
+import type { Task } from "@modelcontextprotocol/sdk/types.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UseManagedRequestorTasksResult {
+  tasks: Task[];
+  refresh: () => Promise<Task[]>;
+}
+
+/**
+ * React hook that subscribes to ManagedRequestorTasksState and returns
+ * requestor tasks + refresh.
+ */
+export function useManagedRequestorTasks(
+  client: InspectorClientProtocol | null,
+  managedRequestorTasksState: ManagedRequestorTasksState | null,
+): UseManagedRequestorTasksResult {
+  const [tasks, setTasks] = useState<Task[]>(
+    managedRequestorTasksState?.getTasks() ?? [],
+  );
+
+  useEffect(() => {
+    if (!managedRequestorTasksState) {
+      setTasks([]);
+      return;
+    }
+    setTasks(managedRequestorTasksState.getTasks());
+    const onTasksChange = (
+      event: TypedEventGeneric<
+        ManagedRequestorTasksStateEventMap,
+        "tasksChange"
+      >,
+    ) => {
+      setTasks(event.detail);
+    };
+    managedRequestorTasksState.addEventListener("tasksChange", onTasksChange);
+    return () => {
+      managedRequestorTasksState.removeEventListener(
+        "tasksChange",
+        onTasksChange,
+      );
+    };
+  }, [managedRequestorTasksState]);
+
+  const refresh = useCallback(async (): Promise<Task[]> => {
+    if (!managedRequestorTasksState || !client) return [];
+    const next = await managedRequestorTasksState.refresh();
+    setTasks(next);
+    return next;
+  }, [client, managedRequestorTasksState]);
+
+  return { tasks, refresh };
+}

--- a/core/react/useManagedResourceTemplates.ts
+++ b/core/react/useManagedResourceTemplates.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect, useCallback } from "react";
+import type { InspectorClientProtocol } from "../mcp/inspectorClientProtocol.js";
+import type {
+  ManagedResourceTemplatesState,
+  ManagedResourceTemplatesStateEventMap,
+} from "../mcp/state/managedResourceTemplatesState.js";
+import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UseManagedResourceTemplatesResult {
+  resourceTemplates: ResourceTemplate[];
+  refresh: () => Promise<ResourceTemplate[]>;
+}
+
+/**
+ * React hook that subscribes to ManagedResourceTemplatesState and returns
+ * resource templates + refresh.
+ */
+export function useManagedResourceTemplates(
+  client: InspectorClientProtocol | null,
+  managedResourceTemplatesState: ManagedResourceTemplatesState | null,
+): UseManagedResourceTemplatesResult {
+  const [resourceTemplates, setResourceTemplates] = useState<
+    ResourceTemplate[]
+  >(managedResourceTemplatesState?.getResourceTemplates() ?? []);
+
+  useEffect(() => {
+    if (!managedResourceTemplatesState) {
+      setResourceTemplates([]);
+      return;
+    }
+    setResourceTemplates(managedResourceTemplatesState.getResourceTemplates());
+    const onResourceTemplatesChange = (
+      event: TypedEventGeneric<
+        ManagedResourceTemplatesStateEventMap,
+        "resourceTemplatesChange"
+      >,
+    ) => {
+      setResourceTemplates(event.detail);
+    };
+    managedResourceTemplatesState.addEventListener(
+      "resourceTemplatesChange",
+      onResourceTemplatesChange,
+    );
+    return () => {
+      managedResourceTemplatesState.removeEventListener(
+        "resourceTemplatesChange",
+        onResourceTemplatesChange,
+      );
+    };
+  }, [managedResourceTemplatesState]);
+
+  const refresh = useCallback(async (): Promise<ResourceTemplate[]> => {
+    if (!managedResourceTemplatesState || !client) return [];
+    const next = await managedResourceTemplatesState.refresh();
+    setResourceTemplates(next);
+    return next;
+  }, [client, managedResourceTemplatesState]);
+
+  return { resourceTemplates, refresh };
+}

--- a/core/react/useManagedResources.ts
+++ b/core/react/useManagedResources.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useCallback } from "react";
+import type { InspectorClientProtocol } from "../mcp/inspectorClientProtocol.js";
+import type {
+  ManagedResourcesState,
+  ManagedResourcesStateEventMap,
+} from "../mcp/state/managedResourcesState.js";
+import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UseManagedResourcesResult {
+  resources: Resource[];
+  refresh: () => Promise<Resource[]>;
+}
+
+/**
+ * React hook that subscribes to ManagedResourcesState and returns resources + refresh.
+ */
+export function useManagedResources(
+  client: InspectorClientProtocol | null,
+  managedResourcesState: ManagedResourcesState | null,
+): UseManagedResourcesResult {
+  const [resources, setResources] = useState<Resource[]>(
+    managedResourcesState?.getResources() ?? [],
+  );
+
+  useEffect(() => {
+    if (!managedResourcesState) {
+      setResources([]);
+      return;
+    }
+    setResources(managedResourcesState.getResources());
+    const onResourcesChange = (
+      event: TypedEventGeneric<
+        ManagedResourcesStateEventMap,
+        "resourcesChange"
+      >,
+    ) => {
+      setResources(event.detail);
+    };
+    managedResourcesState.addEventListener(
+      "resourcesChange",
+      onResourcesChange,
+    );
+    return () => {
+      managedResourcesState.removeEventListener(
+        "resourcesChange",
+        onResourcesChange,
+      );
+    };
+  }, [managedResourcesState]);
+
+  const refresh = useCallback(async (): Promise<Resource[]> => {
+    if (!managedResourcesState || !client) return [];
+    const next = await managedResourcesState.refresh();
+    setResources(next);
+    return next;
+  }, [client, managedResourcesState]);
+
+  return { resources, refresh };
+}

--- a/core/react/useManagedTools.ts
+++ b/core/react/useManagedTools.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect, useCallback } from "react";
+import type { InspectorClientProtocol } from "../mcp/inspectorClientProtocol.js";
+import type { ManagedToolsState } from "../mcp/state/managedToolsState.js";
+import type { ManagedToolsStateEventMap } from "../mcp/state/managedToolsState.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UseManagedToolsResult {
+  tools: Tool[];
+  refresh: () => Promise<Tool[]>;
+}
+
+/**
+ * React hook that subscribes to ManagedToolsState and returns tools + refresh.
+ */
+export function useManagedTools(
+  client: InspectorClientProtocol | null,
+  managedToolsState: ManagedToolsState | null,
+): UseManagedToolsResult {
+  const [tools, setTools] = useState<Tool[]>(
+    managedToolsState?.getTools() ?? [],
+  );
+
+  useEffect(() => {
+    if (!managedToolsState) {
+      setTools([]);
+      return;
+    }
+    setTools(managedToolsState.getTools());
+    const onToolsChange = (
+      event: TypedEventGeneric<ManagedToolsStateEventMap, "toolsChange">,
+    ) => {
+      setTools(event.detail);
+    };
+    managedToolsState.addEventListener("toolsChange", onToolsChange);
+    return () => {
+      managedToolsState.removeEventListener("toolsChange", onToolsChange);
+    };
+  }, [managedToolsState]);
+
+  const refresh = useCallback(async (): Promise<Tool[]> => {
+    if (!managedToolsState || !client) return [];
+    const next = await managedToolsState.refresh();
+    setTools(next);
+    return next;
+  }, [client, managedToolsState]);
+
+  return { tools, refresh };
+}

--- a/core/react/useMessageLog.ts
+++ b/core/react/useMessageLog.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect } from "react";
+import type { MessageEntry } from "../mcp/types.js";
+import type {
+  MessageLogState,
+  MessageLogStateEventMap,
+} from "../mcp/state/messageLogState.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UseMessageLogResult {
+  messages: MessageEntry[];
+}
+
+/**
+ * React hook that subscribes to MessageLogState and returns the message list.
+ */
+export function useMessageLog(
+  messageLogState: MessageLogState | null,
+): UseMessageLogResult {
+  const [messages, setMessages] = useState<MessageEntry[]>(
+    messageLogState?.getMessages() ?? [],
+  );
+
+  useEffect(() => {
+    if (!messageLogState) {
+      setMessages([]);
+      return;
+    }
+    setMessages(messageLogState.getMessages());
+    const onMessagesChange = (
+      event: TypedEventGeneric<MessageLogStateEventMap, "messagesChange">,
+    ) => {
+      setMessages(event.detail);
+    };
+    messageLogState.addEventListener("messagesChange", onMessagesChange);
+    return () => {
+      messageLogState.removeEventListener("messagesChange", onMessagesChange);
+    };
+  }, [messageLogState]);
+
+  return { messages };
+}

--- a/core/react/usePagedPrompts.ts
+++ b/core/react/usePagedPrompts.ts
@@ -1,0 +1,68 @@
+import { useState, useEffect, useCallback } from "react";
+import type { InspectorClientProtocol } from "../mcp/inspectorClientProtocol.js";
+import type {
+  PagedPromptsState,
+  PagedPromptsStateEventMap,
+  LoadPageResult,
+} from "../mcp/state/pagedPromptsState.js";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UsePagedPromptsResult {
+  prompts: Prompt[];
+  loadPage: (
+    cursor?: string,
+    metadata?: Record<string, string>,
+  ) => Promise<LoadPageResult>;
+  clear: () => void;
+}
+
+/**
+ * React hook that subscribes to PagedPromptsState and returns prompts + loadPage.
+ */
+export function usePagedPrompts(
+  client: InspectorClientProtocol | null,
+  pagedPromptsState: PagedPromptsState | null,
+): UsePagedPromptsResult {
+  const [prompts, setPrompts] = useState<Prompt[]>(
+    pagedPromptsState?.getPrompts() ?? [],
+  );
+
+  useEffect(() => {
+    if (!pagedPromptsState) {
+      setPrompts([]);
+      return;
+    }
+    setPrompts(pagedPromptsState.getPrompts());
+    const onPromptsChange = (
+      event: TypedEventGeneric<PagedPromptsStateEventMap, "promptsChange">,
+    ) => {
+      setPrompts(event.detail);
+    };
+    pagedPromptsState.addEventListener("promptsChange", onPromptsChange);
+    return () => {
+      pagedPromptsState.removeEventListener("promptsChange", onPromptsChange);
+    };
+  }, [pagedPromptsState]);
+
+  const loadPage = useCallback(
+    async (
+      cursor?: string,
+      metadata?: Record<string, string>,
+    ): Promise<LoadPageResult> => {
+      if (!pagedPromptsState || !client) {
+        return { prompts: [], nextCursor: undefined };
+      }
+      const result = await pagedPromptsState.loadPage(cursor, metadata);
+      setPrompts(pagedPromptsState.getPrompts());
+      return result;
+    },
+    [client, pagedPromptsState],
+  );
+
+  const clear = useCallback(() => {
+    pagedPromptsState?.clear();
+  }, [pagedPromptsState]);
+
+  return { prompts, loadPage, clear };
+}

--- a/core/react/usePagedRequestorTasks.ts
+++ b/core/react/usePagedRequestorTasks.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect, useCallback } from "react";
+import type { InspectorClientProtocol } from "../mcp/inspectorClientProtocol.js";
+import type {
+  PagedRequestorTasksState,
+  PagedRequestorTasksStateEventMap,
+  LoadPageResult,
+} from "../mcp/state/pagedRequestorTasksState.js";
+import type { Task } from "@modelcontextprotocol/sdk/types.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UsePagedRequestorTasksResult {
+  tasks: Task[];
+  loadPage: (cursor?: string) => Promise<LoadPageResult>;
+  clear: () => void;
+  nextCursor: string | undefined;
+}
+
+/**
+ * React hook that subscribes to PagedRequestorTasksState and returns tasks,
+ * loadPage, clear, and nextCursor.
+ */
+export function usePagedRequestorTasks(
+  client: InspectorClientProtocol | null,
+  pagedRequestorTasksState: PagedRequestorTasksState | null,
+): UsePagedRequestorTasksResult {
+  const [tasks, setTasks] = useState<Task[]>(
+    pagedRequestorTasksState?.getTasks() ?? [],
+  );
+  const [nextCursor, setNextCursor] = useState<string | undefined>(
+    pagedRequestorTasksState?.getNextCursor() ?? undefined,
+  );
+
+  useEffect(() => {
+    if (!pagedRequestorTasksState) {
+      setTasks([]);
+      setNextCursor(undefined);
+      return;
+    }
+    setTasks(pagedRequestorTasksState.getTasks());
+    setNextCursor(pagedRequestorTasksState.getNextCursor() ?? undefined);
+    const onTasksChange = (
+      event: TypedEventGeneric<
+        PagedRequestorTasksStateEventMap,
+        "tasksChange"
+      >,
+    ) => {
+      setTasks(event.detail);
+      setNextCursor(pagedRequestorTasksState.getNextCursor() ?? undefined);
+    };
+    pagedRequestorTasksState.addEventListener("tasksChange", onTasksChange);
+    return () => {
+      pagedRequestorTasksState.removeEventListener(
+        "tasksChange",
+        onTasksChange,
+      );
+    };
+  }, [pagedRequestorTasksState]);
+
+  const loadPage = useCallback(
+    async (cursor?: string): Promise<LoadPageResult> => {
+      if (!pagedRequestorTasksState || !client) {
+        return { tasks: [], nextCursor: undefined };
+      }
+      const result = await pagedRequestorTasksState.loadPage(cursor);
+      setTasks(pagedRequestorTasksState.getTasks());
+      setNextCursor(pagedRequestorTasksState.getNextCursor() ?? undefined);
+      return result;
+    },
+    [client, pagedRequestorTasksState],
+  );
+
+  const clear = useCallback(() => {
+    pagedRequestorTasksState?.clear();
+  }, [pagedRequestorTasksState]);
+
+  return { tasks, loadPage, clear, nextCursor };
+}

--- a/core/react/usePagedResourceTemplates.ts
+++ b/core/react/usePagedResourceTemplates.ts
@@ -1,0 +1,81 @@
+import { useState, useEffect, useCallback } from "react";
+import type { InspectorClientProtocol } from "../mcp/inspectorClientProtocol.js";
+import type {
+  PagedResourceTemplatesState,
+  PagedResourceTemplatesStateEventMap,
+  LoadPageResult,
+} from "../mcp/state/pagedResourceTemplatesState.js";
+import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UsePagedResourceTemplatesResult {
+  resourceTemplates: ResourceTemplate[];
+  loadPage: (
+    cursor?: string,
+    metadata?: Record<string, string>,
+  ) => Promise<LoadPageResult>;
+  clear: () => void;
+}
+
+/**
+ * React hook that subscribes to PagedResourceTemplatesState and returns
+ * resource templates + loadPage.
+ */
+export function usePagedResourceTemplates(
+  client: InspectorClientProtocol | null,
+  pagedResourceTemplatesState: PagedResourceTemplatesState | null,
+): UsePagedResourceTemplatesResult {
+  const [resourceTemplates, setResourceTemplates] = useState<
+    ResourceTemplate[]
+  >(pagedResourceTemplatesState?.getResourceTemplates() ?? []);
+
+  useEffect(() => {
+    if (!pagedResourceTemplatesState) {
+      setResourceTemplates([]);
+      return;
+    }
+    setResourceTemplates(pagedResourceTemplatesState.getResourceTemplates());
+    const onResourceTemplatesChange = (
+      event: TypedEventGeneric<
+        PagedResourceTemplatesStateEventMap,
+        "resourceTemplatesChange"
+      >,
+    ) => {
+      setResourceTemplates(event.detail);
+    };
+    pagedResourceTemplatesState.addEventListener(
+      "resourceTemplatesChange",
+      onResourceTemplatesChange,
+    );
+    return () => {
+      pagedResourceTemplatesState.removeEventListener(
+        "resourceTemplatesChange",
+        onResourceTemplatesChange,
+      );
+    };
+  }, [pagedResourceTemplatesState]);
+
+  const loadPage = useCallback(
+    async (
+      cursor?: string,
+      metadata?: Record<string, string>,
+    ): Promise<LoadPageResult> => {
+      if (!pagedResourceTemplatesState || !client) {
+        return { resourceTemplates: [], nextCursor: undefined };
+      }
+      const result = await pagedResourceTemplatesState.loadPage(
+        cursor,
+        metadata,
+      );
+      setResourceTemplates(pagedResourceTemplatesState.getResourceTemplates());
+      return result;
+    },
+    [client, pagedResourceTemplatesState],
+  );
+
+  const clear = useCallback(() => {
+    pagedResourceTemplatesState?.clear();
+  }, [pagedResourceTemplatesState]);
+
+  return { resourceTemplates, loadPage, clear };
+}

--- a/core/react/usePagedResources.ts
+++ b/core/react/usePagedResources.ts
@@ -1,0 +1,71 @@
+import { useState, useEffect, useCallback } from "react";
+import type { InspectorClientProtocol } from "../mcp/inspectorClientProtocol.js";
+import type {
+  PagedResourcesState,
+  PagedResourcesStateEventMap,
+  LoadPageResult,
+} from "../mcp/state/pagedResourcesState.js";
+import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UsePagedResourcesResult {
+  resources: Resource[];
+  loadPage: (
+    cursor?: string,
+    metadata?: Record<string, string>,
+  ) => Promise<LoadPageResult>;
+  clear: () => void;
+}
+
+/**
+ * React hook that subscribes to PagedResourcesState and returns resources + loadPage.
+ */
+export function usePagedResources(
+  client: InspectorClientProtocol | null,
+  pagedResourcesState: PagedResourcesState | null,
+): UsePagedResourcesResult {
+  const [resources, setResources] = useState<Resource[]>(
+    pagedResourcesState?.getResources() ?? [],
+  );
+
+  useEffect(() => {
+    if (!pagedResourcesState) {
+      setResources([]);
+      return;
+    }
+    setResources(pagedResourcesState.getResources());
+    const onResourcesChange = (
+      event: TypedEventGeneric<PagedResourcesStateEventMap, "resourcesChange">,
+    ) => {
+      setResources(event.detail);
+    };
+    pagedResourcesState.addEventListener("resourcesChange", onResourcesChange);
+    return () => {
+      pagedResourcesState.removeEventListener(
+        "resourcesChange",
+        onResourcesChange,
+      );
+    };
+  }, [pagedResourcesState]);
+
+  const loadPage = useCallback(
+    async (
+      cursor?: string,
+      metadata?: Record<string, string>,
+    ): Promise<LoadPageResult> => {
+      if (!pagedResourcesState || !client) {
+        return { resources: [], nextCursor: undefined };
+      }
+      const result = await pagedResourcesState.loadPage(cursor, metadata);
+      setResources(pagedResourcesState.getResources());
+      return result;
+    },
+    [client, pagedResourcesState],
+  );
+
+  const clear = useCallback(() => {
+    pagedResourcesState?.clear();
+  }, [pagedResourcesState]);
+
+  return { resources, loadPage, clear };
+}

--- a/core/react/usePagedTools.ts
+++ b/core/react/usePagedTools.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect, useCallback } from "react";
+import type { InspectorClientProtocol } from "../mcp/inspectorClientProtocol.js";
+import type {
+  PagedToolsState,
+  PagedToolsStateEventMap,
+  LoadPageResult,
+} from "../mcp/state/pagedToolsState.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UsePagedToolsResult {
+  tools: Tool[];
+  loadPage: (cursor?: string) => Promise<LoadPageResult>;
+  clear: () => void;
+}
+
+/**
+ * React hook that subscribes to PagedToolsState and returns tools + loadPage.
+ */
+export function usePagedTools(
+  client: InspectorClientProtocol | null,
+  pagedToolsState: PagedToolsState | null,
+): UsePagedToolsResult {
+  const [tools, setTools] = useState<Tool[]>(
+    pagedToolsState?.getTools() ?? [],
+  );
+
+  useEffect(() => {
+    if (!pagedToolsState) {
+      setTools([]);
+      return;
+    }
+    setTools(pagedToolsState.getTools());
+    const onToolsChange = (
+      event: TypedEventGeneric<PagedToolsStateEventMap, "toolsChange">,
+    ) => {
+      setTools(event.detail);
+    };
+    pagedToolsState.addEventListener("toolsChange", onToolsChange);
+    return () => {
+      pagedToolsState.removeEventListener("toolsChange", onToolsChange);
+    };
+  }, [pagedToolsState]);
+
+  const loadPage = useCallback(
+    async (cursor?: string): Promise<LoadPageResult> => {
+      if (!pagedToolsState || !client) {
+        return { tools: [], nextCursor: undefined };
+      }
+      const result = await pagedToolsState.loadPage(cursor);
+      setTools(pagedToolsState.getTools());
+      return result;
+    },
+    [client, pagedToolsState],
+  );
+
+  const clear = useCallback(() => {
+    pagedToolsState?.clear();
+  }, [pagedToolsState]);
+
+  return { tools, loadPage, clear };
+}

--- a/core/react/useStderrLog.ts
+++ b/core/react/useStderrLog.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+import type { StderrLogEntry } from "../mcp/types.js";
+import type {
+  StderrLogState,
+  StderrLogStateEventMap,
+} from "../mcp/state/stderrLogState.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+export interface UseStderrLogResult {
+  stderrLogs: StderrLogEntry[];
+}
+
+/**
+ * React hook that subscribes to StderrLogState and returns the stderr log list.
+ */
+export function useStderrLog(
+  stderrLogState: StderrLogState | null,
+): UseStderrLogResult {
+  const [stderrLogs, setStderrLogs] = useState<StderrLogEntry[]>(
+    stderrLogState?.getStderrLogs() ?? [],
+  );
+
+  useEffect(() => {
+    if (!stderrLogState) {
+      setStderrLogs([]);
+      return;
+    }
+    setStderrLogs(stderrLogState.getStderrLogs());
+    const onStderrLogsChange = (
+      event: TypedEventGeneric<StderrLogStateEventMap, "stderrLogsChange">,
+    ) => {
+      setStderrLogs(event.detail);
+    };
+    stderrLogState.addEventListener("stderrLogsChange", onStderrLogsChange);
+    return () => {
+      stderrLogState.removeEventListener(
+        "stderrLogsChange",
+        onStderrLogsChange,
+      );
+    };
+  }, [stderrLogState]);
+
+  return { stderrLogs };
+}


### PR DESCRIPTION
## Summary

Wholesale port of v1.5's React hook layer and the EventTarget-based state machinery the hooks subscribe to. Closes #1243.

- 14 hooks under `core/react/` (useInspectorClient, 5 useManaged*, 5 usePaged*, useMessageLog/useStderrLog/useFetchRequestLog)
- 13 state stores under `core/mcp/state/` (5 managed*, 5 paged*, messageLog, stderrLog, fetchRequestLog)
- Hooks decouple from the concrete `InspectorClient` via a new `InspectorClientProtocol` interface so this layer can land before the runtime class is ported
- v2-only wrapper types added to `core/mcp/types.ts`: `InspectorUrlElicitRequest`, `InspectorPendingRequest`, `InspectorRequestHistoryItem`
- 28 new test files, 264 new tests; full suite at 935 unit tests + 298 storybook tests passing
- Build wiring: `vite.config.ts` dedupes react/react-dom; `tsconfig.app.json`/`tsconfig.test.json` map react/react-dom/vitest to `clients/web/node_modules` so `tsc -b` can resolve bare imports from `core/` source files

## Acceptance criteria status (from #1243)

- [x] All hooks exist under `core/react/` and return the documented shape
- [x] All state modules exist under `core/mcp/state/` using the `EventTarget` subscription pattern
- [x] InspectorClient surface added to `core/mcp/inspectorClientProtocol.ts` + `core/mcp/inspectorClientEventTarget.ts`
- [x] Three v2-only wrapper types added to `core/mcp/types.ts`
- [x] No component-layer changes — `InspectorView` and friends are untouched
- [x] Per-hook unit tests for initial state, subscription wiring, refresh, cleanup
- [x] State module tests for event emission, subscriber notification, list mutation
- [x] `npm run validate` clean

## Known gaps / follow-ups

- **Coverage glob doesn't reach `core/`.** `vite.config.ts` already had `'../../core/mcp/**/*.{ts,tsx}'` in `coverage.include`, but `coverage-summary.json` shows v8 never reports per-file coverage for any file outside `clients/web/src/`. This means the per-file 90% gate from AGENTS.md is not enforced on `core/` files — applies to `core/mcp/apps.ts` and `core/mcp/taskNotificationSchemas.ts` from earlier work, and to all new files in this PR. Tests exist and pass; the gate just doesn't check them. Worth a separate ticket to fix the v8 path resolution.
- **`InspectorClient` runtime class is still not ported.** This PR delivers the protocol surface and the layer that depends on it. The concrete class (~2k LOC) requires porting the v1.5 auth subsystem first and is its own issue.

## Test plan

- [x] `npm run validate` (format, lint, build, test:coverage) — 100 unit test files / 935 tests pass
- [x] `npm run test:storybook` — 67 story files / 298 tests pass
- [x] Existing InspectorView Storybook fixtures still render (no component changes; should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)