### PR TITLE
fix(cli): resolve package metadata from module path

### DIFF
--- a/cli/__tests__/cli.test.ts
+++ b/cli/__tests__/cli.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { runCli } from "./helpers/cli-runner.js";
 import {
   expectCliSuccess,
@@ -18,6 +21,37 @@ import {
   createEchoTool,
   createTestServerInfo,
 } from "./helpers/test-fixtures.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function createPublishedCliFixture(): {
+  cliPath: string;
+  cwd: string;
+  root: string;
+} {
+  const root = mkdtempSync(join(process.cwd(), ".published-cli-"));
+  mkdirSync(join(root, "cli"), { recursive: true });
+  cpSync(resolve(__dirname, "../build"), join(root, "cli", "build"), {
+    recursive: true,
+  });
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({
+      name: "@modelcontextprotocol/inspector",
+      version: "0.0.0-test",
+      type: "module",
+    }),
+  );
+
+  const cwd = join(root, "runner");
+  mkdirSync(cwd);
+
+  return {
+    cliPath: join(root, "cli", "build", "cli.js"),
+    cwd,
+    root,
+  };
+}
 
 describe("CLI Tests", () => {
   describe("Basic CLI Mode", () => {
@@ -41,6 +75,30 @@ describe("CLI Tests", () => {
       expect(toolNames).toContain("echo");
       expect(toolNames).toContain("get-sum");
       expect(toolNames).toContain("get-annotated-message");
+    });
+
+    it("should resolve package metadata from a published package layout", async () => {
+      const { command, args } = getTestMcpServerCommand();
+      const fixture = createPublishedCliFixture();
+
+      try {
+        const result = await runCli(
+          [command, ...args, "--cli", "--method", "tools/list"],
+          {
+            cliPath: fixture.cliPath,
+            cwd: fixture.cwd,
+          },
+        );
+
+        expectCliSuccess(result);
+        const json = expectValidJson(result);
+        expect(json).toHaveProperty("tools");
+        expect(Array.isArray(json.tools)).toBe(true);
+        const toolNames = json.tools.map((tool: any) => tool.name);
+        expect(toolNames).toContain("echo");
+      } finally {
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
     });
 
     it("should fail with nonexistent method", async () => {

--- a/cli/__tests__/helpers/cli-runner.ts
+++ b/cli/__tests__/helpers/cli-runner.ts
@@ -16,6 +16,7 @@ export interface CliResult {
 export interface CliOptions {
   timeout?: number;
   cwd?: string;
+  cliPath?: string;
   env?: Record<string, string>;
   signal?: AbortSignal;
 }
@@ -28,7 +29,7 @@ export async function runCli(
   options: CliOptions = {},
 ): Promise<CliResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn("node", [CLI_PATH, ...args], {
+    const child = spawn("node", [options.cliPath ?? CLI_PATH, ...args], {
       stdio: ["pipe", "pipe", "pipe"],
       cwd: options.cwd,
       env: { ...process.env, ...options.env },

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -103,10 +103,18 @@ function createTransportOptions(
 
 async function callMethod(args: Args): Promise<void> {
   // Read package.json to get name and version for client identity
-  const pathA = "../package.json"; // We're in package @modelcontextprotocol/inspector-cli
-  const pathB = "../../package.json"; // We're in package @modelcontextprotocol/inspector
+  const packageJsonUrls = [
+    new URL("../package.json", import.meta.url), // We're in package @modelcontextprotocol/inspector-cli
+    new URL("../../package.json", import.meta.url), // We're in package @modelcontextprotocol/inspector
+  ];
   let packageJson: { name: string; version: string };
-  let packageJsonData = await import(fs.existsSync(pathA) ? pathA : pathB, {
+  const packageJsonUrl = packageJsonUrls.find((url) => fs.existsSync(url));
+
+  if (!packageJsonUrl) {
+    throw new Error("Unable to locate package.json for client identity");
+  }
+
+  let packageJsonData = await import(packageJsonUrl.href, {
     with: { type: "json" },
   });
   packageJson = packageJsonData.default;


### PR DESCRIPTION
﻿## Summary

Fixes CLI package metadata lookup so `--cli` mode resolves package.json relative to the built module instead of the process working directory.

> **Note:** Inspector V2 is under development to address architectural and UX improvements. During this time, V1 contributions should focus on **bug fixes and MCP spec compliance**. See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test updates
- [ ] Build/CI improvements

## Changes Made

- Resolve the CLI client identity package metadata from `import.meta.url`-relative package.json URLs.
- Preserve support for both package layouts:
  - `@modelcontextprotocol/inspector-cli` with `../package.json`
  - `@modelcontextprotocol/inspector` with `../../package.json`
- Add a regression test that copies the built CLI into a published-package-like fixture without `cli/package.json`, then runs from a cwd where `../package.json` exists.

## Related Issues

Fixes #1334

## Testing

- [ ] Tested in UI mode
- [x] Tested in CLI mode
- [x] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [ ] Manual testing performed

### Test Results and/or Instructions

Passed locally on Windows with Node v24.13.0:

```bash
npm run build-cli
npx prettier --check cli/src/index.ts cli/__tests__/cli.test.ts cli/__tests__/helpers/cli-runner.ts
cd cli; npx vitest run __tests__/cli.test.ts -t "should resolve package metadata from a published package layout"
cd cli; npx vitest run __tests__/cli.test.ts -t "should execute tools/list successfully"
```

I also ran `npm run test-cli`; the full suite has existing Windows/Node 24 HTTP transport subprocess failures where the CLI prints the expected JSON but exits with `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76`. The new stdio regression test passes independently and avoids that unrelated Windows HTTP teardown path.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix` equivalent on changed files)
- [x] Self-review completed
- [ ] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None.

## Additional Context

The previous existence check used cwd-relative strings (`../package.json` / `../../package.json`) to decide which module-relative JSON import to perform. If a caller ran the published root package from a cwd where `../package.json` existed, the CLI could choose `../package.json` and then fail because that file is not included under `cli/` in the root package layout.
