### PR TITLE
fix(client): keep field descriptions visible

### DIFF
--- a/client/src/components/AppsTab.tsx
+++ b/client/src/components/AppsTab.tsx
@@ -21,6 +21,7 @@ import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge"
 import AppRenderer from "./AppRenderer";
 import ListPane from "./ListPane";
 import IconDisplay, { WithIcons } from "./IconDisplay";
+import SchemaFieldDescription from "./SchemaFieldDescription";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -411,6 +412,12 @@ const AppsTab = ({
                               key,
                               inputSchema,
                             );
+                            const descriptionId = `${key}-description`;
+                            const showFieldDescription =
+                              !!prop.description &&
+                              (prop.type === "string" ||
+                                prop.type === "number" ||
+                                prop.type === "integer");
 
                             return (
                               <div key={key} className="space-y-2">
@@ -496,7 +503,14 @@ const AppsTab = ({
                                         });
                                       }}
                                     >
-                                      <SelectTrigger id={key}>
+                                      <SelectTrigger
+                                        id={key}
+                                        aria-describedby={
+                                          showFieldDescription
+                                            ? descriptionId
+                                            : undefined
+                                        }
+                                      >
                                         <SelectValue
                                           placeholder={
                                             prop.description ||
@@ -519,6 +533,11 @@ const AppsTab = ({
                                     <Textarea
                                       id={key}
                                       placeholder={prop.description}
+                                      aria-describedby={
+                                        showFieldDescription
+                                          ? descriptionId
+                                          : undefined
+                                      }
                                       value={
                                         params[key] === undefined
                                           ? ""
@@ -564,6 +583,11 @@ const AppsTab = ({
                                       type="number"
                                       id={key}
                                       placeholder={prop.description}
+                                      aria-describedby={
+                                        showFieldDescription
+                                          ? descriptionId
+                                          : undefined
+                                      }
                                       value={
                                         params[key] === undefined
                                           ? ""
@@ -604,6 +628,12 @@ const AppsTab = ({
                                         });
                                         setTimeout(checkValidationErrors, 100);
                                       }}
+                                    />
+                                  )}
+                                  {showFieldDescription && (
+                                    <SchemaFieldDescription
+                                      id={descriptionId}
+                                      description={prop.description}
                                     />
                                   )}
                                 </div>

--- a/client/src/components/SchemaFieldDescription.tsx
+++ b/client/src/components/SchemaFieldDescription.tsx
@@ -1,0 +1,22 @@
+interface SchemaFieldDescriptionProps {
+  id: string;
+  description?: string;
+}
+
+export default function SchemaFieldDescription({
+  id,
+  description,
+}: SchemaFieldDescriptionProps) {
+  if (!description) {
+    return null;
+  }
+
+  return (
+    <p
+      id={id}
+      className="mt-1 text-xs text-muted-foreground whitespace-pre-wrap"
+    >
+      {description}
+    </p>
+  );
+}

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -40,6 +40,7 @@ import { useEffect, useState, useRef } from "react";
 import ListPane from "./ListPane";
 import JsonView from "./JsonView";
 import ToolResults from "./ToolResults";
+import SchemaFieldDescription from "./SchemaFieldDescription";
 import { useToast } from "@/lib/hooks/useToast";
 import useCopy from "@/lib/hooks/useCopy";
 import IconDisplay, { WithIcons } from "./IconDisplay";
@@ -354,6 +355,12 @@ const ToolsTab = ({
                     const inputSchema =
                       selectedTool.inputSchema as JsonSchemaType;
                     const required = isPropertyRequired(key, inputSchema);
+                    const descriptionId = `${key}-description`;
+                    const showFieldDescription =
+                      !!prop.description &&
+                      (prop.type === "string" ||
+                        prop.type === "number" ||
+                        prop.type === "integer");
                     return (
                       <div key={key}>
                         <div className="flex justify-between">
@@ -447,7 +454,15 @@ const ToolsTab = ({
                                 }
                               }}
                             >
-                              <SelectTrigger id={key} className="mt-1">
+                              <SelectTrigger
+                                id={key}
+                                className="mt-1"
+                                aria-describedby={
+                                  showFieldDescription
+                                    ? descriptionId
+                                    : undefined
+                                }
+                              >
                                 <SelectValue
                                   placeholder={
                                     prop.description || "Select an option"
@@ -467,6 +482,9 @@ const ToolsTab = ({
                               id={key}
                               name={key}
                               placeholder={prop.description}
+                              aria-describedby={
+                                showFieldDescription ? descriptionId : undefined
+                              }
                               value={
                                 params[key] === undefined
                                   ? ""
@@ -522,6 +540,9 @@ const ToolsTab = ({
                               id={key}
                               name={key}
                               placeholder={prop.description}
+                              aria-describedby={
+                                showFieldDescription ? descriptionId : undefined
+                              }
                               value={
                                 params[key] === undefined
                                   ? ""
@@ -575,6 +596,12 @@ const ToolsTab = ({
                                 }}
                               />
                             </div>
+                          )}
+                          {showFieldDescription && (
+                            <SchemaFieldDescription
+                              id={descriptionId}
+                              description={prop.description}
+                            />
                           )}
                         </div>
                       </div>

--- a/client/src/components/__tests__/AppsTab.test.tsx
+++ b/client/src/components/__tests__/AppsTab.test.tsx
@@ -198,6 +198,37 @@ describe("AppsTab", () => {
     expect(screen.getByText("Tool: fieldsApp")).toBeInTheDocument();
   });
 
+  it("should keep input field descriptions visible after values are filled", () => {
+    const toolWithDescription: Tool = {
+      name: "describedApp",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Search phrase to render",
+          },
+        },
+      },
+      _meta: { ui: { resourceUri: "ui://described" } },
+    } as Tool & { _meta?: { ui?: { resourceUri?: string } } };
+
+    renderAppsTab({
+      tools: [toolWithDescription],
+    });
+
+    fireEvent.click(screen.getByText("describedApp"));
+
+    const input = screen.getByLabelText("query");
+    expect(input).toHaveAttribute("aria-describedby", "query-description");
+    expect(screen.getByText("Search phrase to render")).toBeVisible();
+
+    fireEvent.change(input, { target: { value: "filled value" } });
+
+    expect(input).toHaveValue("filled value");
+    expect(screen.getByText("Search phrase to render")).toBeVisible();
+  });
+
   it("should close app renderer when close button is clicked", async () => {
     renderAppsTab({
       tools: [mockAppTool],

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -1015,6 +1015,36 @@ describe("ToolsTab", () => {
       expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
       expect(screen.getByRole("textbox")).toBeInTheDocument();
     });
+
+    it("should keep string parameter descriptions visible after input is filled", () => {
+      const toolWithStringParam: Tool = {
+        name: "stringTool",
+        description: "Tool with regular string parameter",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            text: {
+              type: "string" as const,
+              description: "Some text input",
+            },
+          },
+        },
+      };
+
+      renderToolsTab({
+        tools: [toolWithStringParam],
+        selectedTool: toolWithStringParam,
+      });
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("aria-describedby", "text-description");
+      expect(screen.getByText("Some text input")).toBeVisible();
+
+      fireEvent.change(input, { target: { value: "filled value" } });
+
+      expect(input).toHaveValue("filled value");
+      expect(screen.getByText("Some text input")).toBeVisible();
+    });
   });
 
   describe("JSON Validation Integration", () => {


### PR DESCRIPTION
Fixes #1401.

## Summary
- Render schema field descriptions as persistent helper text for scalar tool inputs instead of only relying on placeholders.
- Apply the same behavior in the Apps tab input form.
- Add regression coverage for descriptions remaining visible after users fill the field.

## Testing
- `npm test -- --runTestsByPath client/src/components/__tests__/ToolsTab.test.tsx client/src/components/__tests__/AppsTab.test.tsx --runInBand`

This is a source-only frontend PR; no deployment was performed.
