### PR TITLE
fix: log dropped fetch body updates

### DIFF
--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -1133,7 +1133,7 @@ function App() {
       fetchRequestLogState?.destroy();
       stderrLogState?.destroy();
 
-      const { environment } = createWebEnvironment(
+      const { environment, logger } = createWebEnvironment(
         getAuthToken(),
         redirectUrlProvider,
         onBeforeOAuthRedirect,
@@ -1221,6 +1221,7 @@ function App() {
       // reads the current log.
       const nextFetchLog = new FetchRequestLogState(client, {
         sessionStorage: sessionStorageAdapter,
+        logger,
         ...(sessionId && { sessionId }),
       });
       fetchLogRef.current = nextFetchLog;

--- a/clients/web/src/test/core/mcp/state/fetchRequestLogState.test.ts
+++ b/clients/web/src/test/core/mcp/state/fetchRequestLogState.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type pino from "pino";
 import type { FetchRequestEntry } from "@inspector/core/mcp/types";
 import { FetchRequestLogState } from "@inspector/core/mcp/state/fetchRequestLogState";
 import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
@@ -121,6 +122,9 @@ describe("FetchRequestLogState", () => {
   });
 
   it("ignores fetchRequestBodyUpdate for unknown ids", () => {
+    const logger = { debug: vi.fn() } as unknown as pino.Logger;
+    state.destroy();
+    state = new FetchRequestLogState(client, { logger });
     client.dispatchTypedEvent("fetchRequest", entry("a"));
     let changes = 0;
     state.addEventListener("fetchRequestsChange", () => changes++);
@@ -129,6 +133,14 @@ describe("FetchRequestLogState", () => {
       responseBody: "x",
     });
     expect(changes).toBe(0);
+    expect(logger.debug).toHaveBeenCalledWith(
+      {
+        id: "nonexistent",
+        storedFetchRequestCount: 1,
+        maxFetchRequests: 1000,
+      },
+      "Dropped fetch request body update because request entry is no longer in log",
+    );
   });
 
   it("does NOT clear on connect or disconnect", () => {

--- a/core/mcp/state/fetchRequestLogState.ts
+++ b/core/mcp/state/fetchRequestLogState.ts
@@ -14,6 +14,7 @@
  */
 
 import type { InspectorClientProtocol } from "../inspectorClientProtocol.js";
+import type pino from "pino";
 import type { FetchRequestEntry } from "../types.js";
 import type {
   InspectorClientStorage,
@@ -24,6 +25,7 @@ import {
   TypedEventTarget,
   type TypedEventGeneric,
 } from "../typedEventTarget.js";
+import { silentLogger } from "../../logging/logger.js";
 
 export interface FetchRequestLogStateEventMap {
   fetchRequest: FetchRequestEntry;
@@ -44,6 +46,8 @@ export interface FetchRequestLogStateOptions {
   sessionStorage?: InspectorClientStorage;
   /** Session ID for load/save; required for sessionStorage to have effect. */
   sessionId?: string;
+  /** Logger used for diagnostic events that do not affect UI state. */
+  logger?: pino.Logger;
 }
 
 export class FetchRequestLogState extends TypedEventTarget<FetchRequestLogStateEventMap> {
@@ -51,6 +55,7 @@ export class FetchRequestLogState extends TypedEventTarget<FetchRequestLogStateE
   private client: InspectorClientProtocol | null = null;
   private unsubscribe: (() => void) | null = null;
   private readonly maxFetchRequests: number;
+  private readonly logger: pino.Logger;
 
   constructor(
     client: InspectorClientProtocol,
@@ -58,6 +63,7 @@ export class FetchRequestLogState extends TypedEventTarget<FetchRequestLogStateE
   ) {
     super();
     this.maxFetchRequests = options.maxFetchRequests ?? 1000;
+    this.logger = options.logger ?? silentLogger;
     this.client = client;
 
     const onFetchRequest = (
@@ -87,7 +93,17 @@ export class FetchRequestLogState extends TypedEventTarget<FetchRequestLogStateE
     ): void => {
       const { id, responseBody } = event.detail;
       const idx = this.fetchRequests.findIndex((e) => e.id === id);
-      if (idx === -1) return;
+      if (idx === -1) {
+        this.logger.debug(
+          {
+            id,
+            storedFetchRequestCount: this.fetchRequests.length,
+            maxFetchRequests: this.maxFetchRequests,
+          },
+          "Dropped fetch request body update because request entry is no longer in log",
+        );
+        return;
+      }
       this.fetchRequests[idx] = {
         ...this.fetchRequests[idx]!,
         responseBody,
@@ -192,9 +208,7 @@ export class FetchRequestLogState extends TypedEventTarget<FetchRequestLogStateE
     if (restored.length === 0) return;
     const merged = [...restored, ...this.fetchRequests];
     this.fetchRequests =
-      this.maxFetchRequests > 0
-        ? merged.slice(-this.maxFetchRequests)
-        : merged;
+      this.maxFetchRequests > 0 ? merged.slice(-this.maxFetchRequests) : merged;
     this.dispatchTypedEvent("fetchRequestsChange", this.getFetchRequests());
   }
 


### PR DESCRIPTION
## Summary
- add an optional logger to `FetchRequestLogState`, defaulting to the existing silent logger
- emit a debug log when `fetchRequestBodyUpdate` arrives after its request entry has already left the bounded log
- pass the web app remote logger into `FetchRequestLogState` so the diagnostic reaches the existing logging pipeline

Fixes #1390.

## Validation
- `cd clients/web && npm test -- src/test/core/mcp/state/fetchRequestLogState.test.ts`
- `./clients/web/node_modules/.bin/prettier --check core/mcp/state/fetchRequestLogState.ts clients/web/src/App.tsx clients/web/src/test/core/mcp/state/fetchRequestLogState.test.ts`
- `./clients/web/node_modules/.bin/eslint --config clients/web/eslint.config.js core/mcp/state/fetchRequestLogState.ts clients/web/src/App.tsx clients/web/src/test/core/mcp/state/fetchRequestLogState.test.ts`
- `git diff --check`