### PR TITLE
fix: add clipboard fallback for non-secure contexts

### DIFF
--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -135,6 +135,29 @@ const Sidebar = ({
     [toast],
   );
 
+  // Fallback clipboard copy for non-secure contexts (HTTP, not HTTPS/localhost)
+  // navigator.clipboard.writeText() requires a secure context
+  const copyToClipboard = useCallback(async (text: string) => {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+    // Fallback: use a temporary textarea element
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    textarea.style.top = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    try {
+      document.execCommand("copy");
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }, []);
+
   // Shared utility function to generate server config
   const generateServerConfig = useCallback(() => {
     if (transportType === "stdio") {
@@ -183,8 +206,7 @@ const Sidebar = ({
   const handleCopyServerEntry = useCallback(() => {
     try {
       const configJson = generateMCPServerEntry();
-      navigator.clipboard
-        .writeText(configJson)
+      copyToClipboard(configJson)
         .then(() => {
           setCopiedServerEntry(true);
 
@@ -213,8 +235,7 @@ const Sidebar = ({
   const handleCopyServerFile = useCallback(() => {
     try {
       const configJson = generateMCPServerFile();
-      navigator.clipboard
-        .writeText(configJson)
+      copyToClipboard(configJson)
         .then(() => {
           setCopiedServerFile(true);
 


### PR DESCRIPTION
## Problem

Clicking 'Copy Servers File' or 'Copy Server Entry' buttons fails when Inspector is hosted over HTTP (not HTTPS) on a local network, such as Docker compose deployments.

**Root cause:** `navigator.clipboard.writeText()` requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or localhost). When accessed via HTTP on a LAN IP, the Clipboard API throws a `DOMException`, and the error toast shows the raw exception message.

## Fix

Add a `copyToClipboard` utility that:
1. Uses the Clipboard API when available (`navigator.clipboard` + `window.isSecureContext`)
2. Falls back to a temporary `<textarea>` + `document.execCommand('copy')` otherwise

This is the same fallback pattern used by many popular libraries (e.g., `clipboard-polyfill`).

## Testing

- Verified the fallback path works in Chrome 142 over HTTP on a LAN IP
- Existing Clipboard API path unchanged for secure contexts

Fixes #913