### PR TITLE
fix: declare commander as a direct dependency (#873)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@modelcontextprotocol/inspector-client": "^0.21.2",
     "@modelcontextprotocol/inspector-server": "^0.21.2",
     "@modelcontextprotocol/sdk": "^1.25.2",
+    "commander": "^13.1.0",
     "concurrently": "^9.2.0",
     "node-fetch": "^3.3.2",
     "open": "^10.2.0",


### PR DESCRIPTION
Closes #873.

## What's wrong

The top-level \`@modelcontextprotocol/inspector\` package ships \`cli/build/cli.js\` as its \`bin\` (it's in the published \`files\` list). That file imports \`commander\` at runtime, but \`commander\` was only declared on the sibling \`@modelcontextprotocol/inspector-cli\` workspace package.

Under npm, the package resolves fine because npm flat-hoists \`commander\` to the top of \`node_modules\`. Under pnpm and other strict installers there's no hoisting, so users hit:

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'commander' imported from
node_modules/.pnpm/@modelcontextprotocol+inspector@0.21.2_.../node_modules/@modelcontextprotocol/inspector/cli/build/cli.js
\`\`\`

## What this PR does

Adds \`\"commander\": \"^13.1.0\"\` to the top-level \`package.json\` so the published bin script can resolve its runtime imports regardless of which installer (or hoisting strategy) the user has chosen. This is Option 1 from the issue, kept narrow so the rest of the publishing layout is unchanged.

I audited the rest of \`cli/src/*.ts\` for external imports. The only non-Node runtime packages it pulls are:

- \`commander\` (this PR)
- \`@modelcontextprotocol/sdk\` (already a top-level dep)
- \`spawn-rx\` (already a top-level dep)

\`express\` is in \`cli/package.json\` but only used in \`cli/__tests__/helpers/test-server-http.ts\`, so it doesn't need to be hoisted to the published top-level.

## Lockfile

I left \`package-lock.json\` alone in this PR because the project's CI runs \`npm install --no-package-lock\` and a fresh \`npm install --package-lock-only\` on my machine produced a noisy diff (~60 unrelated \`peer: true\` toggles from npm normalising my local resolution). Happy to fold a clean lockfile bump into the same commit if you'd prefer, just let me know.