### PR TITLE
fix: route OAuth callback token exchange through proxy fetch

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1285,7 +1285,11 @@ const App = () => {
     );
     return (
       <Suspense fallback={<div>Loading...</div>}>
-        <OAuthCallback onConnect={onOAuthConnect} />
+        <OAuthCallback
+          onConnect={onOAuthConnect}
+          config={config}
+          connectionType={connectionType}
+        />
       </Suspense>
     );
   }

--- a/client/src/components/OAuthCallback.tsx
+++ b/client/src/components/OAuthCallback.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { InspectorOAuthClientProvider } from "../lib/auth";
 import { SESSION_KEYS } from "../lib/constants";
 import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
@@ -7,14 +7,30 @@ import {
   generateOAuthErrorDescription,
   parseOAuthCallbackParams,
 } from "@/utils/oauthUtils.ts";
+import { createProxyFetch } from "@/lib/proxyFetch";
+import { InspectorConfig } from "@/lib/configurationTypes";
 
 interface OAuthCallbackProps {
   onConnect: (serverUrl: string) => void;
+  config: InspectorConfig;
+  connectionType: "direct" | "proxy";
 }
 
-const OAuthCallback = ({ onConnect }: OAuthCallbackProps) => {
+const OAuthCallback = ({
+  onConnect,
+  config,
+  connectionType,
+}: OAuthCallbackProps) => {
   const { toast } = useToast();
   const hasProcessedRef = useRef(false);
+
+  const fetchFn = useMemo(
+    () =>
+      connectionType === "proxy" && config
+        ? createProxyFetch(config)
+        : undefined,
+    [connectionType, config],
+  );
 
   useEffect(() => {
     const handleCallback = async () => {
@@ -49,6 +65,7 @@ const OAuthCallback = ({ onConnect }: OAuthCallbackProps) => {
         result = await auth(serverAuthProvider, {
           serverUrl,
           authorizationCode: params.code,
+          ...(fetchFn && { fetchFn }),
         });
       } catch (error) {
         console.error("OAuth callback error:", error);
@@ -73,7 +90,7 @@ const OAuthCallback = ({ onConnect }: OAuthCallbackProps) => {
     handleCallback().finally(() => {
       window.history.replaceState({}, document.title, "/");
     });
-  }, [toast, onConnect]);
+  }, [toast, onConnect, fetchFn]);
 
   return (
     <div className="flex items-center justify-center h-screen">


### PR DESCRIPTION
## Summary

The `/oauth/callback` handler calls `auth()` without passing a `fetchFn`, so the SDK falls back to global `fetch` for the metadata + token-endpoint requests. Auth servers that emit incomplete CORS headers on POST responses (e.g. `/oauth2/token` returning **no** `Access-Control-Allow-Origin` even though the preflight does) cause the token exchange to fail with `TypeError: Failed to fetch` — even when the initial registration phase succeeded via the existing proxy fetch path.

This matches the proxy-fetch pattern already used in `useConnection.handleAuthError` and `AuthDebugger`, so it's not a new mechanism — just an existing one applied to the callback that was missed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `client/src/components/OAuthCallback.tsx`: accept `config` and `connectionType` props; build a `createProxyFetch(config)` when `connectionType === "proxy"`; pass that as `fetchFn` to `auth()`.
- `client/src/App.tsx`: thread `config` and `connectionType` through to the lazy-loaded `OAuthCallback`.

Net diff: +25 / -4.

## Related Issues

None filed yet. The same root cause as the proxy-fetch work in `useConnection` (commit that added `createProxyFetch`), just for a different callsite.

## Testing

- [x] Tested in UI mode
- [x] Tested with Streamable HTTP transport
- [x] Manual testing performed
- [ ] Added/updated automated tests *(no existing tests for `OAuthCallback.tsx`)*

### Reproducer

Real-world repro against WorkOS's demo MCP — its auth server `signin.shop.workos.com` returns no `Access-Control-Allow-Origin` on the `/oauth2/token` POST response (only on the preflight).

1. Start inspector, transport = Streamable HTTP, URL = `https://shop.workos.com/mcp`, Connection Type = Via Proxy.
2. Click Connect → 401 → OAuth flow kicks off.
3. **Without this fix**: metadata discovery + registration succeed through `/fetch`, browser redirects to authorize, user signs in, lands at `/oauth/callback?code=...`, then `TypeError: Failed to fetch` toast appears and the token exchange dies. Browser console shows three CORS errors against `signin.shop.workos.com` `.well-known/*` and `/oauth2/token` endpoints.
4. **With this fix**: the same three requests are made via `localhost:6277/fetch` instead, the token exchange completes, and the inspector connects to the MCP server.

### Test Results

`npm test -- --testPathPattern="OAuthCallback|App|proxyFetch"` → 59/59 pass. Prettier check passes on changed files.

## Checklist

- [x] Code follows the style guidelines (`prettier --check` passes)
- [x] Self-review completed
- [x] Code is commented where necessary

## Breaking Changes

None. `OAuthCallback` gains two required props but it's only mounted from one place in `App.tsx` (line 1288), which is updated in this PR.

## Additional Context

The original proxy-fetch work landed for the initial-connection OAuth flow but the callback was a separate code path. With both wired up, the inspector now works end-to-end against any auth server whose CORS is "good enough for browsers that don't preflight" but trips on POST responses — a class of misconfiguration we've seen in the wild beyond just WorkOS.