### PR TITLE
feat(client): show loaded tool count

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -300,7 +300,7 @@ const ToolsTab = ({
               <ChevronRight className="w-4 h-4 flex-shrink-0 text-gray-400 mt-1" />
             </div>
           )}
-          title="Tools"
+          title={tools.length > 0 ? `Tools (${tools.length})` : "Tools"}
           buttonText={nextCursor ? "List More Tools" : "List Tools"}
           isButtonDisabled={!nextCursor && tools.length > 0}
         />

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -84,6 +84,20 @@ describe("ToolsTab", () => {
     );
   };
 
+  it("should show the loaded tool count in the tools list title", () => {
+    renderToolsTab();
+
+    expect(
+      screen.getByRole("heading", { name: "Tools (4)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should omit the tool count before tools are loaded", () => {
+    renderToolsTab({ tools: [] });
+
+    expect(screen.getByRole("heading", { name: "Tools" })).toBeInTheDocument();
+  });
+
   it("should reset input values when switching tools", async () => {
     const { rerender } = renderToolsTab({
       selectedTool: mockTools[0],


### PR DESCRIPTION
Fixes #1171.

## Summary
- Show the currently loaded tool count in the Tools list title after tools are listed.
- Keep the empty/unloaded state title as `Tools`.
- Add regression coverage for both loaded and unloaded titles.

## Testing
- `npm test -- --runTestsByPath client/src/components/__tests__/ToolsTab.test.tsx --runInBand`

This is a source-only frontend PR; no deployment was performed.
