### PR TITLE
refactor(core): apply v1.5-port cleanups deferred from #1306

### DIFF
--- a/clients/web/tsconfig.app.json
+++ b/clients/web/tsconfig.app.json
@@ -20,11 +20,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    /* erasableSyntaxOnly disabled: the ported v1.5 core/ subsystem (#1302)
-     * uses TS parameter properties (`constructor(private foo: T)`) extensively.
-     * Re-enable once we either rewrite those constructors or move core/ to
-     * a separate tsconfig with looser rules. */
-    "erasableSyntaxOnly": false,
+    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
 
@@ -44,7 +40,9 @@
       "zustand": ["./node_modules/zustand"],
       "zustand/*": ["./node_modules/zustand/*"],
       "hono": ["./node_modules/hono"],
-      "hono/*": ["./node_modules/hono/*"],
+      "hono/streaming": [
+        "./node_modules/hono/dist/types/helper/streaming/index"
+      ],
       "@hono/node-server": ["./node_modules/@hono/node-server"],
       "atomically": ["./node_modules/atomically"]
     }

--- a/clients/web/tsconfig.test.json
+++ b/clients/web/tsconfig.test.json
@@ -14,7 +14,9 @@
       "zustand": ["./node_modules/zustand"],
       "zustand/*": ["./node_modules/zustand/*"],
       "hono": ["./node_modules/hono"],
-      "hono/*": ["./node_modules/hono/*"],
+      "hono/streaming": [
+        "./node_modules/hono/dist/types/helper/streaming/index"
+      ],
       "@hono/node-server": ["./node_modules/@hono/node-server"],
       "atomically": ["./node_modules/atomically"],
       "express": ["./node_modules/@types/express"],

--- a/core/auth/browser/storage.ts
+++ b/core/auth/browser/storage.ts
@@ -1,145 +1,15 @@
 import { createJSONStorage } from "zustand/middleware";
-import type { OAuthStorage } from "../storage.js";
-import type {
-  OAuthClientInformation,
-  OAuthTokens,
-  OAuthMetadata,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
-import {
-  OAuthClientInformationSchema,
-  OAuthTokensSchema,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
-import { createOAuthStore, type ServerOAuthState } from "../store.js";
+import { OAuthStorageBase } from "../oauth-storage.js";
+import { createOAuthStore } from "../store.js";
 
 /**
  * Browser storage implementation using Zustand with sessionStorage.
  * For web client (can be used by InspectorClient in browser).
  */
-export class BrowserOAuthStorage implements OAuthStorage {
-  private store: ReturnType<typeof createOAuthStore>;
-
+export class BrowserOAuthStorage extends OAuthStorageBase {
   constructor() {
     // Use Zustand's built-in sessionStorage adapter
     // The `name` option in persist() ("mcp-inspector-oauth") becomes the sessionStorage key
-    const storage = createJSONStorage(() => sessionStorage);
-    this.store = createOAuthStore(storage);
-  }
-  async getClientInformation(
-    serverUrl: string,
-    isPreregistered?: boolean,
-  ): Promise<OAuthClientInformation | undefined> {
-    const state = this.store.getState().getServerState(serverUrl);
-    const clientInfo = isPreregistered
-      ? state.preregisteredClientInformation
-      : state.clientInformation;
-
-    if (!clientInfo) {
-      return undefined;
-    }
-
-    return await OAuthClientInformationSchema.parseAsync(clientInfo);
-  }
-
-  async saveClientInformation(
-    serverUrl: string,
-    clientInformation: OAuthClientInformation,
-  ): Promise<void> {
-    this.store.getState().setServerState(serverUrl, {
-      clientInformation,
-    });
-  }
-
-  async savePreregisteredClientInformation(
-    serverUrl: string,
-    clientInformation: OAuthClientInformation,
-  ): Promise<void> {
-    this.store.getState().setServerState(serverUrl, {
-      preregisteredClientInformation: clientInformation,
-    });
-  }
-
-  clearClientInformation(serverUrl: string, isPreregistered?: boolean): void {
-    this.store.getState().getServerState(serverUrl);
-    const updates: Partial<ServerOAuthState> = {};
-
-    if (isPreregistered) {
-      updates.preregisteredClientInformation = undefined;
-    } else {
-      updates.clientInformation = undefined;
-    }
-
-    this.store.getState().setServerState(serverUrl, updates);
-  }
-
-  async getTokens(serverUrl: string): Promise<OAuthTokens | undefined> {
-    const state = this.store.getState().getServerState(serverUrl);
-    if (!state.tokens) {
-      return undefined;
-    }
-
-    return await OAuthTokensSchema.parseAsync(state.tokens);
-  }
-
-  async saveTokens(serverUrl: string, tokens: OAuthTokens): Promise<void> {
-    this.store.getState().setServerState(serverUrl, { tokens });
-  }
-
-  clearTokens(serverUrl: string): void {
-    this.store.getState().setServerState(serverUrl, { tokens: undefined });
-  }
-
-  getCodeVerifier(serverUrl: string): string | undefined {
-    const state = this.store.getState().getServerState(serverUrl);
-    return state.codeVerifier;
-  }
-
-  async saveCodeVerifier(
-    serverUrl: string,
-    codeVerifier: string,
-  ): Promise<void> {
-    this.store.getState().setServerState(serverUrl, { codeVerifier });
-  }
-
-  clearCodeVerifier(serverUrl: string): void {
-    this.store
-      .getState()
-      .setServerState(serverUrl, { codeVerifier: undefined });
-  }
-
-  getScope(serverUrl: string): string | undefined {
-    const state = this.store.getState().getServerState(serverUrl);
-    return state.scope;
-  }
-
-  async saveScope(serverUrl: string, scope: string | undefined): Promise<void> {
-    this.store.getState().setServerState(serverUrl, { scope });
-  }
-
-  clearScope(serverUrl: string): void {
-    this.store.getState().setServerState(serverUrl, { scope: undefined });
-  }
-
-  getServerMetadata(serverUrl: string): OAuthMetadata | null {
-    const state = this.store.getState().getServerState(serverUrl);
-    return state.serverMetadata || null;
-  }
-
-  async saveServerMetadata(
-    serverUrl: string,
-    metadata: OAuthMetadata,
-  ): Promise<void> {
-    this.store
-      .getState()
-      .setServerState(serverUrl, { serverMetadata: metadata });
-  }
-
-  clearServerMetadata(serverUrl: string): void {
-    this.store
-      .getState()
-      .setServerState(serverUrl, { serverMetadata: undefined });
-  }
-
-  clear(serverUrl: string): void {
-    this.store.getState().clearServerState(serverUrl);
+    super(createOAuthStore(createJSONStorage(() => sessionStorage)));
   }
 }

--- a/core/auth/node/storage-node.ts
+++ b/core/auth/node/storage-node.ts
@@ -1,14 +1,5 @@
-import type { OAuthStorage } from "../storage.js";
-import type {
-  OAuthClientInformation,
-  OAuthTokens,
-  OAuthMetadata,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
-import {
-  OAuthClientInformationSchema,
-  OAuthTokensSchema,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
-import { createOAuthStore, type ServerOAuthState } from "../store.js";
+import { OAuthStorageBase } from "../oauth-storage.js";
+import { createOAuthStore } from "../store.js";
 import { createFileStorageAdapter } from "../../storage/adapters/file-storage.js";
 import {
   getDefaultStorageDir,
@@ -59,135 +50,14 @@ export function clearAllOAuthClientState(): void {
 }
 
 /**
- * Node.js storage implementation using Zustand with file-based persistence
- * For InspectorClient, CLI, and TUI
+ * Node.js storage implementation using Zustand with file-based persistence.
+ * For InspectorClient, CLI, and TUI.
  */
-export class NodeOAuthStorage implements OAuthStorage {
-  private store: ReturnType<typeof getOAuthStore>;
-
+export class NodeOAuthStorage extends OAuthStorageBase {
   /**
    * @param storagePath - Optional path to state file. Default: ~/.mcp-inspector/oauth/state.json
    */
   constructor(storagePath?: string) {
-    this.store = getOAuthStore(storagePath);
-  }
-
-  async getClientInformation(
-    serverUrl: string,
-    isPreregistered?: boolean,
-  ): Promise<OAuthClientInformation | undefined> {
-    const state = this.store.getState().getServerState(serverUrl);
-    const clientInfo = isPreregistered
-      ? state.preregisteredClientInformation
-      : state.clientInformation;
-
-    if (!clientInfo) {
-      return undefined;
-    }
-
-    return await OAuthClientInformationSchema.parseAsync(clientInfo);
-  }
-
-  async saveClientInformation(
-    serverUrl: string,
-    clientInformation: OAuthClientInformation,
-  ): Promise<void> {
-    this.store.getState().setServerState(serverUrl, {
-      clientInformation,
-    });
-  }
-
-  async savePreregisteredClientInformation(
-    serverUrl: string,
-    clientInformation: OAuthClientInformation,
-  ): Promise<void> {
-    this.store.getState().setServerState(serverUrl, {
-      preregisteredClientInformation: clientInformation,
-    });
-  }
-
-  clearClientInformation(serverUrl: string, isPreregistered?: boolean): void {
-    this.store.getState().getServerState(serverUrl);
-    const updates: Partial<ServerOAuthState> = {};
-
-    if (isPreregistered) {
-      updates.preregisteredClientInformation = undefined;
-    } else {
-      updates.clientInformation = undefined;
-    }
-
-    this.store.getState().setServerState(serverUrl, updates);
-  }
-
-  async getTokens(serverUrl: string): Promise<OAuthTokens | undefined> {
-    const state = this.store.getState().getServerState(serverUrl);
-    if (!state.tokens) {
-      return undefined;
-    }
-
-    return await OAuthTokensSchema.parseAsync(state.tokens);
-  }
-
-  async saveTokens(serverUrl: string, tokens: OAuthTokens): Promise<void> {
-    this.store.getState().setServerState(serverUrl, { tokens });
-  }
-
-  clearTokens(serverUrl: string): void {
-    this.store.getState().setServerState(serverUrl, { tokens: undefined });
-  }
-
-  getCodeVerifier(serverUrl: string): string | undefined {
-    const state = this.store.getState().getServerState(serverUrl);
-    return state.codeVerifier;
-  }
-
-  async saveCodeVerifier(
-    serverUrl: string,
-    codeVerifier: string,
-  ): Promise<void> {
-    this.store.getState().setServerState(serverUrl, { codeVerifier });
-  }
-
-  clearCodeVerifier(serverUrl: string): void {
-    this.store
-      .getState()
-      .setServerState(serverUrl, { codeVerifier: undefined });
-  }
-
-  getScope(serverUrl: string): string | undefined {
-    const state = this.store.getState().getServerState(serverUrl);
-    return state.scope;
-  }
-
-  async saveScope(serverUrl: string, scope: string | undefined): Promise<void> {
-    this.store.getState().setServerState(serverUrl, { scope });
-  }
-
-  clearScope(serverUrl: string): void {
-    this.store.getState().setServerState(serverUrl, { scope: undefined });
-  }
-
-  getServerMetadata(serverUrl: string): OAuthMetadata | null {
-    const state = this.store.getState().getServerState(serverUrl);
-    return state.serverMetadata || null;
-  }
-
-  async saveServerMetadata(
-    serverUrl: string,
-    metadata: OAuthMetadata,
-  ): Promise<void> {
-    this.store
-      .getState()
-      .setServerState(serverUrl, { serverMetadata: metadata });
-  }
-
-  clearServerMetadata(serverUrl: string): void {
-    this.store
-      .getState()
-      .setServerState(serverUrl, { serverMetadata: undefined });
-  }
-
-  clear(serverUrl: string): void {
-    this.store.getState().clearServerState(serverUrl);
+    super(getOAuthStore(storagePath));
   }
 }

--- a/core/auth/oauth-storage.ts
+++ b/core/auth/oauth-storage.ts
@@ -57,7 +57,6 @@ export class OAuthStorageBase implements OAuthStorage {
   }
 
   clearClientInformation(serverUrl: string, isPreregistered?: boolean): void {
-    this.store.getState().getServerState(serverUrl);
     const updates: Partial<ServerOAuthState> = {};
 
     if (isPreregistered) {

--- a/core/auth/oauth-storage.ts
+++ b/core/auth/oauth-storage.ts
@@ -1,0 +1,143 @@
+import type {
+  OAuthClientInformation,
+  OAuthTokens,
+  OAuthMetadata,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import {
+  OAuthClientInformationSchema,
+  OAuthTokensSchema,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { OAuthStorage } from "./storage.js";
+import { type createOAuthStore, type ServerOAuthState } from "./store.js";
+
+/**
+ * Concrete OAuthStorage implementation parameterized on a Zustand store.
+ * The store carries the storage adapter (sessionStorage, file, remote HTTP, …),
+ * so the same body works for browser, Node, and remote environments.
+ */
+export class OAuthStorageBase implements OAuthStorage {
+  private readonly store: ReturnType<typeof createOAuthStore>;
+
+  constructor(store: ReturnType<typeof createOAuthStore>) {
+    this.store = store;
+  }
+
+  async getClientInformation(
+    serverUrl: string,
+    isPreregistered?: boolean,
+  ): Promise<OAuthClientInformation | undefined> {
+    const state = this.store.getState().getServerState(serverUrl);
+    const clientInfo = isPreregistered
+      ? state.preregisteredClientInformation
+      : state.clientInformation;
+
+    if (!clientInfo) {
+      return undefined;
+    }
+
+    return await OAuthClientInformationSchema.parseAsync(clientInfo);
+  }
+
+  async saveClientInformation(
+    serverUrl: string,
+    clientInformation: OAuthClientInformation,
+  ): Promise<void> {
+    this.store.getState().setServerState(serverUrl, {
+      clientInformation,
+    });
+  }
+
+  async savePreregisteredClientInformation(
+    serverUrl: string,
+    clientInformation: OAuthClientInformation,
+  ): Promise<void> {
+    this.store.getState().setServerState(serverUrl, {
+      preregisteredClientInformation: clientInformation,
+    });
+  }
+
+  clearClientInformation(serverUrl: string, isPreregistered?: boolean): void {
+    this.store.getState().getServerState(serverUrl);
+    const updates: Partial<ServerOAuthState> = {};
+
+    if (isPreregistered) {
+      updates.preregisteredClientInformation = undefined;
+    } else {
+      updates.clientInformation = undefined;
+    }
+
+    this.store.getState().setServerState(serverUrl, updates);
+  }
+
+  async getTokens(serverUrl: string): Promise<OAuthTokens | undefined> {
+    const state = this.store.getState().getServerState(serverUrl);
+    if (!state.tokens) {
+      return undefined;
+    }
+
+    return await OAuthTokensSchema.parseAsync(state.tokens);
+  }
+
+  async saveTokens(serverUrl: string, tokens: OAuthTokens): Promise<void> {
+    this.store.getState().setServerState(serverUrl, { tokens });
+  }
+
+  clearTokens(serverUrl: string): void {
+    this.store.getState().setServerState(serverUrl, { tokens: undefined });
+  }
+
+  getCodeVerifier(serverUrl: string): string | undefined {
+    const state = this.store.getState().getServerState(serverUrl);
+    return state.codeVerifier;
+  }
+
+  async saveCodeVerifier(
+    serverUrl: string,
+    codeVerifier: string,
+  ): Promise<void> {
+    this.store.getState().setServerState(serverUrl, { codeVerifier });
+  }
+
+  clearCodeVerifier(serverUrl: string): void {
+    this.store
+      .getState()
+      .setServerState(serverUrl, { codeVerifier: undefined });
+  }
+
+  getScope(serverUrl: string): string | undefined {
+    const state = this.store.getState().getServerState(serverUrl);
+    return state.scope;
+  }
+
+  async saveScope(serverUrl: string, scope: string | undefined): Promise<void> {
+    this.store.getState().setServerState(serverUrl, { scope });
+  }
+
+  clearScope(serverUrl: string): void {
+    this.store.getState().setServerState(serverUrl, { scope: undefined });
+  }
+
+  getServerMetadata(serverUrl: string): OAuthMetadata | null {
+    const state = this.store.getState().getServerState(serverUrl);
+    return state.serverMetadata || null;
+  }
+
+  async saveServerMetadata(
+    serverUrl: string,
+    metadata: OAuthMetadata,
+  ): Promise<void> {
+    this.store
+      .getState()
+      .setServerState(serverUrl, { serverMetadata: metadata });
+  }
+
+  clearServerMetadata(serverUrl: string): void {
+    this.store
+      .getState()
+      .setServerState(serverUrl, { serverMetadata: undefined });
+  }
+
+  clear(serverUrl: string): void {
+    this.store.getState().clearServerState(serverUrl);
+  }
+}

--- a/core/auth/providers.ts
+++ b/core/auth/providers.ts
@@ -51,8 +51,11 @@ export type OAuthNavigationCallback = (
  */
 export class CallbackNavigation implements OAuthNavigation {
   private authorizationUrl: URL | null = null;
+  private callback: OAuthNavigationCallback;
 
-  constructor(private callback: OAuthNavigationCallback) {}
+  constructor(callback: OAuthNavigationCallback) {
+    this.callback = callback;
+  }
 
   navigateToAuthorization(authorizationUrl: URL): void {
     this.authorizationUrl = authorizationUrl;
@@ -100,6 +103,7 @@ export class BaseOAuthClientProvider implements OAuthClientProvider {
   private capturedAuthUrl: URL | null = null;
   private eventTarget: EventTarget | null = null;
 
+  protected serverUrl: string;
   protected storage: OAuthStorage;
   protected redirectUrlProvider: RedirectUrlProvider;
   protected navigation: OAuthNavigation;
@@ -107,10 +111,11 @@ export class BaseOAuthClientProvider implements OAuthClientProvider {
   protected mode: "normal" | "guided";
 
   constructor(
-    protected serverUrl: string,
+    serverUrl: string,
     oauthConfig: OAuthProviderConfig,
     mode: "normal" | "guided" = "normal",
   ) {
+    this.serverUrl = serverUrl;
     this.storage = oauthConfig.storage;
     this.redirectUrlProvider = oauthConfig.redirectUrlProvider;
     this.navigation = oauthConfig.navigation;

--- a/core/auth/remote/storage-remote.ts
+++ b/core/auth/remote/storage-remote.ts
@@ -4,17 +4,8 @@
  * For web clients that need to share state with Node apps.
  */
 
-import type { OAuthStorage } from "../storage.js";
-import type {
-  OAuthClientInformation,
-  OAuthTokens,
-  OAuthMetadata,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
-import {
-  OAuthClientInformationSchema,
-  OAuthTokensSchema,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
-import { createOAuthStore, type ServerOAuthState } from "../store.js";
+import { OAuthStorageBase } from "../oauth-storage.js";
+import { createOAuthStore } from "../store.js";
 import { createRemoteStorageAdapter } from "../../storage/adapters/remote-storage.js";
 
 export interface RemoteOAuthStorageOptions {
@@ -33,135 +24,17 @@ export interface RemoteOAuthStorageOptions {
  * Stores OAuth state via HTTP API (GET/POST/DELETE /api/storage/:storeId).
  * For web clients that need to share state with Node apps (TUI, CLI).
  */
-export class RemoteOAuthStorage implements OAuthStorage {
-  private store: ReturnType<typeof createOAuthStore>;
-
+export class RemoteOAuthStorage extends OAuthStorageBase {
   constructor(options: RemoteOAuthStorageOptions) {
-    const storage = createRemoteStorageAdapter({
-      baseUrl: options.baseUrl,
-      storeId: options.storeId ?? "oauth",
-      authToken: options.authToken,
-      fetchFn: options.fetchFn,
-    });
-    this.store = createOAuthStore(storage);
-  }
-
-  async getClientInformation(
-    serverUrl: string,
-    isPreregistered?: boolean,
-  ): Promise<OAuthClientInformation | undefined> {
-    const state = this.store.getState().getServerState(serverUrl);
-    const clientInfo = isPreregistered
-      ? state.preregisteredClientInformation
-      : state.clientInformation;
-
-    if (!clientInfo) {
-      return undefined;
-    }
-
-    return await OAuthClientInformationSchema.parseAsync(clientInfo);
-  }
-
-  async saveClientInformation(
-    serverUrl: string,
-    clientInformation: OAuthClientInformation,
-  ): Promise<void> {
-    this.store.getState().setServerState(serverUrl, {
-      clientInformation,
-    });
-  }
-
-  async savePreregisteredClientInformation(
-    serverUrl: string,
-    clientInformation: OAuthClientInformation,
-  ): Promise<void> {
-    this.store.getState().setServerState(serverUrl, {
-      preregisteredClientInformation: clientInformation,
-    });
-  }
-
-  clearClientInformation(serverUrl: string, isPreregistered?: boolean): void {
-    this.store.getState().getServerState(serverUrl);
-    const updates: Partial<ServerOAuthState> = {};
-
-    if (isPreregistered) {
-      updates.preregisteredClientInformation = undefined;
-    } else {
-      updates.clientInformation = undefined;
-    }
-
-    this.store.getState().setServerState(serverUrl, updates);
-  }
-
-  async getTokens(serverUrl: string): Promise<OAuthTokens | undefined> {
-    const state = this.store.getState().getServerState(serverUrl);
-    if (!state.tokens) {
-      return undefined;
-    }
-
-    return await OAuthTokensSchema.parseAsync(state.tokens);
-  }
-
-  async saveTokens(serverUrl: string, tokens: OAuthTokens): Promise<void> {
-    this.store.getState().setServerState(serverUrl, { tokens });
-  }
-
-  clearTokens(serverUrl: string): void {
-    this.store.getState().setServerState(serverUrl, { tokens: undefined });
-  }
-
-  getCodeVerifier(serverUrl: string): string | undefined {
-    const state = this.store.getState().getServerState(serverUrl);
-    return state.codeVerifier;
-  }
-
-  async saveCodeVerifier(
-    serverUrl: string,
-    codeVerifier: string,
-  ): Promise<void> {
-    this.store.getState().setServerState(serverUrl, { codeVerifier });
-  }
-
-  clearCodeVerifier(serverUrl: string): void {
-    this.store
-      .getState()
-      .setServerState(serverUrl, { codeVerifier: undefined });
-  }
-
-  getScope(serverUrl: string): string | undefined {
-    const state = this.store.getState().getServerState(serverUrl);
-    return state.scope;
-  }
-
-  async saveScope(serverUrl: string, scope: string | undefined): Promise<void> {
-    this.store.getState().setServerState(serverUrl, { scope });
-  }
-
-  clearScope(serverUrl: string): void {
-    this.store.getState().setServerState(serverUrl, { scope: undefined });
-  }
-
-  getServerMetadata(serverUrl: string): OAuthMetadata | null {
-    const state = this.store.getState().getServerState(serverUrl);
-    return state.serverMetadata || null;
-  }
-
-  async saveServerMetadata(
-    serverUrl: string,
-    metadata: OAuthMetadata,
-  ): Promise<void> {
-    this.store
-      .getState()
-      .setServerState(serverUrl, { serverMetadata: metadata });
-  }
-
-  clearServerMetadata(serverUrl: string): void {
-    this.store
-      .getState()
-      .setServerState(serverUrl, { serverMetadata: undefined });
-  }
-
-  clear(serverUrl: string): void {
-    this.store.getState().clearServerState(serverUrl);
+    super(
+      createOAuthStore(
+        createRemoteStorageAdapter({
+          baseUrl: options.baseUrl,
+          storeId: options.storeId ?? "oauth",
+          authToken: options.authToken,
+          fetchFn: options.fetchFn,
+        }),
+      ),
+    );
   }
 }

--- a/core/auth/state-machine.ts
+++ b/core/auth/state-machine.ts
@@ -256,12 +256,22 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
 };
 
 export class OAuthStateMachine {
+  private serverUrl: string;
+  private provider: BaseOAuthClientProvider;
+  private updateState: (updates: Partial<AuthGuidedState>) => void;
+  private fetchFn?: typeof fetch;
+
   constructor(
-    private serverUrl: string,
-    private provider: BaseOAuthClientProvider,
-    private updateState: (updates: Partial<AuthGuidedState>) => void,
-    private fetchFn?: typeof fetch,
-  ) {}
+    serverUrl: string,
+    provider: BaseOAuthClientProvider,
+    updateState: (updates: Partial<AuthGuidedState>) => void,
+    fetchFn?: typeof fetch,
+  ) {
+    this.serverUrl = serverUrl;
+    this.provider = provider;
+    this.updateState = updateState;
+    this.fetchFn = fetchFn;
+  }
 
   async executeStep(state: AuthGuidedState): Promise<void> {
     const context: StateMachineContext = {

--- a/core/mcp/elicitationCreateMessage.ts
+++ b/core/mcp/elicitationCreateMessage.ts
@@ -29,14 +29,16 @@ export class ElicitationCreateMessage {
   private resolvePromise?: (result: ElicitResult) => void;
   /** Set only for task-augmented elicit; used when user declines so server's tasks/result receives an error */
   private rejectCallback?: (error: Error) => void;
+  private onRemove: (id: string) => void;
 
   constructor(
     request: ElicitRequest,
     resolve: (result: ElicitResult) => void,
-    private onRemove: (id: string) => void,
+    onRemove: (id: string) => void,
     reject?: (error: Error) => void,
   ) {
-    this.id = `elicitation-${Date.now()}-${Math.random()}`;
+    this.onRemove = onRemove;
+    this.id = `elicitation-${crypto.randomUUID()}`;
     this.timestamp = new Date();
     this.request = request;
     // Extract taskId from request params metadata if present

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -417,10 +417,7 @@ export class InspectorClient extends InspectorClientEventTarget {
     statusMessage?: string;
     pollInterval?: number;
   }): ReceiverTaskRecord {
-    const taskId =
-      typeof crypto !== "undefined" && crypto.randomUUID
-        ? crypto.randomUUID()
-        : `task-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+    const taskId = crypto.randomUUID();
     const ttlMs =
       opts.ttl ??
       (typeof this.receiverTaskTtlMs === "function"

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -174,12 +174,14 @@ export class InspectorClient extends InspectorClientEventTarget {
   private effectiveAuthFetch: typeof fetch;
   // Session ID (for OAuth state and saveSession event; persistence is in FetchRequestLogState)
   private sessionId?: string;
+  private transportConfig: MCPServerConfig;
 
   constructor(
-    private transportConfig: MCPServerConfig,
+    transportConfig: MCPServerConfig,
     options: InspectorClientOptions,
   ) {
     super();
+    this.transportConfig = transportConfig;
     // Extract environment components
     this.transportClientFactory = options.environment.transport;
     this.fetchFn = options.environment.fetch;
@@ -309,7 +311,7 @@ export class InspectorClient extends InspectorClientEventTarget {
     return {
       trackRequest: (message: JSONRPCRequest) => {
         const entry: MessageEntry = {
-          id: `${Date.now()}-${Math.random()}`,
+          id: crypto.randomUUID(),
           timestamp: new Date(),
           direction: "request",
           message,
@@ -320,7 +322,7 @@ export class InspectorClient extends InspectorClientEventTarget {
         message: JSONRPCResultResponse | JSONRPCErrorResponse,
       ) => {
         const entry: MessageEntry = {
-          id: `${Date.now()}-${Math.random()}`,
+          id: crypto.randomUUID(),
           timestamp: new Date(),
           direction: "response",
           message,
@@ -329,7 +331,7 @@ export class InspectorClient extends InspectorClientEventTarget {
       },
       trackNotification: (message: JSONRPCNotification) => {
         const entry: MessageEntry = {
-          id: `${Date.now()}-${Math.random()}`,
+          id: crypto.randomUUID(),
           timestamp: new Date(),
           direction: "notification",
           message,
@@ -1962,7 +1964,10 @@ export class InspectorClient extends InspectorClientEventTarget {
       });
     } catch (error) {
       // Log but don't throw - roots were updated locally even if notification failed
-      console.error("Failed to send roots/list_changed notification:", error);
+      this.logger.error(
+        { error },
+        "Failed to send roots/list_changed notification",
+      );
     }
   }
 

--- a/core/mcp/messageTrackingTransport.ts
+++ b/core/mcp/messageTrackingTransport.ts
@@ -23,10 +23,16 @@ export interface MessageTrackingCallbacks {
 
 // Transport wrapper that intercepts all messages for tracking
 export class MessageTrackingTransport implements Transport {
+  private baseTransport: Transport;
+  private callbacks: MessageTrackingCallbacks;
+
   constructor(
-    private baseTransport: Transport,
-    private callbacks: MessageTrackingCallbacks,
-  ) {}
+    baseTransport: Transport,
+    callbacks: MessageTrackingCallbacks,
+  ) {
+    this.baseTransport = baseTransport;
+    this.callbacks = callbacks;
+  }
 
   async start(): Promise<void> {
     return this.baseTransport.start();

--- a/core/mcp/oauthManager.ts
+++ b/core/mcp/oauthManager.ts
@@ -41,11 +41,13 @@ export interface OAuthManagerParams {
  * InspectorClient creates this when oauth is configured and delegates all OAuth methods.
  */
 export class OAuthManager {
+  private params: OAuthManagerParams;
   private oauthConfig: OAuthManagerConfig;
   private oauthStateMachine: OAuthStateMachine | null = null;
   private oauthState: AuthGuidedState | null = null;
 
-  constructor(private params: OAuthManagerParams) {
+  constructor(params: OAuthManagerParams) {
+    this.params = params;
     this.oauthConfig = { ...params.initialConfig };
   }
 

--- a/core/mcp/remote/node/server.ts
+++ b/core/mcp/remote/node/server.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../storage/store-io.js";
 import type { LogEvent } from "pino";
 import { Hono } from "hono";
-import type { Context, Next } from "hono";
+import type { Context, Env, Next } from "hono";
 import { streamSSE } from "hono/streaming";
 import { createTransportNode } from "../../node/transport.js";
 import type { RemoteConnectRequest, RemoteSendRequest } from "../types.js";
@@ -277,7 +277,7 @@ export function createRemoteApp(
       process.env[API_SERVER_ENV_VARS.AUTH_TOKEN] ||
       randomBytes(32).toString("hex");
 
-  const app = new Hono();
+  const app = new Hono<Env>();
   const sessions = new Map<string, RemoteSession>();
   const { logger: fileLogger, allowedOrigins } = options;
   const storageDir = options.storageDir ?? getDefaultStorageDir();
@@ -453,9 +453,7 @@ export function createRemoteApp(
       return c.json({ error: "Session not found" }, 404);
     }
 
-    // hono's streamSSE generic typing has tightened since v1.5; cast the
-    // route-typed Context down to the broader Context shape it expects.
-    return streamSSE(c as unknown as Parameters<typeof streamSSE>[0], async (stream) => {
+    return streamSSE(c as Context, async (stream) => {
       session.setEventConsumer((event) => {
         const data = JSON.stringify(event);
         void stream.writeSSE({

--- a/core/mcp/remote/node/server.ts
+++ b/core/mcp/remote/node/server.ts
@@ -453,7 +453,7 @@ export function createRemoteApp(
       return c.json({ error: "Session not found" }, 404);
     }
 
-    return streamSSE(c as Context, async (stream) => {
+    return streamSSE(c, async (stream) => {
       session.setEventConsumer((event) => {
         const data = JSON.stringify(event);
         void stream.writeSSE({

--- a/core/mcp/remote/remoteClientTransport.ts
+++ b/core/mcp/remote/remoteClientTransport.ts
@@ -99,6 +99,8 @@ export class RemoteClientTransport implements Transport {
     null;
   private eventStreamAbort: AbortController | null = null;
   private closed = false;
+  private readonly options: RemoteTransportOptions;
+  private readonly config: import("../types.js").MCPServerConfig;
 
   /**
    * Intentionally returns undefined. The MCP Client checks transport.sessionId to detect
@@ -110,9 +112,6 @@ export class RemoteClientTransport implements Transport {
   get sessionId(): string | undefined {
     return undefined;
   }
-
-  private readonly options: RemoteTransportOptions;
-  private readonly config: import("../types.js").MCPServerConfig;
 
   constructor(
     options: RemoteTransportOptions,

--- a/core/mcp/remote/remoteClientTransport.ts
+++ b/core/mcp/remote/remoteClientTransport.ts
@@ -111,10 +111,16 @@ export class RemoteClientTransport implements Transport {
     return undefined;
   }
 
+  private readonly options: RemoteTransportOptions;
+  private readonly config: import("../types.js").MCPServerConfig;
+
   constructor(
-    private readonly options: RemoteTransportOptions,
-    private readonly config: import("../types.js").MCPServerConfig,
-  ) {}
+    options: RemoteTransportOptions,
+    config: import("../types.js").MCPServerConfig,
+  ) {
+    this.options = options;
+    this.config = config;
+  }
 
   private get fetchFn(): typeof fetch {
     return this.options.fetchFn ?? globalThis.fetch;

--- a/core/mcp/samplingCreateMessage.ts
+++ b/core/mcp/samplingCreateMessage.ts
@@ -28,14 +28,16 @@ export class SamplingCreateMessage {
   public readonly taskId?: string;
   private resolvePromise?: (result: CreateMessageResult) => void;
   private rejectPromise?: (error: Error) => void;
+  private onRemove: (id: string) => void;
 
   constructor(
     request: CreateMessageRequest,
     resolve: (result: CreateMessageResult) => void,
     reject: (error: Error) => void,
-    private onRemove: (id: string) => void,
+    onRemove: (id: string) => void,
   ) {
-    this.id = `sampling-${Date.now()}-${Math.random()}`;
+    this.onRemove = onRemove;
+    this.id = `sampling-${crypto.randomUUID()}`;
     this.timestamp = new Date();
     this.request = request;
     // Extract taskId from request params metadata if present


### PR DESCRIPTION
Closes #1309.

Five mechanical cleanups deferred from the v1.5 runtime port (#1306). Each is independent; all together drop ~210 lines and re-tighten TS strictness.

## Summary

1. **Consolidate `OAuthStorage` implementations.** `Browser/Node/RemoteOAuthStorage` were three ~130-line copies that differed only in their adapter. Body lives once in a new `OAuthStorageBase` (`core/auth/oauth-storage.ts`); each environment file is now a 5-line subclass that wires its adapter and calls `super`. Public API (`new BrowserOAuthStorage()`, `new NodeOAuthStorage(path?)`, `new RemoteOAuthStorage(opts)`) is unchanged, so all existing call sites and tests work untouched.

2. **Re-enable `erasableSyntaxOnly`.** Rewrote the seven `constructor(private foo: T)` sites enumerated in the issue, plus two extras the issue missed (`samplingCreateMessage.ts` / `elicitationCreateMessage.ts`), as explicit field declarations + assignments. The temporary `erasableSyntaxOnly: false` override + TODO in `tsconfig.app.json` is gone.

3. **Logger consistency in `inspectorClient.ts`.** Swapped the one `console.error` (roots/list_changed failure path) to `this.logger.error({ error }, "…")` to match the rest of the file.

4. **`crypto.randomUUID()` everywhere.** The five message-tracking + sampling/elicitation ID sites that used `${Date.now()}-${Math.random()}` now use `crypto.randomUUID()` directly (with semantic prefixes preserved on the sampling/elicit cases).

5. **Drop the `streamSSE` cast in `core/mcp/remote/node/server.ts`.** Pinned the hono generic at `new Hono<Env>()` per the issue. Root cause of the `streamSSE(c as unknown as …)` cast turned out to be a tsconfig path-alias bug, not a hono generic mismatch: the `"hono/*": ["./node_modules/hono/*"]` wildcard did not honor hono's subpath exports map, so `hono/streaming` fell through to the root-hoisted `hono@4.12.12` (peerDep of the SDK) while `hono` itself resolved to `clients/web/hono@4.12.18`. Two physically separate packages → TS rejected the (otherwise identical) `Context` types. Replacing the wildcard with an explicit `"hono/streaming"` entry in both `tsconfig.app.json` and `tsconfig.test.json` makes both imports resolve to the same package; the cast is no longer needed.

## Test plan
- [x] `npm run validate` from `clients/web/` (format + lint + build + unit + integration coverage)
- [x] `npm run test:storybook` (67 stories / 298 play-tests)
- [x] OAuth unit & integration suites still pass after the storage consolidation
- [x] `remote-transport.test.ts` (47 tests) still passes after the streamSSE cast removal

## Out of scope
The acceptance-criteria "out of scope" items from #1309 (`BaseOAuthClientProvider` dispatcher refactor, generated `core/mcp/version.ts`, vite alias trimming) remain deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)