### PR TITLE
feat: add URL-mode elicitation support

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -438,15 +438,27 @@ const App = () => {
     onElicitationRequest: (request, resolve) => {
       const currentTab = lastToolCallOriginTabRef.current;
 
+      const requestId = nextRequestId.current++;
+      const requestData =
+        request.params.mode === "url"
+          ? {
+              id: requestId,
+              mode: "url" as const,
+              message: request.params.message,
+              url: request.params.url,
+              elicitationId: request.params.elicitationId,
+            }
+          : {
+              id: requestId,
+              message: request.params.message,
+              requestedSchema: request.params.requestedSchema,
+            };
+
       setPendingElicitationRequests((prev) => [
         ...prev,
         {
-          id: nextRequestId.current++,
-          request: {
-            id: nextRequestId.current,
-            message: request.params.message,
-            requestedSchema: request.params.requestedSchema,
-          },
+          id: requestId,
+          request: requestData,
           originatingTab: currentTab,
           resolve,
           decline: (error: Error) => {

--- a/client/src/components/ElicitationRequest.tsx
+++ b/client/src/components/ElicitationRequest.tsx
@@ -7,6 +7,7 @@ import { generateDefaultValue } from "@/utils/schemaUtils";
 import {
   PendingElicitationRequest,
   ElicitationResponse,
+  ElicitationFormRequestData,
 } from "./ElicitationTab";
 import Ajv from "ajv";
 
@@ -22,11 +23,68 @@ const ElicitationRequest = ({
   const [formData, setFormData] = useState<JsonValue>({});
   const [validationError, setValidationError] = useState<string | null>(null);
 
+  const requestData = request.request;
+  const isUrlMode = requestData.mode === "url";
+
   useEffect(() => {
-    const defaultValue = generateDefaultValue(request.request.requestedSchema);
+    if (isUrlMode) return;
+    const defaultValue = generateDefaultValue(
+      (requestData as ElicitationFormRequestData).requestedSchema,
+    );
     setFormData(defaultValue);
     setValidationError(null);
-  }, [request.request.requestedSchema]);
+  }, [isUrlMode, requestData]);
+
+  if (isUrlMode) {
+    const handleOpenUrl = () => {
+      window.open(requestData.url, "_blank", "noopener,noreferrer");
+      onResolve(request.id, { action: "accept" });
+    };
+
+    return (
+      <div
+        data-testid="elicitation-request"
+        className="flex flex-col gap-4 p-4 border rounded-lg"
+      >
+        <div className="bg-gray-50 dark:bg-gray-800 dark:text-gray-100 p-2 rounded">
+          <div className="space-y-2">
+            <h4 className="font-semibold">URL Request</h4>
+            <p className="text-sm">{requestData.message}</p>
+            <a
+              href={requestData.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-blue-600 dark:text-blue-400 underline break-all"
+            >
+              {requestData.url}
+            </a>
+          </div>
+        </div>
+        <div className="flex space-x-2">
+          <Button type="button" onClick={handleOpenUrl}>
+            Open URL
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onResolve(request.id, { action: "decline" })}
+          >
+            Decline
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onResolve(request.id, { action: "cancel" })}
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // After URL-mode early return, requestData is guaranteed to be form mode
+  const formRequest = requestData as ElicitationFormRequestData;
 
   const validateEmailFormat = (email: string): boolean => {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -75,12 +133,12 @@ const ElicitationRequest = ({
 
   const handleAccept = () => {
     try {
-      if (!validateFormData(formData, request.request.requestedSchema)) {
+      if (!validateFormData(formData, formRequest.requestedSchema)) {
         return;
       }
 
       const ajv = new Ajv();
-      const validate = ajv.compile(request.request.requestedSchema);
+      const validate = ajv.compile(formRequest.requestedSchema);
       const isValid = validate(formData);
 
       if (!isValid) {
@@ -109,8 +167,8 @@ const ElicitationRequest = ({
   };
 
   const schemaTitle =
-    request.request.requestedSchema.title || "Information Request";
-  const schemaDescription = request.request.requestedSchema.description;
+    formRequest.requestedSchema.title || "Information Request";
+  const schemaDescription = formRequest.requestedSchema.description;
 
   return (
     <div
@@ -120,14 +178,14 @@ const ElicitationRequest = ({
       <div className="flex-1 bg-gray-50 dark:bg-gray-800 dark:text-gray-100 p-2 rounded">
         <div className="space-y-2">
           <h4 className="font-semibold">{schemaTitle}</h4>
-          <p className="text-sm">{request.request.message}</p>
+          <p className="text-sm">{formRequest.message}</p>
           {schemaDescription && (
             <p className="text-xs text-muted-foreground">{schemaDescription}</p>
           )}
           <div className="mt-2">
             <h5 className="text-xs font-medium mb-1">Request Schema:</h5>
             <JsonView
-              data={JSON.stringify(request.request.requestedSchema, null, 2)}
+              data={JSON.stringify(formRequest.requestedSchema, null, 2)}
             />
           </div>
         </div>
@@ -137,7 +195,7 @@ const ElicitationRequest = ({
         <div className="space-y-2">
           <h4 className="font-medium">Response Form</h4>
           <DynamicJsonForm
-            schema={request.request.requestedSchema}
+            schema={formRequest.requestedSchema}
             value={formData}
             onChange={(newValue: JsonValue) => {
               setFormData(newValue);

--- a/client/src/components/ElicitationRequest.tsx
+++ b/client/src/components/ElicitationRequest.tsx
@@ -1,5 +1,13 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import DynamicJsonForm from "./DynamicJsonForm";
 import JsonView from "./JsonView";
 import { JsonSchemaType, JsonValue } from "@/utils/jsonUtils";
@@ -22,6 +30,7 @@ const ElicitationRequest = ({
 }: ElicitationRequestProps) => {
   const [formData, setFormData] = useState<JsonValue>({});
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [showUrlConfirm, setShowUrlConfirm] = useState(false);
 
   const requestData = request.request;
   const isUrlMode = requestData.mode === "url";
@@ -36,9 +45,9 @@ const ElicitationRequest = ({
   }, [isUrlMode, requestData]);
 
   if (isUrlMode) {
-    const handleOpenUrl = () => {
+    const handleConfirmOpen = () => {
       window.open(requestData.url, "_blank", "noopener,noreferrer");
-      onResolve(request.id, { action: "accept" });
+      setShowUrlConfirm(false);
     };
 
     return (
@@ -50,19 +59,17 @@ const ElicitationRequest = ({
           <div className="space-y-2">
             <h4 className="font-semibold">URL Request</h4>
             <p className="text-sm">{requestData.message}</p>
-            <a
-              href={requestData.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-blue-600 dark:text-blue-400 underline break-all"
-            >
-              {requestData.url}
-            </a>
           </div>
         </div>
         <div className="flex space-x-2">
-          <Button type="button" onClick={handleOpenUrl}>
+          <Button type="button" onClick={() => setShowUrlConfirm(true)}>
             Open URL
+          </Button>
+          <Button
+            type="button"
+            onClick={() => onResolve(request.id, { action: "accept" })}
+          >
+            Accept
           </Button>
           <Button
             type="button"
@@ -79,6 +86,32 @@ const ElicitationRequest = ({
             Cancel
           </Button>
         </div>
+
+        <Dialog open={showUrlConfirm} onOpenChange={setShowUrlConfirm}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Open External URL</DialogTitle>
+              <DialogDescription>
+                The server is requesting you visit the following URL:
+              </DialogDescription>
+            </DialogHeader>
+            <p
+              data-testid="url-confirm-text"
+              className="text-sm font-mono bg-gray-100 dark:bg-gray-800 p-3 rounded break-all select-all"
+            >
+              {requestData.url}
+            </p>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setShowUrlConfirm(false)}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleConfirmOpen}>Open</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     );
   }

--- a/client/src/components/ElicitationRequest.tsx
+++ b/client/src/components/ElicitationRequest.tsx
@@ -45,8 +45,25 @@ const ElicitationRequest = ({
   }, [isUrlMode, requestData]);
 
   if (isUrlMode) {
+    // Per MCP SEP-1036 security requirements, only HTTPS URLs may be opened.
+    // Validate the server-supplied URL before exposing the "Open URL" affordance
+    // so non-https schemes (http:, file:, javascript:, data:) and malformed URLs
+    // are refused rather than handed to window.open.
+    let parsedUrl: URL | null = null;
+    let urlError: string | null = null;
+    try {
+      parsedUrl = new URL(requestData.url);
+      if (parsedUrl.protocol !== "https:") {
+        urlError = `Refusing to open this URL: only https: URLs are permitted for URL elicitation (received scheme "${parsedUrl.protocol}").`;
+        parsedUrl = null;
+      }
+    } catch {
+      urlError = `The server provided a malformed URL: ${requestData.url}`;
+    }
+
     const handleConfirmOpen = () => {
-      window.open(requestData.url, "_blank", "noopener,noreferrer");
+      if (!parsedUrl) return;
+      window.open(parsedUrl.href, "_blank", "noopener,noreferrer");
       setShowUrlConfirm(false);
     };
 
@@ -61,8 +78,20 @@ const ElicitationRequest = ({
             <p className="text-sm">{requestData.message}</p>
           </div>
         </div>
+        {urlError && (
+          <div
+            data-testid="url-error"
+            className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md text-sm text-red-600 dark:text-red-400"
+          >
+            <strong>Invalid URL:</strong> {urlError}
+          </div>
+        )}
         <div className="flex space-x-2">
-          <Button type="button" onClick={() => setShowUrlConfirm(true)}>
+          <Button
+            type="button"
+            disabled={!!urlError}
+            onClick={() => setShowUrlConfirm(true)}
+          >
             Open URL
           </Button>
           <Button
@@ -95,6 +124,17 @@ const ElicitationRequest = ({
                 The server is requesting you visit the following URL:
               </DialogDescription>
             </DialogHeader>
+            {parsedUrl && (
+              <p className="text-sm">
+                Destination host:{" "}
+                <span
+                  data-testid="url-confirm-host"
+                  className="font-mono font-semibold break-all"
+                >
+                  {parsedUrl.host}
+                </span>
+              </p>
+            )}
             <p
               data-testid="url-confirm-text"
               className="text-sm font-mono bg-gray-100 dark:bg-gray-800 p-3 rounded break-all select-all"

--- a/client/src/components/ElicitationTab.tsx
+++ b/client/src/components/ElicitationTab.tsx
@@ -3,11 +3,25 @@ import { TabsContent } from "@/components/ui/tabs";
 import { JsonSchemaType } from "@/utils/jsonUtils";
 import ElicitationRequest from "./ElicitationRequest";
 
-export interface ElicitationRequestData {
+interface ElicitationRequestBase {
   id: number;
   message: string;
+}
+
+export interface ElicitationFormRequestData extends ElicitationRequestBase {
+  mode?: "form";
   requestedSchema: JsonSchemaType;
 }
+
+export interface ElicitationUrlRequestData extends ElicitationRequestBase {
+  mode: "url";
+  url: string;
+  elicitationId: string;
+}
+
+export type ElicitationRequestData =
+  | ElicitationFormRequestData
+  | ElicitationUrlRequestData;
 
 export interface ElicitationResponse {
   action: "accept" | "decline" | "cancel";

--- a/client/src/components/__tests__/ElicitationRequest.test.tsx
+++ b/client/src/components/__tests__/ElicitationRequest.test.tsx
@@ -333,5 +333,64 @@ describe("ElicitationRequest", () => {
 
       expect(mockOnResolve).toHaveBeenCalledWith(2, { action: "cancel" });
     });
+
+    it("should display the destination host in the consent dialog", async () => {
+      renderElicitationRequest(createUrlRequest());
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /open url/i }));
+      });
+
+      expect(screen.getByTestId("url-confirm-host")).toHaveTextContent(
+        "example.com",
+      );
+    });
+
+    it.each([
+      ["http://example.com/auth", "http: (non-HTTPS)"],
+      ["javascript:alert(1)", "javascript:"],
+      ["file:///etc/passwd", "file:"],
+      ["data:text/html,<script>alert(1)</script>", "data:"],
+    ])(
+      "should refuse to open non-HTTPS URL %s and disable Open URL",
+      async (url) => {
+        const windowOpenSpy = jest
+          .spyOn(window, "open")
+          .mockImplementation(() => null);
+        renderElicitationRequest({
+          id: 2,
+          request: {
+            id: 2,
+            mode: "url",
+            message: "Please complete authentication",
+            url,
+            elicitationId: "elicit-123",
+          },
+        });
+
+        expect(screen.getByTestId("url-error")).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: /open url/i }),
+        ).toBeDisabled();
+        expect(windowOpenSpy).not.toHaveBeenCalled();
+        windowOpenSpy.mockRestore();
+      },
+    );
+
+    it("should show an error and disable Open URL for a malformed URL", () => {
+      renderElicitationRequest({
+        id: 2,
+        request: {
+          id: 2,
+          mode: "url",
+          message: "Please complete authentication",
+          url: "not a url",
+          elicitationId: "elicit-123",
+        },
+      });
+
+      expect(screen.getByTestId("url-error")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /open url/i })).toBeDisabled();
+    });
   });
 });

--- a/client/src/components/__tests__/ElicitationTab.test.tsx
+++ b/client/src/components/__tests__/ElicitationTab.test.tsx
@@ -63,8 +63,6 @@ describe("Elicitation tab", () => {
     ]);
     expect(screen.getAllByTestId("elicitation-request").length).toBe(1);
     expect(screen.getByText("Please authenticate")).toBeTruthy();
-    expect(
-      screen.getByRole("link", { name: "https://example.com/auth" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /open url/i })).toBeTruthy();
   });
 });

--- a/client/src/components/__tests__/ElicitationTab.test.tsx
+++ b/client/src/components/__tests__/ElicitationTab.test.tsx
@@ -47,4 +47,24 @@ describe("Elicitation tab", () => {
     );
     expect(screen.getAllByTestId("elicitation-request").length).toBe(3);
   });
+
+  it("should render a URL-mode elicitation request", () => {
+    renderElicitationTab([
+      {
+        id: 1,
+        request: {
+          id: 1,
+          mode: "url",
+          message: "Please authenticate",
+          url: "https://example.com/auth",
+          elicitationId: "elicit-456",
+        },
+      },
+    ]);
+    expect(screen.getAllByTestId("elicitation-request").length).toBe(1);
+    expect(screen.getByText("Please authenticate")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "https://example.com/auth" }),
+    ).toBeTruthy();
+  });
 });

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -518,7 +518,10 @@ describe("useConnection", () => {
         }),
         expect.objectContaining({
           capabilities: expect.objectContaining({
-            elicitation: {},
+            elicitation: {
+              form: {},
+              url: {},
+            },
           }),
         }),
       );

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -259,9 +259,19 @@ export function useConnection({
 
         pushHistory(requestWithMetadata, response);
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        pushHistory(requestWithMetadata, { error: errorMessage });
+        if (error instanceof McpError) {
+          pushHistory(requestWithMetadata, {
+            error: {
+              code: error.code,
+              message: error.rpcMessage ?? error.message,
+              ...(error.data !== undefined && { data: error.data }),
+            },
+          });
+        } else {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          pushHistory(requestWithMetadata, { error: errorMessage });
+        }
         throw error;
       }
 

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -29,6 +29,7 @@ import {
   ResourceListChangedNotificationSchema,
   ToolListChangedNotificationSchema,
   PromptListChangedNotificationSchema,
+  ElicitationCompleteNotificationSchema,
   Progress,
   LoggingLevel,
   ElicitRequestSchema,
@@ -452,7 +453,10 @@ export function useConnection({
     const clientCapabilities = {
       capabilities: {
         sampling: {},
-        elicitation: {},
+        elicitation: {
+          form: {},
+          url: {},
+        },
         roots: {
           listChanged: true,
         },
@@ -754,6 +758,7 @@ export function useConnection({
           ToolListChangedNotificationSchema,
           PromptListChangedNotificationSchema,
           TaskStatusNotificationSchema,
+          ElicitationCompleteNotificationSchema,
         ].forEach((notificationSchema) => {
           client.setNotificationHandler(notificationSchema, onNotification);
         });

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -259,19 +259,9 @@ export function useConnection({
 
         pushHistory(requestWithMetadata, response);
       } catch (error) {
-        if (error instanceof McpError) {
-          pushHistory(requestWithMetadata, {
-            error: {
-              code: error.code,
-              message: error.rpcMessage ?? error.message,
-              ...(error.data !== undefined && { data: error.data }),
-            },
-          });
-        } else {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-          pushHistory(requestWithMetadata, { error: errorMessage });
-        }
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        pushHistory(requestWithMetadata, { error: errorMessage });
         throw error;
       }
 

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -753,6 +753,11 @@ export function useConnection({
           ToolListChangedNotificationSchema,
           PromptListChangedNotificationSchema,
           TaskStatusNotificationSchema,
+          // SEP-1036: elicitation/complete is surfaced in the notification panel
+          // so the user can observe out-of-band completion. The Inspector does
+          // not auto-correlate the notification's elicitationId back to its
+          // pending request (a spec MAY); the user resolves the request manually
+          // via the Accept button (the spec SHOULD).
           ElicitationCompleteNotificationSchema,
         ].forEach((notificationSchema) => {
           client.setNotificationHandler(notificationSchema, onNotification);


### PR DESCRIPTION
> Supersedes #1108 — same changes, but with the branch pushed directly to the `modelcontextprotocol/inspector` repo so the Claude review workflow can run (it cannot review PRs from forks).

## Summary
- Adds client-side support for URL-mode elicitation (MCP spec 2025-11-25), allowing servers to direct users to external URLs for out-of-band interactions (auth flows, payments, sensitive data entry)
- Announces both `form` and `url` elicitation capabilities during client initialization (`elicitation: { form: {}, url: {} }`)
- Logs `notifications/elicitation/complete` notifications in the Inspector's notification panel

## Changes
- **ElicitationTab.tsx**: Replaced `ElicitationRequestData` with a discriminated union (`ElicitationFormRequestData` | `ElicitationUrlRequestData`)
- **App.tsx**: Updated `onElicitationRequest` handler to branch on `request.params.mode` and build the appropriate request data shape
- **ElicitationRequest.tsx**: Added URL-mode rendering with server message, "Open URL" button that shows a consent dialog displaying the URL as plain text before navigating, a separate "Accept" button that resolves with `{ action: "accept" }` (no `content` field, per spec), and Decline/Cancel buttons; existing form-mode code untouched
- **useConnection.ts**: Declared `elicitation: { form: {}, url: {} }` capability; imported and registered `ElicitationCompleteNotificationSchema` in the notification handler array
- **Tests**: Added URL-mode tests in `ElicitationRequest.test.tsx` (8 tests) and `ElicitationTab.test.tsx` (1 test); updated capability assertion in `useConnection.test.tsx`

## How Has This Been Tested?
Against Everything Server PR [3334](https://github.com/modelcontextprotocol/servers/pull/3334)

### Url Elicitation Tool Entry
<img width="766" height="109" alt="url-elicitation-tool-entry" src="https://github.com/user-attachments/assets/fee8f920-dfe3-4a6c-8f64-17e77e9993fc" />
 
### Url Elicitation Tool
<img width="797" height="815" alt="url-elicitation-tool" src="https://github.com/user-attachments/assets/1c58f6a0-2386-4428-a59f-6b06e7604876" />

### Url Elicitation Request
<img width="1920" height="1081" alt="url-elicitation-request" src="https://github.com/user-attachments/assets/f3422062-e577-411e-9f42-d4c720ed8d84" />

### Url Elicitation Open URL Dialog
<img width="563" height="293" alt="url-elicitation-open-dlalog" src="https://github.com/user-attachments/assets/2c113abf-317a-45c0-ad2a-44fe621c6ccb" />

### Url Elicitation Tool Success
<img width="771" height="278" alt="url-elicitation-success" src="https://github.com/user-attachments/assets/da9c4748-4111-4c2f-8f7a-25e320f8a54e" />

### Url Elicitation Tool Error Path
<img width="780" height="432" alt="url-elicitation-error-path" src="https://github.com/user-attachments/assets/092226e6-87e3-4d8e-9bfb-78cde0b13f19" />

## Test plan
- [x] `npm run build` — no type errors
- [x] `cd client && npm run lint` — no lint issues
- [x] `cd client && npx jest` — 494 tests pass
- [ ] Manual: `npm run dev`, connect to an MCP server, verify form elicitation still works
- [ ] Manual: verify a URL-mode elicitation renders the message, consent dialog, and buttons correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
