### PR TITLE
test(web): harden managed state connect gates

### DIFF
--- a/clients/web/src/test/core/mcp/state/managedPromptsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedPromptsState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import type { InspectorServerSettings } from "@inspector/core/mcp/types.js";
 import { ManagedPromptsState } from "@inspector/core/mcp/state/managedPromptsState";
@@ -84,10 +84,9 @@ describe("ManagedPromptsState", () => {
     const promptlessState = new ManagedPromptsState(promptless, 0);
 
     promptless.dispatchTypedEvent("connect");
-    // Yield so the async refresh chained off connect runs.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(promptless.listPrompts).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(promptless.listPrompts).not.toHaveBeenCalled();
+    });
     expect(promptlessState.getPrompts()).toEqual([]);
   });
 

--- a/clients/web/src/test/core/mcp/state/managedRequestorTasksState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedRequestorTasksState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { Task } from "@modelcontextprotocol/sdk/types.js";
 import { ManagedRequestorTasksState } from "@inspector/core/mcp/state/managedRequestorTasksState";
 import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
@@ -74,10 +74,9 @@ describe("ManagedRequestorTasksState", () => {
     const tasklessState = new ManagedRequestorTasksState(taskless);
 
     taskless.dispatchTypedEvent("connect");
-    // Yield once so the async refresh chained off connect runs.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(taskless.listRequestorTasks).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(taskless.listRequestorTasks).not.toHaveBeenCalled();
+    });
     expect(tasklessState.getTasks()).toEqual([]);
   });
 

--- a/clients/web/src/test/core/mcp/state/managedResourceTemplatesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedResourceTemplatesState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
 import type { InspectorServerSettings } from "@inspector/core/mcp/types.js";
 import { ManagedResourceTemplatesState } from "@inspector/core/mcp/state/managedResourceTemplatesState";
@@ -90,10 +90,9 @@ describe("ManagedResourceTemplatesState", () => {
     );
 
     resourceless.dispatchTypedEvent("connect");
-    // Yield so the async refresh chained off connect runs.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(resourceless.listResourceTemplates).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(resourceless.listResourceTemplates).not.toHaveBeenCalled();
+    });
     expect(resourcelessState.getResourceTemplates()).toEqual([]);
   });
 

--- a/clients/web/src/test/core/mcp/state/managedResourcesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedResourcesState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { Resource } from "@modelcontextprotocol/sdk/types.js";
 import type { InspectorServerSettings } from "@inspector/core/mcp/types.js";
 import { ManagedResourcesState } from "@inspector/core/mcp/state/managedResourcesState";
@@ -89,10 +89,9 @@ describe("ManagedResourcesState", () => {
     const resourcelessState = new ManagedResourcesState(resourceless, 0);
 
     resourceless.dispatchTypedEvent("connect");
-    // Yield so the async refresh chained off connect runs.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(resourceless.listResources).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(resourceless.listResources).not.toHaveBeenCalled();
+    });
     expect(resourcelessState.getResources()).toEqual([]);
   });
 

--- a/clients/web/src/test/core/mcp/state/managedToolsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedToolsState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { InspectorServerSettings } from "@inspector/core/mcp/types.js";
 import { ManagedToolsState } from "@inspector/core/mcp/state/managedToolsState";
@@ -84,10 +84,9 @@ describe("ManagedToolsState", () => {
     const toollessState = new ManagedToolsState(toolless, 0);
 
     toolless.dispatchTypedEvent("connect");
-    // Yield so the async refresh chained off connect runs.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(toolless.listTools).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(toolless.listTools).not.toHaveBeenCalled();
+    });
     expect(toollessState.getTools()).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

Fixes #1396.

Replaces fixed double microtask flushes in the five Managed*State capability-gate connect-path tests with `vi.waitFor` assertions, keeping the tests uniform and less coupled to the current async depth inside `refresh()`.

## Validation

- `npm test -- src/test/core/mcp/state/managedToolsState.test.ts src/test/core/mcp/state/managedPromptsState.test.ts src/test/core/mcp/state/managedResourcesState.test.ts src/test/core/mcp/state/managedResourceTemplatesState.test.ts src/test/core/mcp/state/managedRequestorTasksState.test.ts`
- `./clients/web/node_modules/.bin/prettier --check clients/web/src/test/core/mcp/state/managedToolsState.test.ts clients/web/src/test/core/mcp/state/managedPromptsState.test.ts clients/web/src/test/core/mcp/state/managedResourcesState.test.ts clients/web/src/test/core/mcp/state/managedResourceTemplatesState.test.ts clients/web/src/test/core/mcp/state/managedRequestorTasksState.test.ts`
- `git diff --check`

I did not run full `npm run validate`; this is a test-only change scoped to the five files from #1396.