### PR TITLE
test: harden managed state connect assertions

### DIFF
--- a/clients/web/src/test/core/mcp/state/managedPromptsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedPromptsState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { ManagedPromptsState } from "@inspector/core/mcp/state/managedPromptsState";
 import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
@@ -65,10 +65,9 @@ describe("ManagedPromptsState", () => {
     const promptlessState = new ManagedPromptsState(promptless);
 
     promptless.dispatchTypedEvent("connect");
-    // Yield so the async refresh chained off connect runs.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(promptless.listPrompts).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(promptless.listPrompts).not.toHaveBeenCalled();
+    });
     expect(promptlessState.getPrompts()).toEqual([]);
   });
 

--- a/clients/web/src/test/core/mcp/state/managedRequestorTasksState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedRequestorTasksState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { Task } from "@modelcontextprotocol/sdk/types.js";
 import { ManagedRequestorTasksState } from "@inspector/core/mcp/state/managedRequestorTasksState";
 import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
@@ -74,10 +74,9 @@ describe("ManagedRequestorTasksState", () => {
     const tasklessState = new ManagedRequestorTasksState(taskless);
 
     taskless.dispatchTypedEvent("connect");
-    // Yield once so the async refresh chained off connect runs.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(taskless.listRequestorTasks).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(taskless.listRequestorTasks).not.toHaveBeenCalled();
+    });
     expect(tasklessState.getTasks()).toEqual([]);
   });
 

--- a/clients/web/src/test/core/mcp/state/managedResourceTemplatesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedResourceTemplatesState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
 import { ManagedResourceTemplatesState } from "@inspector/core/mcp/state/managedResourceTemplatesState";
 import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
@@ -73,10 +73,9 @@ describe("ManagedResourceTemplatesState", () => {
     const resourcelessState = new ManagedResourceTemplatesState(resourceless);
 
     resourceless.dispatchTypedEvent("connect");
-    // Yield so the async refresh chained off connect runs.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(resourceless.listResourceTemplates).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(resourceless.listResourceTemplates).not.toHaveBeenCalled();
+    });
     expect(resourcelessState.getResourceTemplates()).toEqual([]);
   });
 

--- a/clients/web/src/test/core/mcp/state/managedResourcesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedResourcesState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { Resource } from "@modelcontextprotocol/sdk/types.js";
 import { ManagedResourcesState } from "@inspector/core/mcp/state/managedResourcesState";
 import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
@@ -70,10 +70,9 @@ describe("ManagedResourcesState", () => {
     const resourcelessState = new ManagedResourcesState(resourceless);
 
     resourceless.dispatchTypedEvent("connect");
-    // Yield so the async refresh chained off connect runs.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(resourceless.listResources).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(resourceless.listResources).not.toHaveBeenCalled();
+    });
     expect(resourcelessState.getResources()).toEqual([]);
   });
 

--- a/clients/web/src/test/core/mcp/state/managedToolsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedToolsState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { ManagedToolsState } from "@inspector/core/mcp/state/managedToolsState";
 import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
@@ -65,10 +65,9 @@ describe("ManagedToolsState", () => {
     const toollessState = new ManagedToolsState(toolless);
 
     toolless.dispatchTypedEvent("connect");
-    // Yield so the async refresh chained off connect runs.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(toolless.listTools).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(toolless.listTools).not.toHaveBeenCalled();
+    });
     expect(toollessState.getTools()).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
- replace fixed double microtask flushes with vi.waitFor assertions in Managed*State connect-path tests
- keep the capability-gate coverage uniform across tools, prompts, resources, resource templates, and requestor tasks

Fixes #1396.

## Verification
- npm run test -- src/test/core/mcp/state/managedToolsState.test.ts src/test/core/mcp/state/managedPromptsState.test.ts src/test/core/mcp/state/managedResourcesState.test.ts src/test/core/mcp/state/managedResourceTemplatesState.test.ts src/test/core/mcp/state/managedRequestorTasksState.test.ts
- npm run format:check -- src/test/core/mcp/state/managedToolsState.test.ts src/test/core/mcp/state/managedPromptsState.test.ts src/test/core/mcp/state/managedResourcesState.test.ts src/test/core/mcp/state/managedResourceTemplatesState.test.ts src/test/core/mcp/state/managedRequestorTasksState.test.ts