### PR TITLE
fix: prevent malformed dual Content-Type on direct-transport token requests

### DIFF
--- a/client/src/lib/hooks/__tests__/oauthHeaderMerge.test.ts
+++ b/client/src/lib/hooks/__tests__/oauthHeaderMerge.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Guards against a malformed dual `Content-Type` on the OAuth token request
+ * made by the direct SSE / Streamable HTTP transports.
+ *
+ * For direct connections the Inspector passes a `requestInit` to the transport.
+ * The SDK wraps it with `createFetchWithInit`, which merges the base
+ * `requestInit.headers` with each request's own headers using a case-SENSITIVE
+ * object spread. The SDK's token request (executeTokenRequest) builds its
+ * headers with `new Headers(...)`, which normalizes the key to lowercase
+ * `content-type`.
+ *
+ * If the Inspector also puts a (capital) `Content-Type` in `requestInit`, both
+ * keys survive the case-sensitive merge and `fetch` comma-joins them into
+ *   `Content-Type: application/json, application/x-www-form-urlencoded`
+ * which strict authorization servers cannot body-parse, breaking token
+ * exchange and refresh.
+ *
+ * The Inspector therefore must not contribute `content-type` (or `accept`) via
+ * `requestInit` — the SDK already sets them per request. These tests drive the
+ * real SDK merge with the token request's exact shape to lock that in.
+ */
+import { createFetchWithInit } from "@modelcontextprotocol/sdk/shared/transport.js";
+
+type CapturedRequest = { url: string; contentType: string | null };
+
+/**
+ * A fetch that records the `Content-Type` the upstream server would actually
+ * receive, using real `Headers` semantics (which combine duplicates).
+ */
+function makeCapturingFetch(captured: CapturedRequest[]) {
+  return (async (
+    input: string | URL | globalThis.Request,
+    init?: RequestInit,
+  ) => {
+    const headers = new Headers(init?.headers);
+    captured.push({
+      url: typeof input === "string" ? input : input.toString(),
+      contentType: headers.get("content-type"),
+    });
+    return new Response("{}", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+// Mirrors the SDK's executeTokenRequest: a Headers object, which lowercases the
+// key to "content-type", plus a form-urlencoded body.
+async function postToken(fetchFn: typeof fetch) {
+  await fetchFn("https://auth.example.com/token", {
+    method: "POST",
+    headers: new Headers({
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    }),
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: "r",
+    }),
+  });
+}
+
+function tokenContentType(captured: CapturedRequest[]): string | null {
+  const req = captured.find((c) => c.url.endsWith("/token"));
+  expect(req).toBeDefined();
+  return req!.contentType;
+}
+
+describe("OAuth token request keeps a single Content-Type", () => {
+  it("does not duplicate Content-Type when requestInit carries only auth headers", async () => {
+    // The headers the Inspector now hands to the transport as
+    // `requestInit.headers`: auth / custom headers only, never content-type.
+    const captured: CapturedRequest[] = [];
+    const fetchFn = createFetchWithInit(makeCapturingFetch(captured), {
+      headers: { Authorization: "Bearer test-access-token" },
+    });
+
+    await postToken(fetchFn);
+
+    expect(tokenContentType(captured)).toBe(
+      "application/x-www-form-urlencoded",
+    );
+  });
+
+  it("a Content-Type left in requestInit re-introduces the dual header", async () => {
+    // Documents the bug this fix removes: a capital "Content-Type" in
+    // requestInit collides with the token request's lowercase "content-type".
+    const captured: CapturedRequest[] = [];
+    const fetchFn = createFetchWithInit(makeCapturingFetch(captured), {
+      headers: { "Content-Type": "application/json" },
+    });
+
+    await postToken(fetchFn);
+
+    expect(tokenContentType(captured)).toBe(
+      "application/json, application/x-www-form-urlencoded",
+    );
+  });
+});

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -580,18 +580,21 @@ export function useConnection({
         }
         switch (transportType) {
           case "sse":
-            requestHeaders["Accept"] = "text/event-stream";
-            requestHeaders["content-type"] = "application/json";
+            // Do not set accept/content-type here. The SDK sets them itself on
+            // each request (SSE GET stream, message POST, and the OAuth token
+            // request). Injecting them via requestInit collides with the SDK's
+            // case-sensitive header merge: the token request builds its headers
+            // with `new Headers(...)`, normalizing to lowercase "content-type",
+            // so a capital "Content-Type" set here survives alongside it and
+            // `fetch` comma-joins them into a malformed dual value that strict
+            // servers cannot parse. See createFetchWithInit in shared/transport.
             transportOptions = {
               authProvider: serverAuthProvider,
               fetch: async (
                 url: string | URL | globalThis.Request,
                 init?: RequestInit,
               ) => {
-                const response = await fetch(url, {
-                  ...init,
-                  headers: requestHeaders,
-                });
+                const response = await fetch(url, init);
 
                 // Capture protocol-related headers from response
                 captureResponseHeaders(response);
@@ -604,19 +607,17 @@ export function useConnection({
             break;
 
           case "streamable-http":
+            // See the SSE note above: the SDK sets accept/content-type itself
+            // per request, so injecting them via requestInit collides with the
+            // SDK's case-sensitive merge and yields a malformed dual
+            // Content-Type on the OAuth token request.
             transportOptions = {
               authProvider: serverAuthProvider,
               fetch: async (
                 url: string | URL | globalThis.Request,
                 init?: RequestInit,
               ) => {
-                requestHeaders["Accept"] =
-                  "text/event-stream, application/json";
-                requestHeaders["Content-Type"] = "application/json";
-                const response = await fetch(url, {
-                  headers: requestHeaders,
-                  ...init,
-                });
+                const response = await fetch(url, init);
 
                 // Capture protocol-related headers from response
                 captureResponseHeaders(response);


### PR DESCRIPTION
## Summary

Direct (non-proxy) SSE and Streamable HTTP connections send a **malformed dual `Content-Type`** on the OAuth **token** request:

```
Content-Type: application/json, application/x-www-form-urlencoded
```

Strict authorization servers can't body-parse this, so token exchange and refresh fail (e.g. Keycloak: *"Failed to parse media type..."*). It surfaces on token refresh once an access token expires.

> **Note:** Inspector V2 is under development to address architectural and UX improvements. During this time, V1 contributions should focus on **bug fixes and MCP spec compliance**. See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

**Root cause**

For direct connections the Inspector passes a `requestInit` to the transport. The SDK wraps it with `createFetchWithInit`, which merges the base `requestInit.headers` with each request's own headers using a **case-sensitive object spread**.

The Inspector was injecting a capital `Content-Type` (and `Accept`) into `requestInit`. On the token request the SDK builds its headers with `new Headers(...)`, which normalizes the key to lowercase `content-type`. Because the merge is case-sensitive, the capital `Content-Type` and the lowercase `content-type` both survive, and `fetch` then comma-joins them into the malformed value above.

**Fix**

Stop contributing `content-type`/`accept` via `requestInit`, and simplify the direct-transport custom fetch to a pass-through `fetch(url, init)`. This is safe and complete because the SDK already sets those headers itself per request:

- MCP `POST` and the SSE `GET` stream — `headers.set('content-type'/'accept', ...)` on a `Headers` object (case-insensitive)
- the token request — sets its own `Content-Type`

Auth/custom headers (e.g. `Authorization`) still reach every request through the SDK's `_commonHeaders()`, which folds in `requestInit.headers`. The change also removes a pre-existing inconsistency where the SSE wrapper let the base headers clobber per-request headers while the Streamable HTTP wrapper did the opposite.

This affects **direct** SSE / Streamable HTTP connections only — proxy connections were unaffected.

## Related Issues

<!-- Link to related issues using #issue_number or "Fixes #issue_number" -->

## Testing

- [x] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [x] Tested with SSE transport
- [x] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

Added `oauthHeaderMerge.test.ts`, which drives the **real** SDK `createFetchWithInit` with the token request's exact shape:

- single `Content-Type` on the token request when `requestInit` carries only auth headers (the fix)
- a case demonstrating that leaving a `Content-Type` in `requestInit` re-introduces the dual header (the bug)

All existing `useConnection` tests (46) still pass; lint and prettier clean.

Also verified end-to-end against a live OAuth-protected MCP server over an ngrok tunnel: the token request now goes out with a single `Content-Type: application/x-www-form-urlencoded`, and token exchange/refresh succeed.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None. Non-breaking bug fix.

## Additional Context

Scope is limited to **direct** (non-proxy) SSE / Streamable HTTP connections; proxy connections were unaffected.
