### PR TITLE
feat(servers): export server list as mcp.json download (#1346)

### DIFF
--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -21,6 +21,7 @@ import { ManagedResourcesState } from "@inspector/core/mcp/state/managedResource
 import { ManagedResourceTemplatesState } from "@inspector/core/mcp/state/managedResourceTemplatesState.js";
 import { ManagedRequestorTasksState } from "@inspector/core/mcp/state/managedRequestorTasksState.js";
 import { ResourceSubscriptionsState } from "@inspector/core/mcp/state/resourceSubscriptionsState.js";
+import { serverEntriesToMcpConfig } from "@inspector/core/mcp/serverList.js";
 import { MessageLogState } from "@inspector/core/mcp/state/messageLogState.js";
 import { FetchRequestLogState } from "@inspector/core/mcp/state/fetchRequestLogState.js";
 import { StderrLogState } from "@inspector/core/mcp/state/stderrLogState.js";
@@ -605,6 +606,26 @@ function App() {
     /* TODO: not wired yet */
   }, []);
 
+  // Download the current server list as a canonical mcp.json file. Uses the
+  // in-memory `servers` list (kept in sync with disk by useServers' refresh-
+  // after-mutate flow) so there's no extra HTTP roundtrip. The 2-space
+  // indent matches serializeStore on the backend, so a round-trip through
+  // export → hand-edit → import (or symlink into Claude Desktop) preserves
+  // formatting. Append-to-body before click is for Firefox compatibility;
+  // modern browsers don't require it but it's the safe pattern.
+  const onServerExport = useCallback(() => {
+    const json = JSON.stringify(serverEntriesToMcpConfig(servers), null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "mcp.json";
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }, [servers]);
+
   // Remove handler — runs after the user confirms in the modal. When removing
   // the active server, also tear down the session in-place so the client and
   // its 9 state managers can be GC'd now instead of lingering until the next
@@ -740,6 +761,7 @@ function App() {
         onServerAdd={() => setConfigModal({ mode: "add" })}
         onServerImportConfig={todoNoop}
         onServerImportJson={todoNoop}
+        onServerExport={onServerExport}
         onServerInfo={todoNoop}
         onServerSettings={todoNoop}
         onServerEdit={(id) => setConfigModal({ mode: "edit", targetId: id })}

--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -21,7 +21,7 @@ import { ManagedResourcesState } from "@inspector/core/mcp/state/managedResource
 import { ManagedResourceTemplatesState } from "@inspector/core/mcp/state/managedResourceTemplatesState.js";
 import { ManagedRequestorTasksState } from "@inspector/core/mcp/state/managedRequestorTasksState.js";
 import { ResourceSubscriptionsState } from "@inspector/core/mcp/state/resourceSubscriptionsState.js";
-import { serverEntriesToMcpConfig } from "@inspector/core/mcp/serverList.js";
+import { serializeMcpConfig } from "@inspector/core/mcp/serverList.js";
 import { MessageLogState } from "@inspector/core/mcp/state/messageLogState.js";
 import { FetchRequestLogState } from "@inspector/core/mcp/state/fetchRequestLogState.js";
 import { StderrLogState } from "@inspector/core/mcp/state/stderrLogState.js";
@@ -46,6 +46,7 @@ import {
   type ServerConfigModalMode,
 } from "./components/groups/ServerConfigModal/ServerConfigModal";
 import { ServerRemoveConfirmModal } from "./components/groups/ServerRemoveConfirmModal/ServerRemoveConfirmModal";
+import { downloadJsonFile } from "./lib/downloadFile";
 import { createWebEnvironment } from "./lib/environmentFactory";
 
 // OAuth redirect URL provider — points at the dev backend's `/oauth/callback`
@@ -608,22 +609,14 @@ function App() {
 
   // Download the current server list as a canonical mcp.json file. Uses the
   // in-memory `servers` list (kept in sync with disk by useServers' refresh-
-  // after-mutate flow) so there's no extra HTTP roundtrip. The 2-space
-  // indent matches serializeStore on the backend, so a round-trip through
-  // export → hand-edit → import (or symlink into Claude Desktop) preserves
-  // formatting. Append-to-body before click is for Firefox compatibility;
-  // modern browsers don't require it but it's the safe pattern.
+  // after-mutate flow) so there's no extra HTTP roundtrip. Serialization
+  // format (2-space indent) lives in serializeMcpConfig so the export
+  // matches what serializeStore writes on the backend. The button is
+  // disabled when the list is empty, but the guard here keeps the handler
+  // locally correct against any future programmatic caller.
   const onServerExport = useCallback(() => {
-    const json = JSON.stringify(serverEntriesToMcpConfig(servers), null, 2);
-    const blob = new Blob([json], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = "mcp.json";
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
-    URL.revokeObjectURL(url);
+    if (servers.length === 0) return;
+    downloadJsonFile("mcp.json", serializeMcpConfig(servers));
   }, [servers]);
 
   // Remove handler — runs after the user confirms in the modal. When removing

--- a/clients/web/src/components/groups/ServerListControls/ServerListControls.stories.tsx
+++ b/clients/web/src/components/groups/ServerListControls/ServerListControls.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 import { ServerListControls } from "./ServerListControls";
 
 const meta: Meta<typeof ServerListControls> = {
@@ -18,6 +18,17 @@ export const WithServers: Story = {
     onAddManually: fn(),
     onImportConfig: fn(),
     onImportServerJson: fn(),
+    onExport: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    // Real-Chromium regression guard: Export is enabled when servers exist,
+    // and clicking it fires onExport. Unit tests cover the same path under
+    // happy-dom; this catches anything browser-specific in the wiring.
+    const body = within(canvasElement.ownerDocument.body);
+    const exportBtn = await body.findByRole("button", { name: /Export/ });
+    await expect(exportBtn).not.toBeDisabled();
+    await userEvent.click(exportBtn);
+    await expect(args.onExport).toHaveBeenCalledTimes(1);
   },
 };
 
@@ -29,5 +40,11 @@ export const WithoutServers: Story = {
     onAddManually: fn(),
     onImportConfig: fn(),
     onImportServerJson: fn(),
+    onExport: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    const exportBtn = await body.findByRole("button", { name: /Export/ });
+    await expect(exportBtn).toBeDisabled();
   },
 };

--- a/clients/web/src/components/groups/ServerListControls/ServerListControls.test.tsx
+++ b/clients/web/src/components/groups/ServerListControls/ServerListControls.test.tsx
@@ -10,19 +10,23 @@ const baseProps = {
   onAddManually: vi.fn(),
   onImportConfig: vi.fn(),
   onImportServerJson: vi.fn(),
+  onExport: vi.fn(),
 };
 
 describe("ServerListControls", () => {
-  it("hides the list toggle when there are no servers", () => {
+  it("hides the list toggle when there are no servers (Export + Add Servers remain)", () => {
     renderWithMantine(<ServerListControls {...baseProps} />);
     const buttons = screen.getAllByRole("button");
-    expect(buttons).toHaveLength(1);
-    expect(buttons[0]).toHaveAccessibleName(/Add Servers/);
+    expect(buttons).toHaveLength(2);
+    expect(screen.getByRole("button", { name: /Export/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Add Servers/ }),
+    ).toBeInTheDocument();
   });
 
-  it("shows the list toggle when servers exist", () => {
+  it("shows the list toggle alongside Export + Add Servers when servers exist", () => {
     renderWithMantine(<ServerListControls {...baseProps} serverCount={2} />);
-    expect(screen.getAllByRole("button")).toHaveLength(2);
+    expect(screen.getAllByRole("button")).toHaveLength(3);
   });
 
   it("calls onToggleList when the list toggle is clicked", async () => {
@@ -38,5 +42,25 @@ describe("ServerListControls", () => {
     const buttons = screen.getAllByRole("button");
     await user.click(buttons[0]);
     expect(onToggleList).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Export when the list is empty (nothing to download)", () => {
+    renderWithMantine(<ServerListControls {...baseProps} />);
+    expect(screen.getByRole("button", { name: /Export/ })).toBeDisabled();
+  });
+
+  it("enables Export when at least one server exists", () => {
+    renderWithMantine(<ServerListControls {...baseProps} serverCount={1} />);
+    expect(screen.getByRole("button", { name: /Export/ })).not.toBeDisabled();
+  });
+
+  it("calls onExport when Export is clicked (with at least one server)", async () => {
+    const user = userEvent.setup();
+    const onExport = vi.fn();
+    renderWithMantine(
+      <ServerListControls {...baseProps} serverCount={1} onExport={onExport} />,
+    );
+    await user.click(screen.getByRole("button", { name: /Export/ }));
+    expect(onExport).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/components/groups/ServerListControls/ServerListControls.tsx
+++ b/clients/web/src/components/groups/ServerListControls/ServerListControls.tsx
@@ -1,4 +1,4 @@
-import { Group } from "@mantine/core";
+import { Button, Group } from "@mantine/core";
 import { ListToggle } from "../../elements/ListToggle/ListToggle";
 import {
   ServerAddMenu,
@@ -9,6 +9,8 @@ export interface ServerListControlsProps extends AddServerMenuProps {
   compact: boolean;
   serverCount: number;
   onToggleList: () => void;
+  /** Download the current server list as a canonical `mcp.json` file. */
+  onExport: () => void;
 }
 
 export function ServerListControls({
@@ -18,12 +20,16 @@ export function ServerListControls({
   onAddManually,
   onImportConfig,
   onImportServerJson,
+  onExport,
 }: ServerListControlsProps) {
   return (
     <Group justify="flex-end">
       {serverCount > 0 && (
         <ListToggle compact={compact} onToggle={onToggleList} />
       )}
+      <Button variant="default" onClick={onExport} disabled={serverCount === 0}>
+        Export
+      </Button>
       <ServerAddMenu
         onAddManually={onAddManually}
         onImportConfig={onImportConfig}

--- a/clients/web/src/components/screens/ServerListScreen/ServerListScreen.stories.tsx
+++ b/clients/web/src/components/screens/ServerListScreen/ServerListScreen.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta<typeof ServerListScreen> = {
     onAddManually: fn(),
     onImportConfig: fn(),
     onImportServerJson: fn(),
+    onExport: fn(),
     onToggleConnection: fn(),
     onServerInfo: fn(),
     onSettings: fn(),

--- a/clients/web/src/components/screens/ServerListScreen/ServerListScreen.test.tsx
+++ b/clients/web/src/components/screens/ServerListScreen/ServerListScreen.test.tsx
@@ -18,6 +18,7 @@ const baseProps = {
   onAddManually: vi.fn(),
   onImportConfig: vi.fn(),
   onImportServerJson: vi.fn(),
+  onExport: vi.fn(),
   onToggleConnection: vi.fn(),
   onServerInfo: vi.fn(),
   onSettings: vi.fn(),

--- a/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
+++ b/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
@@ -11,6 +11,8 @@ export interface ServerListScreenProps {
   onAddManually: () => void;
   onImportConfig: () => void;
   onImportServerJson: () => void;
+  /** Download the current server list as a canonical `mcp.json` file. */
+  onExport: () => void;
   onToggleConnection: (id: string) => void;
   onServerInfo: (id: string) => void;
   onSettings: (id: string) => void;
@@ -35,6 +37,7 @@ export function ServerListScreen({
   onAddManually,
   onImportConfig,
   onImportServerJson,
+  onExport,
   onToggleConnection,
   onServerInfo,
   onSettings,
@@ -57,6 +60,7 @@ export function ServerListScreen({
         onAddManually={onAddManually}
         onImportConfig={onImportConfig}
         onImportServerJson={onImportServerJson}
+        onExport={onExport}
       />
 
       <ScrollArea.Autosize mah="calc(100vh - var(--app-shell-header-height, 60px) - var(--mantine-spacing-xl) * 2 - 60px)">

--- a/clients/web/src/components/views/InspectorView/InspectorView.stories.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.stories.tsx
@@ -294,6 +294,7 @@ const meta: Meta<typeof InspectorView> = {
     onServerAdd: fn(),
     onServerImportConfig: fn(),
     onServerImportJson: fn(),
+    onServerExport: fn(),
     onServerInfo: fn(),
     onServerSettings: fn(),
     onServerEdit: fn(),

--- a/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
@@ -58,6 +58,7 @@ function makeProps(
     onServerAdd: vi.fn(),
     onServerImportConfig: vi.fn(),
     onServerImportJson: vi.fn(),
+    onServerExport: vi.fn(),
     onServerInfo: vi.fn(),
     onServerSettings: vi.fn(),
     onServerEdit: vi.fn(),

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -154,6 +154,8 @@ export interface InspectorViewProps {
   onServerAdd: () => void;
   onServerImportConfig: () => void;
   onServerImportJson: () => void;
+  /** Download the current server list as a canonical `mcp.json` file. */
+  onServerExport: () => void;
   onServerInfo: (id: string) => void;
   onServerSettings: (id: string) => void;
   onServerEdit: (id: string) => void;
@@ -233,6 +235,7 @@ export function InspectorView({
   onServerAdd,
   onServerImportConfig,
   onServerImportJson,
+  onServerExport,
   onServerInfo,
   onServerSettings,
   onServerEdit,
@@ -356,6 +359,7 @@ export function InspectorView({
               onAddManually={onServerAdd}
               onImportConfig={onServerImportConfig}
               onImportServerJson={onServerImportJson}
+              onExport={onServerExport}
               onToggleConnection={onToggleConnection}
               onServerInfo={onServerInfo}
               onSettings={onServerSettings}

--- a/clients/web/src/lib/downloadFile.ts
+++ b/clients/web/src/lib/downloadFile.ts
@@ -1,0 +1,32 @@
+/**
+ * Browser-side helpers for triggering file downloads from in-memory content.
+ *
+ * Centralized so the temp-anchor incantation (`appendChild` for Firefox,
+ * try/finally to keep cleanup bulletproof, `revokeObjectURL` to release the
+ * object URL) lives in one place — and so the wiring is unit-testable
+ * under happy-dom without dragging React along.
+ */
+
+/**
+ * Download an in-memory string as a JSON file. Uses a temporary anchor
+ * element to trigger the browser's save dialog. The append-to-body step is
+ * for older Firefox versions that wouldn't fire `click()` on a detached
+ * anchor; modern browsers don't require it but it stays as the safe path.
+ *
+ * The cleanup (removeChild + revokeObjectURL) runs in a `finally` so even
+ * a thrown `click()` doesn't leak the DOM node or the object URL.
+ */
+export function downloadJsonFile(filename: string, json: string): void {
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  try {
+    anchor.click();
+  } finally {
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+}

--- a/clients/web/src/test/core/mcp/serverList.test.ts
+++ b/clients/web/src/test/core/mcp/serverList.test.ts
@@ -4,6 +4,7 @@ import {
   mcpConfigToServerEntries,
   normalizeServerType,
   serverEntriesToMcpConfig,
+  serializeMcpConfig,
 } from "@inspector/core/mcp/serverList.js";
 import type { MCPConfig, ServerEntry } from "@inspector/core/mcp/types.js";
 
@@ -166,6 +167,42 @@ describe("serverEntriesToMcpConfig", () => {
       "a",
       "b",
     ]);
+  });
+});
+
+describe("serializeMcpConfig", () => {
+  it("produces 2-space-indented canonical JSON", () => {
+    const json = serializeMcpConfig([
+      {
+        id: "alpha",
+        name: "alpha",
+        config: { type: "stdio", command: "node" },
+        connection: { status: "disconnected" },
+      },
+    ]);
+    expect(json).toBe(
+      `{\n  "mcpServers": {\n    "alpha": {\n      "type": "stdio",\n      "command": "node"\n    }\n  }\n}`,
+    );
+  });
+
+  it("strips runtime-only fields (connection, info, name) from the output", () => {
+    const json = serializeMcpConfig([
+      {
+        id: "alpha",
+        name: "Alpha (pretty)",
+        config: { type: "stdio", command: "node" },
+        connection: { status: "connected" },
+        info: { name: "alpha-impl", version: "1.0.0" },
+      },
+    ]);
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      mcpServers: { alpha: { type: "stdio", command: "node" } },
+    });
+  });
+
+  it('returns `{ "mcpServers": {} }` for an empty list', () => {
+    expect(serializeMcpConfig([])).toBe(`{\n  "mcpServers": {}\n}`);
   });
 });
 

--- a/clients/web/src/test/lib/downloadFile.test.ts
+++ b/clients/web/src/test/lib/downloadFile.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the downloadJsonFile helper. Mocks URL.createObjectURL +
+ * URL.revokeObjectURL (happy-dom doesn't ship them) and asserts the temp
+ * anchor's attributes + click + cleanup sequence.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { downloadJsonFile } from "../../lib/downloadFile";
+
+describe("downloadJsonFile", () => {
+  const originalCreate = URL.createObjectURL;
+  const originalRevoke = URL.revokeObjectURL;
+  let createMock: ReturnType<typeof vi.fn>;
+  let revokeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    createMock = vi.fn().mockReturnValue("blob:mock-url");
+    revokeMock = vi.fn();
+    // happy-dom doesn't implement URL.createObjectURL/revokeObjectURL.
+    URL.createObjectURL = createMock as unknown as typeof URL.createObjectURL;
+    URL.revokeObjectURL = revokeMock as unknown as typeof URL.revokeObjectURL;
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreate;
+    URL.revokeObjectURL = originalRevoke;
+    vi.restoreAllMocks();
+  });
+
+  it("creates an anchor with the right href + download attributes and clicks it", () => {
+    const clickedAnchors: HTMLAnchorElement[] = [];
+    const origCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation(((tag: string) => {
+      const el = origCreateElement(tag) as HTMLAnchorElement;
+      if (tag === "a") {
+        el.click = function click() {
+          clickedAnchors.push(el);
+        };
+      }
+      return el;
+    }) as typeof document.createElement);
+
+    downloadJsonFile("mcp.json", '{"hello":"world"}');
+
+    expect(createMock).toHaveBeenCalledOnce();
+    const blob = createMock.mock.calls[0]?.[0] as Blob;
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("application/json");
+
+    expect(clickedAnchors).toHaveLength(1);
+    const anchor = clickedAnchors[0]!;
+    expect(anchor.getAttribute("href")).toBe("blob:mock-url");
+    expect(anchor.getAttribute("download")).toBe("mcp.json");
+
+    // After the call, the anchor must be removed and the URL revoked.
+    expect(document.body.contains(anchor)).toBe(false);
+    expect(revokeMock).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("still cleans up the anchor + URL when click() throws (try/finally guard)", () => {
+    const removed: Node[] = [];
+    const origCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation(((tag: string) => {
+      const el = origCreateElement(tag) as HTMLAnchorElement;
+      if (tag === "a") {
+        el.click = () => {
+          throw new Error("simulated click failure");
+        };
+      }
+      return el;
+    }) as typeof document.createElement);
+    // Stub removeChild outright so the throw doesn't double up with a
+    // "not a child" error from a partially-mocked DOM.
+    vi.spyOn(document.body, "removeChild").mockImplementation(((node: Node) => {
+      removed.push(node);
+      return node;
+    }) as typeof document.body.removeChild);
+
+    expect(() => downloadJsonFile("oops.json", '{"oops":true}')).toThrow(
+      /simulated click failure/,
+    );
+
+    // Cleanup still ran despite the throw.
+    expect(removed).toHaveLength(1);
+    expect(revokeMock).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("passes the JSON string into the Blob constructor verbatim", async () => {
+    downloadJsonFile("test.json", '{"x":1}');
+    const blob = createMock.mock.calls[0]?.[0] as Blob;
+    const text = await blob.text();
+    expect(text).toBe('{"x":1}');
+  });
+});

--- a/core/mcp/serverList.ts
+++ b/core/mcp/serverList.ts
@@ -79,6 +79,17 @@ export function serverEntriesToMcpConfig(entries: ServerEntry[]): MCPConfig {
 }
 
 /**
+ * Canonical JSON serialization for `mcp.json` files. Two-space indent — the
+ * same format `serializeStore` in core/storage/store-io.ts writes on the
+ * backend, so a round-trip through export → hand-edit → import preserves
+ * the on-disk shape. Browser-safe (no Node imports); the backend uses the
+ * Node-only serializeStore but the formatting must match.
+ */
+export function serializeMcpConfig(entries: ServerEntry[]): string {
+  return JSON.stringify(serverEntriesToMcpConfig(entries), null, 2);
+}
+
+/**
  * Default seeds written to `~/.mcp-inspector/mcp.json` on first launch when
  * the file is absent. Picked to cover the two shapes a developer reaches for
  * first: a real filesystem scoped to /tmp, and the canonical "everything"


### PR DESCRIPTION
Closes #1346. Follow-up to #1349 (the server-list file).

## Summary

- Adds an **Export** button to the Servers screen, next to "Add Servers". Clicking it downloads the current server list as a canonical `mcp.json` (2-space indent, same shape the backend writes via `serializeStore`).
- Disabled when the list is empty — nothing to download.
- Pure client-side: no backend changes, no extra HTTP roundtrip. The handler reads the in-memory `servers` list (kept in sync with disk by `useServers`' refresh-after-mutate flow), runs it through `serverEntriesToMcpConfig`, and dispatches a Blob via a temporary anchor.

## Wiring

| File | Change |
|---|---|
| `ServerListControls.tsx` | New `Button variant="default"` between the list toggle and the Add Servers menu; `disabled={serverCount === 0}` |
| `ServerListScreen.tsx` | Threads `onExport` through |
| `InspectorView.tsx` | Adds `onServerExport` to the view prop interface; passes through as `onExport` |
| `App.tsx` | `onServerExport` `useCallback`: serialize + Blob + temp anchor + click + revoke. Appends to body before click for Firefox compatibility, removes after |

## Tests

- **Unit (happy-dom):** ServerListControls tests cover the new button — present in both empty and populated states, disabled-on-empty, enabled-with-servers, click fires `onExport`. Existing tests/stories for `ServerListScreen` + `InspectorView` updated for the new prop.
- **Storybook (real Chromium):** both `ServerListControls` stories grow `play` functions — `WithServers` asserts Export is enabled and a click fires the spy; `WithoutServers` asserts Export is disabled. Real-browser regression guard for anything browser-specific in the wiring.

**Totals:** 1641 unit (+3) + 410 integration + 306 storybook = 2357 green.

## Test plan

- [x] `npm run validate`
- [x] `npm run test:integration`
- [x] `npm run test:storybook`
- [ ] Manual smoke: click Export with the two-seed first-run list, verify `mcp.json` lands in Downloads with both seed servers in canonical format. Click Export after removing all servers, verify button is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)