### PR TITLE
fix(state): dispatch connect event after capabilities are populated

### DIFF
--- a/clients/web/src/test/integration/mcp/inspectorClient.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient.test.ts
@@ -689,12 +689,15 @@ describe("InspectorClient", () => {
       expect((await client.listTools()).tools.length).toBeGreaterThan(0);
     });
 
-    it("ManagedToolsState populates on connect (regression: capability gate must see capabilities before the connect event)", async () => {
+    it("managed list states populate on connect (regression: capability gate must see capabilities before the connect event)", async () => {
       // Regression for #1395 + connect-ordering: the managed list-state managers
       // refresh on the "connect" event and gate their list RPC on
       // getCapabilities(). If "connect" is dispatched before fetchServerInfo()
       // populates capabilities, the synchronous gate reads undefined and wipes
       // the list to empty — tools/prompts/resources all vanish on every connect.
+      // The single fix is shared by all the managed states, so we cover tools
+      // and resources (two distinct capabilities) to guard against a future
+      // change gating only one primitive differently.
       client = new InspectorClient(
         {
           type: "stdio",
@@ -704,15 +707,22 @@ describe("InspectorClient", () => {
         { environment: { transport: createTransportNode } },
       );
       const toolsState = new ManagedToolsState(client);
+      const resourcesState = new ManagedResourcesState(client);
 
+      // Await the change events the connect-triggered refresh() emits rather than
+      // a fixed sleep — refresh() is async past its synchronous capability gate.
+      const toolsChanged = waitForEvent(toolsState, "toolsChange");
+      const resourcesChanged = waitForEvent(resourcesState, "resourcesChange");
       await client.connect();
-      // Settle: the connect-triggered refresh() is async past its capability gate.
-      await new Promise((r) => setTimeout(r, 100));
+      await Promise.all([toolsChanged, resourcesChanged]);
 
       expect(client.getCapabilities()?.tools).toBeDefined();
       expect(toolsState.getTools().length).toBeGreaterThan(0);
+      expect(client.getCapabilities()?.resources).toBeDefined();
+      expect(resourcesState.getResources().length).toBeGreaterThan(0);
 
       toolsState.destroy();
+      resourcesState.destroy();
     });
   });
 

--- a/clients/web/src/test/integration/mcp/inspectorClient.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient.test.ts
@@ -10,6 +10,7 @@ import {
   PagedPromptsState,
   ManagedResourcesState,
   ManagedPromptsState,
+  ManagedToolsState,
 } from "@inspector/core/mcp/state/index.js";
 import { createTransportNode } from "@inspector/core/mcp/node/transport.js";
 import { SamplingCreateMessage } from "@inspector/core/mcp/samplingCreateMessage.js";
@@ -686,6 +687,32 @@ describe("InspectorClient", () => {
 
       // Client no longer stores tools; listTools() still returns server tools when called
       expect((await client.listTools()).tools.length).toBeGreaterThan(0);
+    });
+
+    it("ManagedToolsState populates on connect (regression: capability gate must see capabilities before the connect event)", async () => {
+      // Regression for #1395 + connect-ordering: the managed list-state managers
+      // refresh on the "connect" event and gate their list RPC on
+      // getCapabilities(). If "connect" is dispatched before fetchServerInfo()
+      // populates capabilities, the synchronous gate reads undefined and wipes
+      // the list to empty — tools/prompts/resources all vanish on every connect.
+      client = new InspectorClient(
+        {
+          type: "stdio",
+          command: serverCommand.command,
+          args: serverCommand.args,
+        },
+        { environment: { transport: createTransportNode } },
+      );
+      const toolsState = new ManagedToolsState(client);
+
+      await client.connect();
+      // Settle: the connect-triggered refresh() is async past its capability gate.
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(client.getCapabilities()?.tools).toBeDefined();
+      expect(toolsState.getTools().length).toBeGreaterThan(0);
+
+      toolsState.destroy();
     });
   });
 

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -656,10 +656,15 @@ export class InspectorClient extends InspectorClientEventTarget {
       }
       this.status = "connected";
       this.dispatchTypedEvent("statusChange", this.status);
-      this.dispatchTypedEvent("connect");
 
-      // Always fetch server info (capabilities, serverInfo, instructions) - this is just cached data from initialize
+      // Always fetch server info (capabilities, serverInfo, instructions) - this is just cached data from initialize.
+      // Must run BEFORE the "connect" event: the managed list-state managers
+      // refresh on "connect" and gate their list RPC on getCapabilities() (see
+      // #1395). If "connect" fired first, that gate would read undefined
+      // capabilities and wipe tools/prompts/resources to empty on every connect.
       await this.fetchServerInfo();
+
+      this.dispatchTypedEvent("connect");
 
       // Set initial logging level if configured and server supports it
       if (this.initialLoggingLevel && this.capabilities?.logging) {


### PR DESCRIPTION
Closes #1406 

## Problem

Tools, prompts, resources, and resource templates were disappearing for some servers on the v2 web Inspector — nothing showed under any primitive.

## Root cause

Regression from #1395 ("gate list fetches on server capability"). That PR added a capability gate to each list-state manager's `refresh()`:

```ts
if (!client.getCapabilities()?.tools) {
  this.tools = [];
  this.dispatchTypedEvent("toolsChange", this.tools);
  return this.getTools();
}
```

The gate is correct, but it exposed an **ordering race** in `InspectorClient.connect()`:

```ts
this.dispatchTypedEvent("connect");   // managers refresh() here
await this.fetchServerInfo();         // capabilities set HERE, after
```

The managed states refresh on the `"connect"` event. `refresh()` runs synchronously up to its first `await` (the real `listTools` call), so the capability gate executes *during* the synchronous `dispatch("connect")` — before `fetchServerInfo()` populates `this.capabilities` (which is reset to `undefined` on every disconnect). The gate reads `undefined`, trips, and wipes the list to empty. All four primitives are gated identically, so all of them vanish.

Before #1395 `refresh()` didn't read capabilities, so the ordering never mattered.

## Fix

Dispatch `"connect"` **after** the awaited `fetchServerInfo()`, so capabilities are populated before any manager refreshes.

## Tests

The unit tests missed this because their `FakeInspectorClient` has capabilities populated from construction. Added an integration regression test that wires a real `ManagedToolsState` on connect and asserts the tool list is non-empty — it **fails without the fix**, passes with it.

- Integration suite: 176 passed
- `npm run validate`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)