### PR TITLE
fix: allow cancelling task polling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -124,6 +124,50 @@ const cloneToolParams = (
   }
 };
 
+const createPollingCancelledError = (): Error | DOMException => {
+  if (typeof DOMException !== "undefined") {
+    return new DOMException("Polling cancelled", "AbortError");
+  }
+
+  const error = new Error("Polling cancelled");
+  error.name = "AbortError";
+  return error;
+};
+
+const isAbortError = (error: unknown): boolean => {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: string }).name === "AbortError"
+  );
+};
+
+const waitForNextTaskPoll = (
+  pollInterval: number,
+  signal: AbortSignal,
+): Promise<void> => {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(createPollingCancelledError());
+      return;
+    }
+
+    function onAbort() {
+      window.clearTimeout(timeoutId);
+      signal.removeEventListener("abort", onAbort);
+      reject(createPollingCancelledError());
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, pollInterval);
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+};
+
 const filterReservedMetadata = (
   metadata: Record<string, string>,
 ): Record<string, string> => {
@@ -304,6 +348,7 @@ const App = () => {
   const [selectedTool, setSelectedTool] = useState<Tool | null>(null);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [isPollingTask, setIsPollingTask] = useState(false);
+  const pollingAbortControllerRef = useRef<AbortController | null>(null);
   const [nextResourceCursor, setNextResourceCursor] = useState<
     string | undefined
   >();
@@ -317,6 +362,16 @@ const App = () => {
   const [nextTaskCursor, setNextTaskCursor] = useState<string | undefined>();
   const progressTokenRef = useRef(0);
   const prefilledAppsToolCallIdRef = useRef(0);
+
+  const cancelToolPolling = useCallback(() => {
+    pollingAbortControllerRef.current?.abort();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      pollingAbortControllerRef.current?.abort();
+    };
+  }, []);
 
   const [activeTab, setActiveTab] = useState<string>(() => {
     const hash = window.location.hash.slice(1);
@@ -839,9 +894,10 @@ const App = () => {
     request: ClientRequest,
     schema: T,
     tabKey?: keyof typeof errors,
+    options?: Parameters<typeof makeRequest>[2],
   ): Promise<SchemaOutput<T>> => {
     try {
-      const response = await makeRequest(request, schema);
+      const response = await makeRequest(request, schema, options);
       if (tabKey !== undefined) {
         clearError(tabKey);
       }
@@ -1070,6 +1126,8 @@ const App = () => {
       if (runAsTask && isTaskResult(response)) {
         const taskId = response.task.taskId;
         const pollInterval = response.task.pollInterval;
+        const abortController = new AbortController();
+        pollingAbortControllerRef.current = abortController;
         // Set polling state BEFORE setting tool result for proper UI update
         setIsPollingTask(true);
         // Safely extract any _meta from the original response (if present)
@@ -1095,100 +1153,130 @@ const App = () => {
 
         // Polling loop
         let taskCompleted = false;
-        while (!taskCompleted) {
-          try {
-            // Wait for 1 second before polling
-            await new Promise((resolve) => setTimeout(resolve, pollInterval));
+        try {
+          while (!taskCompleted && !abortController.signal.aborted) {
+            try {
+              await waitForNextTaskPoll(pollInterval, abortController.signal);
 
-            const taskStatus = await sendMCPRequest(
-              {
-                method: "tasks/get",
-                params: { taskId },
-              },
-              GetTaskResultSchema,
-            );
-
-            if (
-              taskStatus.status === "completed" ||
-              taskStatus.status === "failed" ||
-              taskStatus.status === "cancelled"
-            ) {
-              taskCompleted = true;
-              console.log(
-                `Polling complete for task ${taskId}: ${taskStatus.status}`,
+              const taskStatus = await sendMCPRequest(
+                {
+                  method: "tasks/get",
+                  params: { taskId },
+                },
+                GetTaskResultSchema,
+                undefined,
+                { signal: abortController.signal },
               );
 
-              if (taskStatus.status === "completed") {
-                console.log(`Fetching result for task ${taskId}`);
-                const result = await sendMCPRequest(
-                  {
-                    method: "tasks/result",
-                    params: { taskId },
-                  },
-                  CompatibilityCallToolResultSchema,
+              if (
+                taskStatus.status === "completed" ||
+                taskStatus.status === "failed" ||
+                taskStatus.status === "cancelled"
+              ) {
+                taskCompleted = true;
+                console.log(
+                  `Polling complete for task ${taskId}: ${taskStatus.status}`,
                 );
-                console.log(`Result received for task ${taskId}:`, result);
-                latestToolResult = result as CompatibilityCallToolResult;
-                setToolResult(latestToolResult);
 
-                // Refresh tasks list to show completed state
-                void listTasks();
+                if (taskStatus.status === "completed") {
+                  console.log(`Fetching result for task ${taskId}`);
+                  const result = await sendMCPRequest(
+                    {
+                      method: "tasks/result",
+                      params: { taskId },
+                    },
+                    CompatibilityCallToolResultSchema,
+                    undefined,
+                    { signal: abortController.signal },
+                  );
+                  console.log(`Result received for task ${taskId}:`, result);
+                  latestToolResult = result as CompatibilityCallToolResult;
+                  setToolResult(latestToolResult);
+
+                  // Refresh tasks list to show completed state
+                  void listTasks();
+                } else {
+                  latestToolResult = {
+                    content: [
+                      {
+                        type: "text",
+                        text: `Task ${taskStatus.status}: ${taskStatus.statusMessage || "No additional information"}`,
+                      },
+                    ],
+                    isError: true,
+                  };
+                  setToolResult(latestToolResult);
+                  // Refresh tasks list to show failed/cancelled state
+                  void listTasks();
+                }
               } else {
+                // Update status message while polling
+                // Safely extract any _meta from the original response (if present)
+                const pollingResponseMeta =
+                  response &&
+                  typeof response === "object" &&
+                  "_meta" in (response as Record<string, unknown>)
+                    ? ((response as { _meta?: Record<string, unknown> })
+                        ._meta ?? {})
+                    : undefined;
                 latestToolResult = {
                   content: [
                     {
                       type: "text",
-                      text: `Task ${taskStatus.status}: ${taskStatus.statusMessage || "No additional information"}`,
+                      text: `Task status: ${taskStatus.status}${taskStatus.statusMessage ? ` - ${taskStatus.statusMessage}` : ""}. Polling...`,
                     },
                   ],
-                  isError: true,
+                  _meta: {
+                    ...(pollingResponseMeta || {}),
+                    "io.modelcontextprotocol/related-task": { taskId },
+                  },
                 };
                 setToolResult(latestToolResult);
-                // Refresh tasks list to show failed/cancelled state
+                // Refresh tasks list to show progress
                 void listTasks();
               }
-            } else {
-              // Update status message while polling
-              // Safely extract any _meta from the original response (if present)
-              const pollingResponseMeta =
-                response &&
-                typeof response === "object" &&
-                "_meta" in (response as Record<string, unknown>)
-                  ? ((response as { _meta?: Record<string, unknown> })._meta ??
-                    {})
-                  : undefined;
+            } catch (pollingError) {
+              if (
+                abortController.signal.aborted ||
+                isAbortError(pollingError)
+              ) {
+                latestToolResult = {
+                  content: [
+                    {
+                      type: "text",
+                      text: `Polling cancelled for task ${taskId}. The task may still be running on the server.`,
+                    },
+                  ],
+                  _meta: {
+                    ...(initialResponseMeta || {}),
+                    "io.modelcontextprotocol/related-task": { taskId },
+                  },
+                };
+                setToolResult(latestToolResult);
+                taskCompleted = true;
+                break;
+              }
+
+              console.error("Error polling task status:", pollingError);
               latestToolResult = {
                 content: [
                   {
                     type: "text",
-                    text: `Task status: ${taskStatus.status}${taskStatus.statusMessage ? ` - ${taskStatus.statusMessage}` : ""}. Polling...`,
+                    text: `Error polling task status: ${pollingError instanceof Error ? pollingError.message : String(pollingError)}`,
                   },
                 ],
-                _meta: {
-                  ...(pollingResponseMeta || {}),
-                  "io.modelcontextprotocol/related-task": { taskId },
-                },
+                isError: true,
               };
               setToolResult(latestToolResult);
-              // Refresh tasks list to show progress
-              void listTasks();
+              taskCompleted = true;
             }
-          } catch (pollingError) {
-            console.error("Error polling task status:", pollingError);
-            latestToolResult = {
-              content: [
-                {
-                  type: "text",
-                  text: `Error polling task status: ${pollingError instanceof Error ? pollingError.message : String(pollingError)}`,
-                },
-              ],
-              isError: true,
-            };
-            setToolResult(latestToolResult);
-            taskCompleted = true;
+          }
+        } finally {
+          setIsPollingTask(false);
+          if (pollingAbortControllerRef.current === abortController) {
+            pollingAbortControllerRef.current = null;
           }
         }
-        setIsPollingTask(false);
         // Clear any validation errors since tool execution completed
         setErrors((prev) => ({ ...prev, tools: null }));
         return latestToolResult;
@@ -1587,6 +1675,7 @@ const App = () => {
                       }}
                       toolResult={toolResult}
                       isPollingTask={isPollingTask}
+                      cancelPolling={cancelToolPolling}
                       nextCursor={nextToolCursor}
                       error={errors.tools}
                       resourceContent={resourceContentMap}

--- a/client/src/__tests__/App.toolsAppsPrefill.test.tsx
+++ b/client/src/__tests__/App.toolsAppsPrefill.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import "@testing-library/jest-dom";
 import App from "../App";
 import { useConnection } from "../lib/hooks/useConnection";
@@ -56,6 +62,7 @@ jest.mock("../utils/configUtils", () => ({
   getInitialArgs: jest.fn(() => ""),
   initializeInspectorConfig: jest.fn(() => ({})),
   saveInspectorConfig: jest.fn(),
+  getMCPTaskTtl: jest.fn(() => 60000),
 }));
 
 jest.mock("../lib/hooks/useDraggablePane", () => ({
@@ -135,6 +142,9 @@ jest.mock("../components/ToolsTab", () => ({
   default: ({
     listTools,
     callTool,
+    toolResult,
+    isPollingTask,
+    cancelPolling,
   }: {
     listTools: () => void;
     callTool: (
@@ -143,6 +153,11 @@ jest.mock("../components/ToolsTab", () => ({
       metadata?: Record<string, unknown>,
       runAsTask?: boolean,
     ) => Promise<unknown>;
+    toolResult?: {
+      content?: Array<{ type: string; text: string }>;
+    } | null;
+    isPollingTask?: boolean;
+    cancelPolling?: () => void;
   }) => (
     <div data-testid="tools-tab">
       <button type="button" onClick={listTools}>
@@ -156,6 +171,20 @@ jest.mock("../components/ToolsTab", () => ({
       >
         mock run app tool
       </button>
+      <button
+        type="button"
+        onClick={() => {
+          void callTool("weatherApp", { city: "Lisbon" }, undefined, true);
+        }}
+      >
+        mock run task tool
+      </button>
+      {isPollingTask && (
+        <button type="button" onClick={cancelPolling}>
+          mock cancel polling
+        </button>
+      )}
+      <div data-testid="tools-result">{JSON.stringify(toolResult ?? null)}</div>
     </div>
   ),
 }));
@@ -280,5 +309,101 @@ describe("App - Tools to Apps prefilled handoff", () => {
     await waitFor(() => {
       expect(screen.getByTestId("apps-prefilled")).toHaveTextContent("null");
     });
+  });
+
+  it("can cancel task polling from ToolsTab", async () => {
+    const makeRequest = jest.fn(
+      async (request: { method: string; params?: { name?: string } }) => {
+        if (request.method === "tools/call") {
+          return {
+            task: {
+              taskId: "task-1",
+              status: "pending",
+              pollInterval: 10000,
+            },
+          };
+        }
+
+        if (request.method === "tasks/get") {
+          return {
+            taskId: "task-1",
+            status: "running",
+            pollInterval: 10000,
+            lastUpdatedAt: new Date().toISOString(),
+          };
+        }
+
+        throw new Error(`Unexpected method: ${request.method}`);
+      },
+    );
+
+    mockUseConnection.mockReturnValue({
+      connectionStatus: "connected",
+      serverCapabilities: {
+        tools: { listChanged: true },
+        tasks: { requests: { tools: { call: true } } },
+      },
+      serverImplementation: null,
+      mcpClient: {
+        request: jest.fn(),
+        notification: jest.fn(),
+        close: jest.fn(),
+      } as unknown as Client,
+      requestHistory: [],
+      clearRequestHistory: jest.fn(),
+      makeRequest,
+      cancelTask: jest.fn(),
+      listTasks: jest.fn(),
+      sendNotification: jest.fn(),
+      handleCompletion: jest.fn(),
+      completionsSupported: false,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+    } as ReturnType<typeof useConnection>);
+
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /mock run task tool/i }),
+      );
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        makeRequest.mock.calls.some(
+          ([request]) => request.method === "tools/call",
+        ),
+      ).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tools-result")).toHaveTextContent(
+        "Task created: task-1",
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /mock cancel polling/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /mock cancel polling/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tools-result")).toHaveTextContent(
+        "Polling cancelled for task task-1",
+      );
+    });
+
+    expect(
+      makeRequest.mock.calls.some(
+        ([request]) => request.method === "tasks/get",
+      ),
+    ).toBe(false);
   });
 });

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -35,6 +35,7 @@ import {
   AlertCircle,
   Copy,
   CheckCheck,
+  XCircle,
 } from "lucide-react";
 import { useEffect, useState, useRef } from "react";
 import ListPane from "./ListPane";
@@ -173,6 +174,7 @@ const ToolsTab = ({
   setSelectedTool,
   toolResult,
   isPollingTask,
+  cancelPolling,
   nextCursor,
   error,
   resourceContent,
@@ -192,6 +194,7 @@ const ToolsTab = ({
   setSelectedTool: (tool: Tool | null) => void;
   toolResult: CompatibilityCallToolResult | null;
   isPollingTask?: boolean;
+  cancelPolling?: () => void;
   nextCursor: ListToolsResult["nextCursor"];
   error: string | null;
   resourceContent: Record<string, string>;
@@ -855,6 +858,12 @@ const ToolsTab = ({
                     </>
                   )}
                 </Button>
+                {isPollingTask && cancelPolling && (
+                  <Button variant="destructive" onClick={cancelPolling}>
+                    <XCircle className="w-4 h-4 mr-2" />
+                    Cancel Polling
+                  </Button>
+                )}
                 <div className="flex gap-2">
                   <Button
                     onClick={async () => {

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -423,6 +423,26 @@ describe("ToolsTab", () => {
     expect(submitButton.getAttribute("disabled")).toBeNull();
   });
 
+  it("should show cancel polling button while polling a task", () => {
+    const cancelPolling = jest.fn();
+
+    renderToolsTab({
+      selectedTool: mockTools[0],
+      isPollingTask: true,
+      cancelPolling,
+    });
+
+    const cancelButton = screen.getByRole("button", {
+      name: /cancel polling/i,
+    });
+    fireEvent.click(cancelButton);
+
+    expect(cancelPolling).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("button", { name: /polling task/i }),
+    ).toBeDisabled();
+  });
+
   describe("Output Schema Display", () => {
     const toolWithOutputSchema: Tool = {
       name: "weatherTool",


### PR DESCRIPTION
## Summary

- Add cancellable task polling for run-as-task tool calls.
- Show a `Cancel Polling` button in the Tools tab while task polling is active.
- Preserve related task metadata in the cancellation result so the task can still be inspected separately.

> **Note:** Inspector V2 is under development to address architectural and UX improvements. During this time, V1 contributions should focus on **bug fixes and MCP spec compliance**. See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test updates
- [ ] Build/CI improvements

## Changes Made

- Track the active task-polling loop with an `AbortController`.
- Make the polling delay and `tasks/get` / `tasks/result` requests observe the abort signal.
- Add a destructive `Cancel Polling` action next to the disabled run button while polling.
- Add component and App-level tests for the cancel-polling path.

## Related Issues

Fixes #1039

## Testing

- [ ] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [ ] Manual testing performed

### Test Results and/or Instructions

- `npm test` — 517 passed
- `cd client && npm run lint` — passed
- `npm run build-client` — passed

## Checklist

- [x] Code follows the style guidelines (ran `npm test` / Prettier check)
- [x] Self-review completed
- [ ] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None.

## Additional Context

This cancels client-side polling. The server-side task may continue running and can still be inspected or cancelled through task APIs.
