### PR TITLE
refactor(app): extract resetSessionScopedUiState() helper (#1394)

### DIFF
--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -342,6 +342,23 @@ function App() {
     };
   }, [inspectorClient]);
 
+  // Reset the session-scoped UI state that lives in App.tsx (rather than
+  // inside the per-server state managers), so the next server's screens don't
+  // show server A's last result. The per-call panels (`toolCallState` /
+  // `getPromptState` / `readResourceState`) and the optimistic
+  // `currentLogLevel` all survive a disconnect/reconnect cycle otherwise —
+  // see #1368. `latencyMs` is intentionally excluded: it resets via the
+  // `connectionStatus` effect above, which has its own connecting-edge ref to
+  // coordinate with. Colocated with the setters it touches so this is the
+  // single place to extend as App.tsx accrues more per-session state (#1394).
+  // Setters are stable, so the callback identity never changes.
+  const resetSessionScopedUiState = useCallback(() => {
+    setToolCallState(undefined);
+    setGetPromptState(undefined);
+    setReadResourceState(undefined);
+    setCurrentLogLevel("info");
+  }, []);
+
   // Reset activeServerId whenever the live session ends. Without this the
   // other ServerCards stay `inert` after disconnect — ServerCard dims any
   // card whose id differs from `activeServer`. Subscribing to
@@ -349,16 +366,9 @@ function App() {
   // (explicit toggle, header Disconnect button, mid-session transport
   // failure / process exit) and avoids the first-render-clobbers-new-id
   // trap that watching connectionStatus has (status starts as
-  // "disconnected" for the new client before connect() runs).
-  //
-  // This is also where session-scoped UI state that lives in App.tsx
-  // (rather than inside the per-server state managers) gets reset, so the
-  // next server's screens don't show server A's last result. The per-call
-  // panels (`toolCallState` / `getPromptState` / `readResourceState`) and
-  // the optimistic `currentLogLevel` all survive a disconnect/reconnect
-  // cycle otherwise — see #1368. `latencyMs` resets via the
-  // `connectionStatus` effect above instead because it has its own
-  // connecting-edge ref to coordinate with.
+  // "disconnected" for the new client before connect() runs). The
+  // session-scoped panel/level reset rides along here too via
+  // `resetSessionScopedUiState`.
   useEffect(() => {
     if (!inspectorClient) return;
     const onDisconnect = () => {
@@ -366,18 +376,13 @@ function App() {
       // Drop the open flag too — without this the modal would pop back the
       // next time `initializeResult` re-becomes truthy (e.g. reconnect).
       setConnectionInfoModalOpen(false);
-      // Clear the per-call result panels so the next session starts empty.
-      setToolCallState(undefined);
-      setGetPromptState(undefined);
-      setReadResourceState(undefined);
-      // Back to the default level the next session begins at.
-      setCurrentLogLevel("info");
+      resetSessionScopedUiState();
     };
     inspectorClient.addEventListener("disconnect", onDisconnect);
     return () => {
       inspectorClient.removeEventListener("disconnect", onDisconnect);
     };
-  }, [inspectorClient]);
+  }, [inspectorClient, resetSessionScopedUiState]);
 
   // Build the InitializeResult the connected ViewHeader expects from the
   // hook's split fields. `protocolVersion` is hard-coded for now — the


### PR DESCRIPTION
Closes #1394.

## What

Extracts the four session-scoped UI resets that the `disconnect` listener in `App.tsx` performs — the per-call result panels (`toolCallState` / `getPromptState` / `readResourceState`) and the optimistic `currentLogLevel` — into a colocated `resetSessionScopedUiState` `useCallback`. The listener keeps its `activeServerId` + Connection Info modal-flag bookkeeping inline and calls the helper.

## Why now

#1394 was filed as a deferred tripwire during the #1368 review: the note was to extract this helper once `App.tsx` accrued more per-session state, since four inline setters is below the abstraction threshold. We've opted to do it now anyway so there's a single named seam (`resetSessionScopedUiState`) to extend as that state grows — the next addition is one line in the helper instead of another setter buried in the listener body.

## Notes

- **Pure refactor, no behavior change.** Same four setters, same reset values, fired at the same point in the disconnect handler.
- `latencyMs` remains intentionally excluded — it resets via the `connectionStatus` edge effect, which coordinates with its own connecting-edge ref.
- The helper's deps are `[]` (the `useState` setters are stable), so its identity never changes; it's added to the disconnect effect's dep array.
- The existing `App.test.tsx` disconnect test (asserts all four pieces reset) is unchanged and still passes — it exercises the behavior through the same `disconnect` event, so it covers the helper transparently.

## Verification

`npm run validate` (1891 tests), `npm run test:storybook` (322) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)