### PR TITLE
fix(web): filter toggle hover as border, not background (#1460)

### DIFF
--- a/clients/web/src/App.css
+++ b/clients/web/src/App.css
@@ -199,8 +199,14 @@
  * filled background. Keeping the two states distinct means toggling a button
  * off while the cursor is still over it is immediately visible, instead of the
  * hover background masking the removal of the active background (issue #1460).
- * The 1px transparent border is reserved in the `filterToggle` theme variant so
- * the hover border doesn't shift layout. */
+ * The 1px transparent border is reserved here (not as an inline style in the
+ * theme variant — inline styles outrank stylesheet `:hover` rules) so the hover
+ * border doesn't shift layout. */
+
+.filter-toggle {
+  border: 1px solid transparent;
+  border-radius: var(--mantine-radius-md);
+}
 
 .filter-toggle:hover {
   border-color: var(--inspector-brand-primary);

--- a/clients/web/src/App.css
+++ b/clients/web/src/App.css
@@ -192,6 +192,24 @@
   background-color: var(--mantine-primary-color-light);
 }
 
+/* ── Filter toggle buttons (Logging / History / Network) ─────────
+ *
+ * Shared by the FilterToggleButton element. Unlike `.list-item`, hover is a
+ * thin border rather than a background fill, and the active (on) state is the
+ * filled background. Keeping the two states distinct means toggling a button
+ * off while the cursor is still over it is immediately visible, instead of the
+ * hover background masking the removal of the active background (issue #1460).
+ * The 1px transparent border is reserved in the `filterToggle` theme variant so
+ * the hover border doesn't shift layout. */
+
+.filter-toggle:hover {
+  border-color: var(--inspector-brand-primary);
+}
+
+.filter-toggle[aria-pressed="true"] {
+  background-color: var(--mantine-primary-color-light);
+}
+
 /* ── Select / Autocomplete dropdown / option (dark mode) ─────────
  *
  * Select and Autocomplete each render with their own static selector

--- a/clients/web/src/components/elements/FilterToggleButton/FilterToggleButton.stories.tsx
+++ b/clients/web/src/components/elements/FilterToggleButton/FilterToggleButton.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { FilterToggleButton } from "./FilterToggleButton";
+
+const meta: Meta<typeof FilterToggleButton> = {
+  title: "Elements/FilterToggleButton",
+  component: FilterToggleButton,
+  args: {
+    label: "debug",
+    color: "blue",
+    onToggle: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FilterToggleButton>;
+
+// Active (on): filled background, aria-pressed=true.
+export const Active: Story = {
+  args: {
+    active: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("button", { name: "debug" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  },
+};
+
+// Inactive (off): no fill; hover shows a thin border (visual only).
+export const Inactive: Story = {
+  args: {
+    active: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("button", { name: "debug" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  },
+};
+
+// Clicking an active button invokes onToggle(false).
+export const TogglesOff: Story = {
+  args: {
+    active: true,
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button", { name: "debug" }));
+    await expect(args.onToggle).toHaveBeenCalledWith(false);
+  },
+};

--- a/clients/web/src/components/elements/FilterToggleButton/FilterToggleButton.stories.tsx
+++ b/clients/web/src/components/elements/FilterToggleButton/FilterToggleButton.stories.tsx
@@ -22,22 +22,35 @@ export const Active: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByRole("button", { name: "debug" }),
-    ).toHaveAttribute("aria-pressed", "true");
+    const button = await canvas.findByRole("button", { name: "debug" });
+    await expect(button).toHaveAttribute("aria-pressed", "true");
+    // Active renders a filled background (driven by `[aria-pressed="true"]`).
+    await expect(getComputedStyle(button).backgroundColor).not.toBe(
+      "rgba(0, 0, 0, 0)",
+    );
   },
 };
 
-// Inactive (off): no fill; hover shows a thin border (visual only).
+const TRANSPARENT = "rgba(0, 0, 0, 0)";
+
+// Inactive (off): no fill, and the reserved border is transparent. The visible
+// hover border is intentionally NOT asserted here — the Storybook/vitest runner
+// dispatches synthetic pointer events that don't engage real CSS `:hover`. The
+// border-on-hover (and that it isn't an inline style outranking the `:hover`
+// rule — the #1460 regression) was verified with real Playwright `page.hover`.
 export const Inactive: Story = {
   args: {
     active: false,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByRole("button", { name: "debug" }),
-    ).toHaveAttribute("aria-pressed", "false");
+    const button = await canvas.findByRole("button", { name: "debug" });
+    await expect(button).toHaveAttribute("aria-pressed", "false");
+
+    // The reserved border is transparent by default and there's no active fill,
+    // so the inactive button reads as empty until hovered or toggled on.
+    await expect(getComputedStyle(button).borderTopColor).toBe(TRANSPARENT);
+    await expect(getComputedStyle(button).backgroundColor).toBe(TRANSPARENT);
   },
 };
 

--- a/clients/web/src/components/elements/FilterToggleButton/FilterToggleButton.test.tsx
+++ b/clients/web/src/components/elements/FilterToggleButton/FilterToggleButton.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { FilterToggleButton } from "./FilterToggleButton";
+
+const baseProps = {
+  label: "debug",
+  color: "blue",
+  active: false,
+  onToggle: vi.fn(),
+};
+
+describe("FilterToggleButton", () => {
+  it("renders the label as the accessible name", () => {
+    renderWithMantine(<FilterToggleButton {...baseProps} />);
+    expect(screen.getByRole("button", { name: "debug" })).toBeInTheDocument();
+  });
+
+  it("reflects the active state via aria-pressed=true", () => {
+    renderWithMantine(<FilterToggleButton {...baseProps} active={true} />);
+    expect(screen.getByRole("button", { name: "debug" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("reflects the inactive state via aria-pressed=false", () => {
+    renderWithMantine(<FilterToggleButton {...baseProps} active={false} />);
+    expect(screen.getByRole("button", { name: "debug" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("toggles to true when an inactive button is clicked", async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    renderWithMantine(
+      <FilterToggleButton {...baseProps} active={false} onToggle={onToggle} />,
+    );
+    await user.click(screen.getByRole("button", { name: "debug" }));
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it("toggles to false when an active button is clicked", async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    renderWithMantine(
+      <FilterToggleButton {...baseProps} active={true} onToggle={onToggle} />,
+    );
+    await user.click(screen.getByRole("button", { name: "debug" }));
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+});

--- a/clients/web/src/components/elements/FilterToggleButton/FilterToggleButton.tsx
+++ b/clients/web/src/components/elements/FilterToggleButton/FilterToggleButton.tsx
@@ -1,0 +1,44 @@
+import { Text, UnstyledButton } from "@mantine/core";
+
+export interface FilterToggleButtonProps {
+  /** Visible label and accessible name for the toggle. */
+  label: string;
+  /** Mantine text color for the label (e.g. "blue", "red", "dimmed"). */
+  color: string;
+  /** Whether the filter is currently on (rendered as a filled background). */
+  active: boolean;
+  /** Receives the next desired active state when the button is clicked. */
+  onToggle: (active: boolean) => void;
+}
+
+const ToggleLabel = Text.withProps({
+  ta: "center",
+  fw: 500,
+});
+
+/**
+ * A single full-width filter toggle used by the Logging, History, and Network
+ * controls. The `filterToggle` theme variant + `.filter-toggle` rules own the
+ * styling: hover shows a thin border, the active (`aria-pressed`) state shows a
+ * filled background. Keeping hover as a border (not a fill) means toggling a
+ * button off while the cursor is still over it is visibly distinct from hover,
+ * instead of the two states sharing the same background. See issue #1460.
+ */
+export function FilterToggleButton({
+  label,
+  color,
+  active,
+  onToggle,
+}: FilterToggleButtonProps) {
+  return (
+    <UnstyledButton
+      w="100%"
+      p="sm"
+      variant="filterToggle"
+      aria-pressed={active}
+      onClick={() => onToggle(!active)}
+    >
+      <ToggleLabel c={color}>{label}</ToggleLabel>
+    </UnstyledButton>
+  );
+}

--- a/clients/web/src/components/groups/LogControls/LogControls.test.tsx
+++ b/clients/web/src/components/groups/LogControls/LogControls.test.tsx
@@ -132,6 +132,20 @@ describe("LogControls", () => {
     expect(onToggleAllLevels).toHaveBeenCalledTimes(1);
   });
 
+  it("reflects level visibility via aria-pressed", () => {
+    renderWithMantine(
+      <LogControls {...baseProps} visibleLevels={someVisible} />,
+    );
+    expect(screen.getByRole("button", { name: "debug" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "warning" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
   it("invokes onToggleLevel when a level button is clicked", async () => {
     const user = userEvent.setup();
     const onToggleLevel = vi.fn();

--- a/clients/web/src/components/groups/LogControls/LogControls.tsx
+++ b/clients/web/src/components/groups/LogControls/LogControls.tsx
@@ -4,12 +4,11 @@ import {
   Group,
   Select,
   Stack,
-  Text,
   TextInput,
   Title,
-  UnstyledButton,
 } from "@mantine/core";
 import type { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
+import { FilterToggleButton } from "../../elements/FilterToggleButton/FilterToggleButton";
 
 const LOG_LEVELS: LoggingLevel[] = [
   "debug",
@@ -102,24 +101,15 @@ export function LogControls({
         </SubtleButton>
       </Group>
       <Stack gap="xs">
-        {LOG_LEVELS.map((level) => {
-          const style = LEVEL_COLORS[level];
-          const active = visibleLevels[level];
-          return (
-            <UnstyledButton
-              key={level}
-              w="100%"
-              p="sm"
-              variant="listItem"
-              bg={active ? "var(--mantine-primary-color-light)" : undefined}
-              onClick={() => onToggleLevel(level, !active)}
-            >
-              <Text c={style.c} ta="center" fw={500}>
-                {level}
-              </Text>
-            </UnstyledButton>
-          );
-        })}
+        {LOG_LEVELS.map((level) => (
+          <FilterToggleButton
+            key={level}
+            label={level}
+            color={LEVEL_COLORS[level].c}
+            active={visibleLevels[level]}
+            onToggle={(visible) => onToggleLevel(level, visible)}
+          />
+        ))}
       </Stack>
     </Stack>
   );

--- a/clients/web/src/components/groups/MessageDirectionFilter/MessageDirectionFilter.tsx
+++ b/clients/web/src/components/groups/MessageDirectionFilter/MessageDirectionFilter.tsx
@@ -1,12 +1,6 @@
-import {
-  Button,
-  Group,
-  Stack,
-  Text,
-  Title,
-  UnstyledButton,
-} from "@mantine/core";
+import { Button, Group, Stack, Title } from "@mantine/core";
 import type { MessageOrigin } from "@inspector/core/mcp/types.js";
+import { FilterToggleButton } from "../../elements/FilterToggleButton/FilterToggleButton";
 
 const SubtleButton = Button.withProps({
   variant: "subtle",
@@ -33,8 +27,8 @@ export interface MessageDirectionFilterProps {
 
 /**
  * "Filter by Message Direction" section — a Select/Deselect All control plus a
- * listItem toggle per direction (client → server / client ← server). Used by the
- * History controls. (Kept as its own component so the section is testable in
+ * FilterToggleButton per direction (client → server / client ← server). Used by
+ * the History controls. (Kept as its own component so the section is testable in
  * isolation and reusable if another screen ever needs a direction filter.)
  */
 export function MessageDirectionFilter({
@@ -53,24 +47,15 @@ export function MessageDirectionFilter({
         </SubtleButton>
       </Group>
       <Stack gap="xs">
-        {MESSAGE_DIRECTIONS.map(({ origin, label, color }) => {
-          const active = visibleDirections[origin];
-          return (
-            <UnstyledButton
-              key={origin}
-              w="100%"
-              p="sm"
-              variant="listItem"
-              aria-pressed={active}
-              bg={active ? "var(--mantine-primary-color-light)" : undefined}
-              onClick={() => onToggleDirection(origin, !active)}
-            >
-              <Text c={color} ta="center" fw={500}>
-                {label}
-              </Text>
-            </UnstyledButton>
-          );
-        })}
+        {MESSAGE_DIRECTIONS.map(({ origin, label, color }) => (
+          <FilterToggleButton
+            key={origin}
+            label={label}
+            color={color}
+            active={visibleDirections[origin]}
+            onToggle={(visible) => onToggleDirection(origin, visible)}
+          />
+        ))}
       </Stack>
     </>
   );

--- a/clients/web/src/components/groups/NetworkControls/NetworkControls.test.tsx
+++ b/clients/web/src/components/groups/NetworkControls/NetworkControls.test.tsx
@@ -32,6 +32,20 @@ describe("NetworkControls", () => {
     expect(onFilterChange).toHaveBeenLastCalledWith("x");
   });
 
+  it("clears the filter text when the clear button is clicked", async () => {
+    const user = userEvent.setup();
+    const onFilterChange = vi.fn();
+    renderWithMantine(
+      <NetworkControls
+        {...baseProps}
+        filterText="auth"
+        onFilterChange={onFilterChange}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+    expect(onFilterChange).toHaveBeenCalledWith("");
+  });
+
   it("reflects category visibility via aria-pressed", () => {
     renderWithMantine(
       <NetworkControls

--- a/clients/web/src/components/groups/NetworkControls/NetworkControls.tsx
+++ b/clients/web/src/components/groups/NetworkControls/NetworkControls.tsx
@@ -3,12 +3,11 @@ import {
   CloseButton,
   Group,
   Stack,
-  Text,
   TextInput,
   Title,
-  UnstyledButton,
 } from "@mantine/core";
 import type { FetchRequestCategory } from "@inspector/core/mcp/types.js";
+import { FilterToggleButton } from "../../elements/FilterToggleButton/FilterToggleButton";
 
 const NETWORK_CATEGORIES: FetchRequestCategory[] = ["auth", "transport"];
 
@@ -64,24 +63,15 @@ export function NetworkControls({
         </SubtleButton>
       </Group>
       <Stack gap="xs">
-        {NETWORK_CATEGORIES.map((category) => {
-          const active = visibleCategories[category];
-          return (
-            <UnstyledButton
-              key={category}
-              w="100%"
-              p="sm"
-              variant="listItem"
-              aria-pressed={active}
-              bg={active ? "var(--mantine-primary-color-light)" : undefined}
-              onClick={() => onToggleCategory(category, !active)}
-            >
-              <Text c={CATEGORY_COLORS[category]} ta="center" fw={500}>
-                {category}
-              </Text>
-            </UnstyledButton>
-          );
-        })}
+        {NETWORK_CATEGORIES.map((category) => (
+          <FilterToggleButton
+            key={category}
+            label={category}
+            color={CATEGORY_COLORS[category]}
+            active={visibleCategories[category]}
+            onToggle={(visible) => onToggleCategory(category, visible)}
+          />
+        ))}
       </Stack>
     </Stack>
   );

--- a/clients/web/src/theme/UnstyledButton.ts
+++ b/clients/web/src/theme/UnstyledButton.ts
@@ -3,11 +3,22 @@ import { UnstyledButton } from "@mantine/core";
 export const ThemeUnstyledButton = UnstyledButton.extend({
   classNames: (_theme, props) => {
     if (props.variant === "listItem") return { root: "list-item" };
+    if (props.variant === "filterToggle") return { root: "filter-toggle" };
     return {};
   },
   styles: (_theme, props) => {
     if (props.variant === "listItem") {
       return { root: { borderRadius: "var(--mantine-radius-md)" } };
+    }
+    // A permanently-present transparent border reserves the space so the
+    // hover border (`.filter-toggle:hover` in App.css) doesn't shift layout.
+    if (props.variant === "filterToggle") {
+      return {
+        root: {
+          borderRadius: "var(--mantine-radius-md)",
+          border: "1px solid transparent",
+        },
+      };
     }
     return { root: {} };
   },

--- a/clients/web/src/theme/UnstyledButton.ts
+++ b/clients/web/src/theme/UnstyledButton.ts
@@ -10,16 +10,11 @@ export const ThemeUnstyledButton = UnstyledButton.extend({
     if (props.variant === "listItem") {
       return { root: { borderRadius: "var(--mantine-radius-md)" } };
     }
-    // A permanently-present transparent border reserves the space so the
-    // hover border (`.filter-toggle:hover` in App.css) doesn't shift layout.
-    if (props.variant === "filterToggle") {
-      return {
-        root: {
-          borderRadius: "var(--mantine-radius-md)",
-          border: "1px solid transparent",
-        },
-      };
-    }
+    // `filterToggle` is styled entirely via the `.filter-toggle` rules in
+    // App.css (border-radius, the reserved transparent border, the :hover
+    // border, and the active background). Crucially the border must NOT be set
+    // here as an inline style — inline styles outrank stylesheet `:hover`
+    // rules, which would stop the hover border from ever showing (see #1460).
     return { root: {} };
   },
 });


### PR DESCRIPTION
Closes #1460

## Problem

The **Filter by …** toggle buttons on the **Logging**, **History**, and **Network** screens gave no feedback when toggled *off*: their **hover** background and their **active (on)** background were the same token (`--mantine-primary-color-light`). Clicking a toggled-on button to turn it off while the cursor was still over it looked like nothing happened — the identical hover background immediately replaced the active one.

## Fix

- **Shared `FilterToggleButton` element** (`components/elements/FilterToggleButton/`) now used by `LogControls`, `NetworkControls`, and `MessageDirectionFilter`, replacing the duplicated `UnstyledButton` + inline `bg={active ? "var(--mantine-primary-color-light)" : undefined}` in each of the three. The toggle styling lives in one place now.
- **New `filterToggle` theme variant** (`theme/UnstyledButton.ts`) + `.filter-toggle` rules (`App.css`):
  - **Hover → thin border** (`--inspector-brand-primary`), reserved via a permanent `1px solid transparent` border so it doesn't shift layout.
  - **Active → filled background**, keyed off `aria-pressed="true"`.
  - The two states are now visually distinct, so toggling off is immediately visible even under the cursor.
- The shared `.list-item` selectable rows (Prompts/Apps/Tools/Resources lists, `sectionHeader` Groups) are **untouched** — they keep their hover-fill since they're single-select/navigation rows, not toggles.
- Added `aria-pressed` to the **Logging level** toggles (previously missing; the Network/Direction toggles already had it).

## Screencapture

https://github.com/user-attachments/assets/6de6547a-0e3e-4ee0-881f-8de0f3d0dcb6



## Tests

- New `FilterToggleButton` unit tests + stories (active/inactive `aria-pressed`, toggle-on, toggle-off).
- Added an `aria-pressed` reflection test to `LogControls`, and a clear-button test to `NetworkControls` (keeps per-file coverage ≥ 90% after the line-count shrank).
- `npm run validate` ✅ · `npm run test:storybook` ✅ (353 passed).

> Note: the active-fill/hover-border are CSS-only (applied in real browsers); happy-dom unit tests assert the behavior via `aria-pressed`, and the Storybook play functions run in real Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)