### PR TITLE
feat(client): revoke OAuth tokens on Disconnect (RFC 7009)

### DIFF
--- a/client/src/lib/__tests__/auth.test.ts
+++ b/client/src/lib/__tests__/auth.test.ts
@@ -1,5 +1,6 @@
-import { discoverScopes } from "../auth";
+import { discoverScopes, revokeTokens } from "../auth";
 import { discoverAuthorizationServerMetadata } from "@modelcontextprotocol/sdk/client/auth.js";
+import { SESSION_KEYS, getServerSpecificKey } from "../constants";
 
 jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
   discoverAuthorizationServerMetadata: jest.fn(),
@@ -155,4 +156,184 @@ describe("discoverScopes", () => {
       expect(result).toBeUndefined();
     },
   );
+});
+
+describe("revokeTokens", () => {
+  const serverUrl = "https://example.com";
+  const revocationEndpoint = "https://test.com/revoke";
+  const metadataWithRevocation = {
+    ...baseMetadata,
+    revocation_endpoint: revocationEndpoint,
+  };
+
+  const seedTokens = (tokens: {
+    access_token: string;
+    token_type?: string;
+    refresh_token?: string;
+  }) => {
+    sessionStorage.setItem(
+      getServerSpecificKey(SESSION_KEYS.TOKENS, serverUrl),
+      JSON.stringify({ token_type: "Bearer", ...tokens }),
+    );
+  };
+
+  const seedClientInfo = (
+    client_id: string,
+    { isPreregistered = false } = {},
+  ) => {
+    const key = getServerSpecificKey(
+      isPreregistered
+        ? SESSION_KEYS.PREREGISTERED_CLIENT_INFORMATION
+        : SESSION_KEYS.CLIENT_INFORMATION,
+      serverUrl,
+    );
+    sessionStorage.setItem(key, JSON.stringify({ client_id }));
+  };
+
+  const parseRevokeBody = (call: [unknown, RequestInit | undefined]) => {
+    const init = call[1];
+    return new URLSearchParams(init?.body as string);
+  };
+
+  let warnSpy: jest.SpyInstance;
+  let debugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it("posts refresh_token to revocation_endpoint when available, includes client_id", async () => {
+    mockDiscoverAuth.mockResolvedValue(metadataWithRevocation);
+    seedTokens({ access_token: "at-123", refresh_token: "rt-456" });
+    seedClientInfo("client-xyz");
+    const fetchFn = jest
+      .fn<Promise<Response>, [RequestInfo | URL, RequestInit?]>()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    await revokeTokens({ serverUrl, fetchFn });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe(revocationEndpoint);
+    expect(init?.method).toBe("POST");
+    expect((init?.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    const body = parseRevokeBody(fetchFn.mock.calls[0]);
+    expect(body.get("token")).toBe("rt-456");
+    expect(body.get("token_type_hint")).toBe("refresh_token");
+    expect(body.get("client_id")).toBe("client-xyz");
+  });
+
+  it("prefers preregistered client_id over dynamic", async () => {
+    mockDiscoverAuth.mockResolvedValue(metadataWithRevocation);
+    seedTokens({ access_token: "at-123", refresh_token: "rt-456" });
+    seedClientInfo("dynamic-client");
+    seedClientInfo("preregistered-client", { isPreregistered: true });
+    const fetchFn = jest
+      .fn<Promise<Response>, [RequestInfo | URL, RequestInit?]>()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    await revokeTokens({ serverUrl, fetchFn });
+
+    const body = parseRevokeBody(fetchFn.mock.calls[0]);
+    expect(body.get("client_id")).toBe("preregistered-client");
+  });
+
+  it("falls back to access_token when no refresh_token is present", async () => {
+    mockDiscoverAuth.mockResolvedValue(metadataWithRevocation);
+    seedTokens({ access_token: "at-only" });
+    const fetchFn = jest
+      .fn<Promise<Response>, [RequestInfo | URL, RequestInit?]>()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    await revokeTokens({ serverUrl, fetchFn });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const body = parseRevokeBody(fetchFn.mock.calls[0]);
+    expect(body.get("token")).toBe("at-only");
+    expect(body.get("token_type_hint")).toBe("access_token");
+    expect(body.get("client_id")).toBeNull();
+  });
+
+  it("no-ops when no tokens are stored", async () => {
+    const fetchFn = jest.fn<
+      Promise<Response>,
+      [RequestInfo | URL, RequestInit?]
+    >();
+
+    await revokeTokens({ serverUrl, fetchFn });
+
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(mockDiscoverAuth).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when AS metadata has no revocation_endpoint", async () => {
+    mockDiscoverAuth.mockResolvedValue(baseMetadata);
+    seedTokens({ access_token: "at-123", refresh_token: "rt-456" });
+    const fetchFn = jest.fn<
+      Promise<Response>,
+      [RequestInfo | URL, RequestInit?]
+    >();
+
+    await revokeTokens({ serverUrl, fetchFn });
+
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("swallows fetch rejection and logs a warning", async () => {
+    mockDiscoverAuth.mockResolvedValue(metadataWithRevocation);
+    seedTokens({ access_token: "at-123", refresh_token: "rt-456" });
+    const fetchFn = jest
+      .fn<Promise<Response>, [RequestInfo | URL, RequestInit?]>()
+      .mockRejectedValue(new Error("network down"));
+
+    await expect(revokeTokens({ serverUrl, fetchFn })).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Token revocation failed (best-effort):",
+      expect.any(Error),
+    );
+  });
+
+  it("treats non-2xx response as a soft failure without throwing", async () => {
+    mockDiscoverAuth.mockResolvedValue(metadataWithRevocation);
+    seedTokens({ access_token: "at-123", refresh_token: "rt-456" });
+    const fetchFn = jest
+      .fn<Promise<Response>, [RequestInfo | URL, RequestInit?]>()
+      .mockResolvedValue(
+        new Response("nope", { status: 400, statusText: "Bad Request" }),
+      );
+
+    await expect(revokeTokens({ serverUrl, fetchFn })).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Token revocation responded 400"),
+    );
+  });
+
+  it("uses the provided fetchFn, not the global fetch", async () => {
+    mockDiscoverAuth.mockResolvedValue(metadataWithRevocation);
+    seedTokens({ access_token: "at-123", refresh_token: "rt-456" });
+    const globalFetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const fetchFn = jest
+      .fn<Promise<Response>, [RequestInfo | URL, RequestInit?]>()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    try {
+      await revokeTokens({ serverUrl, fetchFn });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      expect(globalFetchSpy).not.toHaveBeenCalled();
+    } finally {
+      globalFetchSpy.mockRestore();
+    }
+  });
 });

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -129,6 +129,92 @@ export const clearScopeFromSessionStorage = (serverUrl: string) => {
   sessionStorage.removeItem(key);
 };
 
+/**
+ * Best-effort RFC 7009 token revocation. Called on user-initiated disconnect so
+ * the authorization server can invalidate the access/refresh token rather than
+ * waiting for natural expiry. Per RFC 7009 §2.1, revoking a refresh token also
+ * invalidates associated access tokens, so we prefer the refresh token when
+ * present and fall back to the access token otherwise.
+ *
+ * Never throws: if there are no saved tokens, no advertised revocation_endpoint,
+ * or the POST fails for any reason, this resolves quietly. A 3s timeout keeps a
+ * slow AS from blocking the UI.
+ */
+export const revokeTokens = async ({
+  serverUrl,
+  fetchFn,
+}: {
+  serverUrl: string;
+  fetchFn?: typeof fetch;
+}): Promise<void> => {
+  try {
+    const tokensRaw = sessionStorage.getItem(
+      getServerSpecificKey(SESSION_KEYS.TOKENS, serverUrl),
+    );
+    if (!tokensRaw) {
+      return;
+    }
+    const tokens = await OAuthTokensSchema.parseAsync(JSON.parse(tokensRaw));
+
+    const metadata = await discoverAuthorizationServerMetadata(
+      new URL("/", serverUrl),
+      { fetchFn },
+    );
+    // `revocation_endpoint` is declared on OAuthMetadata but not on the OIDC
+    // branch of the union, even though OIDC providers may advertise it at
+    // runtime per RFC 8414. Narrow with `in` so we read it from either shape.
+    const revocationEndpoint =
+      metadata && "revocation_endpoint" in metadata
+        ? (metadata as { revocation_endpoint?: string }).revocation_endpoint
+        : undefined;
+    if (!revocationEndpoint) {
+      return;
+    }
+
+    const token = tokens.refresh_token ?? tokens.access_token;
+    const tokenTypeHint = tokens.refresh_token
+      ? "refresh_token"
+      : "access_token";
+
+    const body = new URLSearchParams();
+    body.set("token", token);
+    body.set("token_type_hint", tokenTypeHint);
+
+    // Public-client convention: include client_id in the form body. Try
+    // preregistered first, then dynamically registered (same priority as
+    // InspectorOAuthClientProvider.clientInformation()).
+    const clientInfo =
+      (await getClientInformationFromSessionStorage({
+        serverUrl,
+        isPreregistered: true,
+      })) ??
+      (await getClientInformationFromSessionStorage({
+        serverUrl,
+        isPreregistered: false,
+      }));
+    if (clientInfo?.client_id) {
+      body.set("client_id", clientInfo.client_id);
+    }
+
+    const response = await (fetchFn ?? fetch)(revocationEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+      signal: AbortSignal.timeout(3000),
+    });
+
+    if (!response.ok) {
+      console.warn(
+        `Token revocation responded ${response.status} ${response.statusText} (best-effort, continuing)`,
+      );
+      return;
+    }
+    console.debug("Token revocation succeeded");
+  } catch (error) {
+    console.warn("Token revocation failed (best-effort):", error);
+  }
+};
+
 export class InspectorOAuthClientProvider implements OAuthClientProvider {
   constructor(protected serverUrl: string) {
     // Save the server URL to session storage

--- a/client/src/lib/configurationTypes.ts
+++ b/client/src/lib/configurationTypes.ts
@@ -45,4 +45,12 @@ export type InspectorConfig = {
    * Default Time-to-Live (TTL) in milliseconds for newly created tasks.
    */
   MCP_TASK_TTL: ConfigItem;
+
+  /**
+   * Whether to send an RFC 7009 token revocation request to the authorization server
+   * on Disconnect (when the server advertises a `revocation_endpoint`). Default `true`
+   * (spec-compliant). Disable to test server behavior when a client disconnects
+   * without revoking, or to suppress the network call during offline testing.
+   */
+  MCP_OAUTH_REVOKE_ON_DISCONNECT: ConfigItem;
 };

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -92,4 +92,11 @@ export const DEFAULT_INSPECTOR_CONFIG: InspectorConfig = {
     value: 60000,
     is_session_item: false,
   },
+  MCP_OAUTH_REVOKE_ON_DISCONNECT: {
+    label: "Revoke OAuth Tokens on Disconnect",
+    description:
+      "When disconnecting, send an RFC 7009 token revocation request to the authorization server before clearing local state. Disable to test how a server behaves when a client disconnects without revoking.",
+    value: true,
+    is_session_item: false,
+  },
 } as const;

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -25,7 +25,7 @@ import {
   ElicitRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
-import { discoverScopes } from "../../auth";
+import { discoverScopes, revokeTokens } from "../../auth";
 import { CustomHeaders } from "../../types/customHeaders";
 
 // Mock fetch
@@ -145,17 +145,22 @@ jest.mock("../../auth", () => ({
   InspectorOAuthClientProvider: jest.fn().mockImplementation(() => ({
     tokens: jest.fn().mockResolvedValue({ access_token: "mock-token" }),
     redirectUrl: "http://localhost:3000/oauth/callback",
+    clear: jest.fn(),
   })),
   clearClientInformationFromSessionStorage: jest.fn(),
   saveClientInformationToSessionStorage: jest.fn(),
   saveScopeToSessionStorage: jest.fn(),
   clearScopeFromSessionStorage: jest.fn(),
   discoverScopes: jest.fn(),
+  revokeTokens: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockAuth = auth as jest.MockedFunction<typeof auth>;
 const mockDiscoverScopes = discoverScopes as jest.MockedFunction<
   typeof discoverScopes
+>;
+const mockRevokeTokens = revokeTokens as jest.MockedFunction<
+  typeof revokeTokens
 >;
 
 describe("useConnection", () => {
@@ -1792,6 +1797,47 @@ describe("useConnection", () => {
       expect(
         mockStreamableHTTPTransport.url?.searchParams.get("proxyFullAddress"),
       ).toBeNull();
+    });
+  });
+
+  describe("disconnect", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test("revokes tokens (RFC 7009) before clearing local OAuth state", async () => {
+      const { InspectorOAuthClientProvider } = jest.requireMock("../../auth");
+      const providerCtor = InspectorOAuthClientProvider as jest.Mock;
+      providerCtor.mockClear();
+
+      const { result } = renderHook(() => useConnection(defaultProps));
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      await act(async () => {
+        await result.current.disconnect();
+      });
+
+      expect(mockRevokeTokens).toHaveBeenCalledTimes(1);
+      expect(mockRevokeTokens).toHaveBeenCalledWith({
+        serverUrl: defaultProps.sseUrl,
+        fetchFn: expect.any(Function),
+      });
+
+      // disconnect constructs an InspectorOAuthClientProvider just for the
+      // local-clear step; that instance's clear() must have been invoked.
+      const disconnectInstance = providerCtor.mock.results[
+        providerCtor.mock.results.length - 1
+      ].value as { clear: jest.Mock };
+      expect(disconnectInstance.clear).toHaveBeenCalledTimes(1);
+
+      // Revocation must precede the local clear() so we have tokens to send.
+      expect(mockRevokeTokens.mock.invocationCallOrder[0]).toBeLessThan(
+        disconnectInstance.clear.mock.invocationCallOrder[0],
+      );
+
+      expect(result.current.connectionStatus).toBe("disconnected");
     });
   });
 });

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -1839,5 +1839,42 @@ describe("useConnection", () => {
 
       expect(result.current.connectionStatus).toBe("disconnected");
     });
+
+    test("skips revokeTokens when MCP_OAUTH_REVOKE_ON_DISCONNECT is false", async () => {
+      const { InspectorOAuthClientProvider } = jest.requireMock("../../auth");
+      const providerCtor = InspectorOAuthClientProvider as jest.Mock;
+      providerCtor.mockClear();
+
+      const propsWithRevokeDisabled: Parameters<typeof useConnection>[0] = {
+        ...defaultProps,
+        config: {
+          ...DEFAULT_INSPECTOR_CONFIG,
+          MCP_OAUTH_REVOKE_ON_DISCONNECT: {
+            ...DEFAULT_INSPECTOR_CONFIG.MCP_OAUTH_REVOKE_ON_DISCONNECT,
+            value: false,
+          },
+        },
+      };
+
+      const { result } = renderHook(() =>
+        useConnection(propsWithRevokeDisabled),
+      );
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      await act(async () => {
+        await result.current.disconnect();
+      });
+
+      expect(mockRevokeTokens).not.toHaveBeenCalled();
+      // Local clear still runs so the user gets a fresh slate even when
+      // remote revocation is opted out.
+      const disconnectInstance = providerCtor.mock.results[
+        providerCtor.mock.results.length - 1
+      ].value as { clear: jest.Mock };
+      expect(disconnectInstance.clear).toHaveBeenCalledTimes(1);
+      expect(result.current.connectionStatus).toBe("disconnected");
+    });
   });
 });

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -63,6 +63,7 @@ import {
   saveScopeToSessionStorage,
   clearScopeFromSessionStorage,
   discoverScopes,
+  revokeTokens,
 } from "../auth";
 import { createProxyFetch } from "../proxyFetch";
 import {
@@ -1191,6 +1192,11 @@ export function useConnection({
         clientTransport as StreamableHTTPClientTransport
       ).terminateSession();
     await mcpClient?.close();
+    // RFC 7009: revoke tokens at the AS before wiping local state, so the
+    // server doesn't keep a still-valid token around as a tombstone.
+    const fetchFn =
+      connectionType === "proxy" ? createProxyFetch(config) : undefined;
+    await revokeTokens({ serverUrl: sseUrl, fetchFn });
     const authProvider = new InspectorOAuthClientProvider(sseUrl);
     authProvider.clear();
     setMcpClient(null);

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -72,6 +72,7 @@ import {
   getMCPServerRequestMaxTotalTimeout,
   resetRequestTimeoutOnProgress,
   getMCPProxyAuthToken,
+  revokeOAuthTokensOnDisconnect,
 } from "@/utils/configUtils";
 import { getMCPServerRequestTimeout } from "@/utils/configUtils";
 import { InspectorConfig } from "../configurationTypes";
@@ -1193,10 +1194,13 @@ export function useConnection({
       ).terminateSession();
     await mcpClient?.close();
     // RFC 7009: revoke tokens at the AS before wiping local state, so the
-    // server doesn't keep a still-valid token around as a tombstone.
-    const fetchFn =
-      connectionType === "proxy" ? createProxyFetch(config) : undefined;
-    await revokeTokens({ serverUrl: sseUrl, fetchFn });
+    // server doesn't keep a still-valid token around as a tombstone. Users
+    // testing the inverse scenario can opt out via the config toggle.
+    if (revokeOAuthTokensOnDisconnect(config)) {
+      const fetchFn =
+        connectionType === "proxy" ? createProxyFetch(config) : undefined;
+      await revokeTokens({ serverUrl: sseUrl, fetchFn });
+    }
     const authProvider = new InspectorOAuthClientProvider(sseUrl);
     authProvider.clear();
     setMcpClient(null);

--- a/client/src/utils/configUtils.ts
+++ b/client/src/utils/configUtils.ts
@@ -58,6 +58,12 @@ export const getMCPTaskTtl = (config: InspectorConfig): number => {
   return config.MCP_TASK_TTL.value as number;
 };
 
+export const revokeOAuthTokensOnDisconnect = (
+  config: InspectorConfig,
+): boolean => {
+  return config.MCP_OAUTH_REVOKE_ON_DISCONNECT.value as boolean;
+};
+
 export const getInitialTransportType = ():
   | "stdio"
   | "sse"


### PR DESCRIPTION
## Summary

- On Disconnect, send an RFC 7009 token revocation request to the AS's `revocation_endpoint` (discovered via RFC 8414) before wiping local OAuth state. Prefers the refresh token so the AS cascade-invalidates associated access tokens per RFC 7009 §2.1; falls back to the access token if no refresh token is held.
- Best-effort: no `revocation_endpoint` advertised → silent no-op; network error or non-2xx → swallowed with a `console.warn`; 3 s `AbortSignal.timeout` so a slow AS can't hang the UI. Disconnect always completes.
- Adds an `MCP_OAUTH_REVOKE_ON_DISCONNECT` config toggle (default `true`, mirrors the existing `MCP_REQUEST_TIMEOUT_RESET_ON_PROGRESS` pattern). Off is useful when testing how a server behaves with un-revoked tokens after a client walks away — Inspector's whole point being to poke at server behavior.

## Why

Currently the Disconnect button clears local session storage but never tells the authorization server, so every disconnected session leaves a still-valid access token (and refresh token, if issued) sitting on the AS until natural expiry. Server-side this manifests as "tombstone" sessions for downstream services to clean up. RFC 7009 §2 explicitly says clients **SHOULD** revoke tokens when they're no longer needed; the Inspector's Disconnect is exactly that moment.

This builds on #280 (local-clear-on-disconnect) by adding the missing remote-revocation step in front of the existing local clear. It's adjacent to but distinct from #1046 (OIDC `end_session_endpoint`) — that issue's author lays out the three-layer model cleanly:

1. local clear (already implemented, refined by #280)
2. **AS token revocation (this PR)**
3. IdP session logout (#1046, future)

This PR addresses (2) only.

## Behavior change

- **No advertised `revocation_endpoint`** → no behavior change (silent no-op). Any AS that doesn't implement RFC 7009 will continue to work exactly as before.
- **AS advertises `revocation_endpoint`** → on Disconnect, a `POST <revocation_endpoint>` with `application/x-www-form-urlencoded` body containing `token=<refresh|access>`, `token_type_hint`, and (when available) `client_id`. Routed through `createProxyFetch` when `connectionType === "proxy"`, matching every other OAuth call in `useConnection`.
- **Opt-out:** the new `MCP_OAUTH_REVOKE_ON_DISCONNECT` setting (Settings panel → "Revoke OAuth Tokens on Disconnect") toggles the call. Local clear still runs either way, so the user still gets a clean slate in the Inspector even with revocation disabled.

## Files changed

- `client/src/lib/auth.ts` — new module-level `revokeTokens({ serverUrl, fetchFn })` helper. Module-level (not a method) keeps it decoupled from `InspectorOAuthClientProvider.clear()`, which is also reached from auth-error paths where calling `/revoke` would be redundant or even error.
- `client/src/lib/hooks/useConnection.ts` — `disconnect()` awaits `revokeTokens` before the existing `authProvider.clear()`.
- `client/src/lib/configurationTypes.ts`, `client/src/lib/constants.ts`, `client/src/utils/configUtils.ts` — new `MCP_OAUTH_REVOKE_ON_DISCONNECT` ConfigItem + getter.
- Tests: 8 new in `client/src/lib/__tests__/auth.test.ts`, 2 new in `client/src/lib/hooks/__tests__/useConnection.test.tsx`.

## Test plan

- [x] `npm test` — 525/525 pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Manual E2E against a real OAuth-protected MCP server: connect → complete OAuth → click Disconnect → confirm `POST /revoke` in the AS access logs returning 200, confirm the token is no longer accepted on a follow-up request, confirm local session storage is cleared.
- [x] Manual E2E against an AS that does **not** advertise `revocation_endpoint`: confirm Disconnect still completes promptly, session storage clears, no error in the console.
- [x] Manual: flip `MCP_OAUTH_REVOKE_ON_DISCONNECT` to False in Settings → click Disconnect → confirm no revocation request is sent, local clear still happens.

## Out of scope

- OIDC RP-Initiated Logout (#1046) — different lifecycle (IdP session, not OAuth token). Could be a follow-up that adds a third call alongside this one.
- Revoking on browser-close / `beforeunload` — no graceful await available there; intentional Disconnect is the right hook.
- Any AS-side fixes. RFC 7009 support is a SHOULD on the client side; whether your AS implements it is an AS concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)