### PR TITLE
fix: allow empty CLI env values

### DIFF
--- a/cli/__tests__/cli.test.ts
+++ b/cli/__tests__/cli.test.ts
@@ -123,6 +123,26 @@ describe("CLI Tests", () => {
       expect(envVars.API_KEY).toBe("abc123=xyz789==");
     });
 
+    it("should accept empty environment variable values", async () => {
+      const { command, args } = getTestMcpServerCommand();
+      const result = await runCli([
+        command,
+        ...args,
+        "-e",
+        "EMPTY_ENV=",
+        "--cli",
+        "--method",
+        "resources/read",
+        "--uri",
+        "test://env",
+      ]);
+
+      expectCliSuccess(result);
+      const json = expectValidJson(result);
+      const envVars = JSON.parse(json.contents[0].text);
+      expect(envVars.EMPTY_ENV).toBe("");
+    });
+
     it("should handle environment variable with base64-encoded value", async () => {
       const { command, args } = getTestMcpServerCommand();
       const result = await runCli([

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -205,17 +205,24 @@ function parseKeyValuePair(
   value: string,
   previous: Record<string, string> = {},
 ): Record<string, string> {
-  const parts = value.split("=");
-  const key = parts[0];
-  const val = parts.slice(1).join("=");
+  const equalsIndex = value.indexOf("=");
 
-  if (val === undefined || val === "") {
+  if (equalsIndex === -1) {
     throw new Error(
       `Invalid parameter format: ${value}. Use key=value format.`,
     );
   }
 
-  return { ...previous, [key as string]: val };
+  const key = value.slice(0, equalsIndex);
+  const val = value.slice(equalsIndex + 1);
+
+  if (key === "") {
+    throw new Error(
+      `Invalid parameter format: ${value}. Use key=value format.`,
+    );
+  }
+
+  return { ...previous, [key]: val };
 }
 
 function parseHeaderPair(


### PR DESCRIPTION
## Summary
- allow `-e KEY=` in the Inspector launcher instead of rejecting empty environment variable values
- keep rejecting malformed values without an `=` and empty keys
- add CLI regression coverage for passing an empty env var through to a stdio MCP server

## Validation
- `npm install`
- `npm run build-cli`
- `npx prettier --check cli/src/cli.ts cli/__tests__/cli.test.ts`
- `export PATH=/home/ubuntu/gh-pr/inspector-main/node_modules/.bin:$PATH; cd cli && npm run test:cli -- -t "empty environment variable values"`
- `export PATH=/home/ubuntu/gh-pr/inspector-main/node_modules/.bin:$PATH; timeout 30s node cli/build/cli.js tsx /home/ubuntu/gh-pr/inspector-main/cli/__tests__/helpers/test-server-stdio.ts -e EMPTY_ENV= --cli --method resources/read --uri test://env`
- `git diff --check`

Note: running the full CLI suite without adding the repo-local `node_modules/.bin` to `PATH` timed out in this local checkout because the test MCP server command could not resolve `tsx`; the targeted regression passes when `tsx` is resolvable.