### PR TITLE
feat(client): handle tools/resources/prompts list_changed notifications (closes #832)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -404,6 +404,15 @@ const App = () => {
       if (notification.method === "notifications/tasks/list_changed") {
         void listTasks();
       }
+      if (notification.method === "notifications/tools/list_changed") {
+        void listTools();
+      }
+      if (notification.method === "notifications/resources/list_changed") {
+        void listResources();
+      }
+      if (notification.method === "notifications/prompts/list_changed") {
+        void listPrompts();
+      }
 
       if (notification.method === "notifications/tasks/status") {
         const task = notification.params as unknown as Task;


### PR DESCRIPTION
Implements #832 — list-changed notification handling for tools, resources, and prompts.

### Why this matters

Per the MCP spec, a server that advertises `tools: { listChanged: true }` (or `resources` / `prompts`) sends `notifications/{tools,resources,prompts}/list_changed` whenever its catalog changes — e.g. a gateway MCP server dynamically loading/unloading tools, a server that hot-reloads its config, or any flow that mutates the catalog mid-session.

Before this PR, the inspector imported `ToolListChangedNotificationSchema`, `ResourceListChangedNotificationSchema`, and `PromptListChangedNotificationSchema` from the SDK (see `client/src/lib/hooks/useConnection.ts:27-29`) but never wired them up. As a result, when a real server sent these notifications, the inspector's view became stale — users had to manually reconnect or switch tabs to see the new tools.

### The fix

Three additional handlers in the `onNotification` callback in `client/src/App.tsx`, matching the pattern already used for `notifications/tasks/list_changed`:

```diff
       if (notification.method === "notifications/tasks/list_changed") {
         void listTasks();
       }
+      if (notification.method === "notifications/tools/list_changed") {
+        void listTools();
+      }
+      if (notification.method === "notifications/resources/list_changed") {
+        void listResources();
+      }
+      if (notification.method === "notifications/prompts/list_changed") {
+        void listPrompts();
+      }
```

`listTools`, `listResources`, and `listPrompts` are already defined further down in the same component (lines 861, 982, 995) and are what the existing UI buttons call when the user clicks "Refresh". The notification handlers reuse them — no new fetch logic, no risk of drift between manual refresh and notification-driven refresh.

### Why no capability check

The MCP spec says servers shouldn't send `list_changed` notifications unless they advertised `listChanged: true` in `initialize`. A malformed server that sends them anyway is its own bug — handling them here is a no-op against an empty list, so there's no harm. Skipping the capability gate keeps the patch minimal.

### Verification

Followed the CONTRIBUTING.md checklist:

- `npm run prettier-check` → all files pass
- `npm test` → **515 / 515** test suites pass (no regressions, no new tests required by CONTRIBUTING for a small spec-compliance bug fix)

Closes #832.
