### PR TITLE
fix: use the auth provider's current token instead of a connect-time snapshot

### DIFF
--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -1313,7 +1313,7 @@ describe("useConnection", () => {
       );
     });
 
-    test("uses OAuth token when no custom headers or legacy auth provided", async () => {
+    test("relies on the auth provider for the OAuth token instead of baking it into requestInit", async () => {
       const propsWithoutAuth = {
         ...defaultProps,
       };
@@ -1324,8 +1324,12 @@ describe("useConnection", () => {
         await result.current.connect();
       });
 
-      const headers = mockSSETransport.options?.requestInit?.headers;
-      expect(headers).toHaveProperty("Authorization", "Bearer mock-token");
+      const options = mockSSETransport.options;
+      // The SDK's authProvider supplies (and refreshes) the OAuth token on every
+      // request, so the Inspector must not snapshot it into requestInit — doing
+      // so would shadow the refreshed token and 401-loop after expiry.
+      expect(options?.authProvider).toBeDefined();
+      expect(options?.requestInit?.headers).not.toHaveProperty("Authorization");
     });
 
     test("warns of enabled empty Bearer token", async () => {
@@ -1792,6 +1796,62 @@ describe("useConnection", () => {
       expect(
         mockStreamableHTTPTransport.url?.searchParams.get("proxyFullAddress"),
       ).toBeNull();
+    });
+  });
+
+  describe("OAuth access token is supplied by the provider, not snapshotted", () => {
+    // The mocked InspectorOAuthClientProvider always returns a token, so the
+    // pre-fix code would have baked "Bearer mock-token" into requestInit. These
+    // tests assert it no longer does, for the direct transports where the SDK's
+    // authProvider is the single, always-current source of the token.
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockSSETransport.options = undefined;
+      mockStreamableHTTPTransport.options = undefined;
+    });
+
+    test("direct streamable-http does not bake an Authorization header into requestInit", async () => {
+      const props = {
+        ...defaultProps,
+        connectionType: "direct" as const,
+        transportType: "streamable-http" as const,
+        sseUrl: "http://localhost:8080",
+      };
+
+      const { result } = renderHook(() => useConnection(props));
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      const options = mockStreamableHTTPTransport.options;
+      expect(options).toBeDefined();
+      // The provider is the single source of truth for the OAuth token.
+      expect(options?.authProvider).toBeDefined();
+      // No connect-time snapshot that would shadow the provider's refreshed
+      // token (the SDK lets requestInit override the provider) and cause a
+      // 401 loop after the access token expires.
+      expect(options?.requestInit?.headers).not.toHaveProperty("Authorization");
+      expect(options?.requestInit?.headers).not.toHaveProperty("authorization");
+    });
+
+    test("direct SSE does not bake an Authorization header into requestInit", async () => {
+      const props = {
+        ...defaultProps,
+        connectionType: "direct" as const,
+        transportType: "sse" as const,
+        sseUrl: "http://localhost:8080",
+      };
+
+      const { result } = renderHook(() => useConnection(props));
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      const options = mockSSETransport.options;
+      expect(options).toBeDefined();
+      expect(options?.authProvider).toBeDefined();
+      expect(options?.requestInit?.headers).not.toHaveProperty("Authorization");
+      expect(options?.requestInit?.headers).not.toHaveProperty("authorization");
     });
   });
 });

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -499,7 +499,7 @@ export function useConnection({
       const serverAuthProvider = new InspectorOAuthClientProvider(sseUrl);
 
       // Use custom headers (migration is handled in App.tsx)
-      let finalHeaders: CustomHeaders = customHeaders || [];
+      const finalHeaders: CustomHeaders = customHeaders || [];
 
       const isEmptyAuthHeader = (header: CustomHeaders[number]) =>
         header.name.trim().toLowerCase() === "authorization" &&
@@ -519,27 +519,15 @@ export function useConnection({
         });
       }
 
-      const needsOAuthToken = !finalHeaders.some(
-        (header) =>
-          header.enabled &&
-          header.name.trim().toLowerCase() === "authorization",
-      );
-
-      if (needsOAuthToken) {
-        const oauthToken = (await serverAuthProvider.tokens())?.access_token;
-        if (oauthToken) {
-          // Add the OAuth token
-          finalHeaders = [
-            // Remove any existing Authorization headers with empty tokens
-            ...finalHeaders.filter((header) => !isEmptyAuthHeader(header)),
-            {
-              name: "Authorization",
-              value: `Bearer ${oauthToken}`,
-              enabled: true,
-            },
-          ];
-        }
-      }
+      // Do not inject the OAuth access token here. The transports below receive
+      // `serverAuthProvider` as their authProvider, so the SDK adds a fresh
+      // `Authorization` from the provider on every request and replaces it after
+      // a refresh. Baking a connect-time snapshot into requestInit.headers would
+      // shadow that: the SDK's _commonHeaders lets requestInit override the
+      // provider token, so the stale token would keep being sent and the session
+      // would 401-loop once the access token expires. A user-supplied static
+      // Authorization header still flows through the custom-headers path below
+      // and intentionally overrides the provider.
 
       // Process all enabled custom headers
       const customHeaderNames: string[] = [];


### PR DESCRIPTION
## Summary

After a successful OAuth token refresh, direct (non-proxy) connections keep sending the **old** access token, so the session enters a 401 loop it can't recover from. Once the access token expires:

1. `POST /mcp` returns 401, the SDK refreshes, `POST /token` (grant_type=refresh_token) returns 200, and the provider stores the new token.
2. The retried `POST /mcp` still carries the **old** `Authorization: Bearer …`, gets another 401.
3. The SDK's circuit breaker throws **"Server returned 401 after successful authentication"**.

This is rarely hit with a long token TTL, but a short TTL breaks the session at first expiry.

> **Note:** Inspector V2 is under development to address architectural and UX improvements. During this time, V1 contributions should focus on **bug fixes and MCP spec compliance**. See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

### Root cause

When relying on OAuth, `useConnection` read the access token from the provider **once at connection setup** and baked `Authorization: Bearer <token>` into `requestInit.headers`.

The transports already receive that same provider as their `authProvider`, so the SDK adds a fresh `Authorization` from it on every request (and refreshes it on 401). But the SDK's `_commonHeaders()` spreads `requestInit.headers` **after** the provider token:

```js
const headers = {};
if (this._authProvider) {
  const tokens = await this._authProvider.tokens();      // fresh token (post-refresh)
  headers['Authorization'] = `Bearer ${tokens.access_token}`;
}
const extraHeaders = normalizeHeaders(this._requestInit?.headers); // connect-time snapshot
return new Headers({ ...headers, ...extraHeaders });     // ← snapshot wins
```

So the connect-time snapshot always shadows the provider's current token. The provider does store the refreshed token (`saveTokens`/`tokens()` round-trip the same `sessionStorage` key) — it just never gets used.

### Fix

Stop snapshotting the OAuth token into `requestInit`. The provider is the single, always-current source of the token, and the SDK injects and refreshes it per request. A user-supplied **static** `Authorization` header still flows through the custom-headers path and intentionally overrides the provider.

This affects connections that use the SDK's OAuth `authProvider` and is independent of the malformed-`Content-Type` fix.

## Related Issues

<!-- Link to related issues using #issue_number or "Fixes #issue_number" -->

## Testing

- [ ] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [x] Tested with SSE transport
- [x] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [ ] Manual testing performed

### Test Results and/or Instructions

- Updated the test that asserted the old baking behavior to assert the token is no longer baked into `requestInit` and that `authProvider` is set.
- Added direct SSE / Streamable HTTP tests covering the same.
- The existing "preserves server Authorization header" test still passes, confirming static user-supplied tokens are unaffected.

All `useConnection` tests pass; lint and prettier clean; client build compiles.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None. Non-breaking bug fix.

## Additional Context

<!-- Add any other context, screenshots, or information about the PR here -->
