### PR TITLE
fix(client): remove place-items: center from body so app fills window width

### DIFF
--- a/client/e2e/full-window-width.spec.ts
+++ b/client/e2e/full-window-width.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+// Regression for #876 — body{ place-items: center } in the Vite template
+// default centered the React tree inside a grid context and left visible
+// margins on either side. The app root should fill the viewport width.
+const APP_URL = "http://localhost:6274/";
+const VIEWPORT = { width: 1920, height: 1080 };
+// Allow for a scrollbar gutter; widths within this tolerance count as "filled".
+const TOLERANCE_PX = 20;
+
+test.describe("Full window width", () => {
+  test.use({ viewport: VIEWPORT });
+
+  test("app root fills the viewport width", async ({ page }) => {
+    await page.goto(APP_URL);
+
+    const rootWidth = await page.evaluate(() => {
+      const root = document.getElementById("root");
+      if (!root) throw new Error("#root not found");
+      return root.getBoundingClientRect().width;
+    });
+
+    expect(rootWidth).toBeGreaterThanOrEqual(VIEWPORT.width - TOLERANCE_PX);
+  });
+
+  test("body does not center its children via grid", async ({ page }) => {
+    await page.goto(APP_URL);
+
+    const placeItems = await page.evaluate(
+      () => getComputedStyle(document.body).placeItems,
+    );
+
+    // `normal normal` (or just `normal`) is the default; `center` was the bug.
+    expect(placeItems).not.toContain("center");
+  });
+});

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -28,7 +28,6 @@ a:hover {
 
 body {
   margin: 0;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary

Closes #876.

The Vite/React template default `body { place-items: center; ... }` shipped into `client/src/index.css` keeps the app centered with visible blank margins on wide windows — see the before/after screenshots in #876. Removing the rule lets the React tree fill the viewport width as expected.

## Fix

- `client/src/index.css` — drop `place-items: center` from the `body` rule. Keep `margin: 0`, `min-width: 320px`, `min-height: 100vh`.
- `client/e2e/full-window-width.spec.ts` (new) — Playwright regression with two assertions:
  - On a 1920×1080 viewport, `#root`'s `getBoundingClientRect().width` is within 20px of the viewport width (scrollbar tolerance).
  - `getComputedStyle(document.body).placeItems` does not contain `"center"`, so a future template paste-in can't silently reintroduce the bug.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 515 tests passing
- [x] `npx playwright test full-window-width.spec.ts --project=chromium` — 2 passed
- [x] Re-ran the new spec against the pre-fix state with `git stash`: `body does not center its children via grid` fails on `place-items: center`, passes after removal — regression coverage works
- [x] Manual: opened the dev server on a wide window, confirmed the app now spans the full viewport