### PR TITLE
fix(server): guard stdio SSE notification sends

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -668,11 +668,41 @@ app.get(
 
       await webAppTransport.start();
 
+      let transportsClosed = false;
+      const closeStdioTransports = () => {
+        if (transportsClosed) {
+          return;
+        }
+        transportsClosed = true;
+
+        webAppTransports.delete(webAppTransport.sessionId);
+        serverTransports.delete(webAppTransport.sessionId);
+        sessionHeaderHolders.delete(webAppTransport.sessionId);
+
+        webAppTransport.close().catch((error: unknown) => {
+          console.error("Error closing inspector client transport:", error);
+        });
+        serverTransport.close().catch((error: unknown) => {
+          console.error("Error closing stdio server transport:", error);
+        });
+      };
+
+      const sendStdioNotification = async (
+        message: Parameters<typeof webAppTransport.send>[0],
+      ) => {
+        try {
+          await webAppTransport.send(message);
+        } catch (error) {
+          console.error("Error sending stdio notification:", error);
+          closeStdioTransports();
+        }
+      };
+
       (serverTransport as StdioClientTransport).stderr!.on("data", (chunk) => {
         if (chunk.toString().includes("MODULE_NOT_FOUND")) {
           // Server command not found, remove transports
           const message = "Command not found, transports removed";
-          webAppTransport.send({
+          void sendStdioNotification({
             jsonrpc: "2.0",
             method: "notifications/message",
             params: {
@@ -682,12 +712,7 @@ app.get(
                 message,
               },
             },
-          });
-          webAppTransport.close();
-          serverTransport.close();
-          webAppTransports.delete(webAppTransport.sessionId);
-          serverTransports.delete(webAppTransport.sessionId);
-          sessionHeaderHolders.delete(webAppTransport.sessionId);
+          }).finally(closeStdioTransports);
           console.error(message);
         } else {
           // Inspect message and attempt to assign a RFC 5424 Syslog Protocol level
@@ -722,7 +747,7 @@ app.get(
           } else {
             level = "info";
           }
-          webAppTransport.send({
+          void sendStdioNotification({
             jsonrpc: "2.0",
             method: "notifications/message",
             params: {


### PR DESCRIPTION
## Summary

- Catches failed SSE sends when forwarding stdio stderr notifications.
- Cleans up the paired client/server transports idempotently after the inspector
  client disconnects.
- Preserves the existing command-not-found cleanup path while preventing an
  unhandled `Not connected` error from crashing the server.

> **Note:** Inspector V2 is under development to address architectural and UX improvements. During this time, V1 contributions should focus on **bug fixes and MCP spec compliance**. See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

- Adds a guarded `sendStdioNotification` helper for `/stdio` stderr forwarding.
- Adds idempotent cleanup for the SSE client transport and stdio server
  transport when notification delivery fails.
- Reuses the guarded path for both ordinary stderr notifications and the
  `MODULE_NOT_FOUND` cleanup notification.

## Related Issues

Fixes #1014

## Testing

- [ ] Tested in UI mode
- [ ] Tested in CLI mode
- [x] Tested with STDIO transport
- [x] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [ ] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

- `npm.cmd run build` in `server/`
- `server/node_modules/.bin/prettier.cmd --check server/src/index.ts`
- `git diff --check`
- Manual smoke test: started `server/build/index.js` with auth disabled on a
  local test port, repeatedly opened and aborted `/stdio` SSE connections while
  the child process wrote stderr, and confirmed the server did not crash.

Local note: the default npm registry path repeatedly timed out on this machine,
so local verification dependencies were installed temporarily through
`registry.npmmirror.com` without changing package manifests or lockfiles.

## Checklist

- [x] Code follows the style guidelines (ran Prettier on the changed file)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None.

## Additional Context

This PR was prepared with AI assistance from Echo (`echooo-agent`). I reviewed
the scope and validation before submitting.

No documentation changes were needed for this internal server error-handling
fix.
