### PR TITLE
Expose negotiated MCP protocol version

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -374,6 +374,7 @@ const App = () => {
   const {
     connectionStatus,
     serverCapabilities,
+    mcpProtocolVersion,
     serverImplementation,
     mcpClient,
     requestHistory,
@@ -1342,6 +1343,7 @@ const App = () => {
           connectionType={connectionType}
           setConnectionType={setConnectionType}
           serverImplementation={serverImplementation}
+          mcpProtocolVersion={mcpProtocolVersion}
         />
         <div
           onMouseDown={handleSidebarDragStart}

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -78,6 +78,7 @@ interface SidebarProps {
   serverImplementation?:
     | (WithIcons & { name?: string; version?: string; websiteUrl?: string })
     | null;
+  mcpProtocolVersion?: string | null;
 }
 
 const Sidebar = ({
@@ -110,6 +111,7 @@ const Sidebar = ({
   connectionType,
   setConnectionType,
   serverImplementation,
+  mcpProtocolVersion,
 }: SidebarProps) => {
   const [theme, setTheme] = useTheme();
   const [showEnvVars, setShowEnvVars] = useState(false);
@@ -845,6 +847,11 @@ const Sidebar = ({
                     {serverImplementation.version && (
                       <div className="text-xs text-gray-500 dark:text-gray-400">
                         Version: {serverImplementation.version}
+                      </div>
+                    )}
+                    {mcpProtocolVersion && (
+                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                        Protocol: {mcpProtocolVersion}
                       </div>
                     )}
                   </div>

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -1213,6 +1213,34 @@ describe("useConnection", () => {
         mockStreamableHTTPTransport.options?.requestInit?.headers,
       ).toHaveProperty("X-MCP-Proxy-Auth", "Bearer test-proxy-token");
     });
+
+    test("exposes negotiated protocol version from response headers", async () => {
+      const response = {
+        headers: {
+          get: jest.fn((name: string) =>
+            name === "mcp-protocol-version" ? "2025-06-18" : null,
+          ),
+        },
+      } as unknown as Response;
+      (global.fetch as jest.Mock).mockResolvedValueOnce(response);
+
+      const { result } = renderHook(() =>
+        useConnection({
+          ...defaultProps,
+          connectionType: "direct",
+        }),
+      );
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      await act(async () => {
+        await mockSSETransport.options?.fetch?.("http://localhost:8080");
+      });
+
+      expect(result.current.mcpProtocolVersion).toBe("2025-06-18");
+    });
   });
 
   describe("Custom Headers", () => {

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -1200,6 +1200,7 @@ export function useConnection({
   return {
     connectionStatus,
     serverCapabilities,
+    mcpProtocolVersion,
     serverImplementation,
     mcpClient,
     requestHistory,


### PR DESCRIPTION
## Summary

- Return `mcpProtocolVersion` from `useConnection`
- Pass the negotiated protocol version through `App` to the sidebar
- Show the protocol version in the connected server metadata when available
- Add hook coverage for reading `mcp-protocol-version` from response headers


## Tests

- `npm test -- --runTestsByPath src/lib/hooks/__tests__/useConnection.test.tsx --runInBand`
- `npm run lint` in `client`
- `npm run build` in `client`
- `npx prettier --check client/src/App.tsx client/src/components/Sidebar.tsx client/src/lib/hooks/useConnection.ts client/src/lib/hooks/__tests__/useConnection.test.tsx`