### PR TITLE
fix(web): style Resources accordion native scrollbars to match Mantine (#1466)

### DIFF
--- a/clients/web/src/App.css
+++ b/clients/web/src/App.css
@@ -36,6 +36,11 @@
   --inspector-border-default: var(--mantine-color-default-border);
   --inspector-border-subtle: var(--mantine-color-gray-3);
 
+  /* ── Scrollbar ─────────────────────────────────────────── */
+  /* Matches Mantine ScrollArea's thumb so native scrollbars (used where a
+     ScrollArea would break flex sizing, e.g. the Resources accordion) blend in. */
+  --inspector-scrollbar-thumb: rgba(0, 0, 0, 0.4);
+
   /* ── Connection status ─────────────────────────────────── */
   --inspector-status-connected: var(--mantine-color-green-6);
   --inspector-status-connecting: var(--mantine-color-yellow-6);
@@ -73,6 +78,7 @@
   --inspector-surface-code: var(--mantine-color-dark-9);
   --inspector-border-subtle: var(--mantine-color-gray-4);
   --inspector-input-background: var(--mantine-color-dark-9);
+  --inspector-scrollbar-thumb: rgba(255, 255, 255, 0.4);
 }
 
 /* ── Animations ──────────────────────────────────────────── */
@@ -212,7 +218,13 @@
  * (set in ResourceControls) hands space from long sections to short ones. With
  * `flex-grow: 0`, nothing expands or scrolls until the combined content
  * overflows the panel, so sections never scroll while the panel has free space
- * (issue #1462). Closed sections collapse to their header height. */
+ * (issue #1462). Closed sections collapse to their header height.
+ *
+ * The per-section scroll uses a NATIVE scrollbar, styled below to match
+ * Mantine's ScrollArea thumb (#1466). A Mantine `ScrollArea` component can't be
+ * used here: its viewport has no intrinsic height, which would collapse the
+ * panel's content-based `flex-basis` that the per-section sizing above depends
+ * on, so the sections would no longer size to their content. */
 
 .disclosure-sections {
   display: flex;
@@ -236,6 +248,27 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--inspector-scrollbar-thumb) transparent;
+}
+
+.disclosure-sections
+  > .mantine-Accordion-item[data-active]
+  .mantine-Accordion-panel::-webkit-scrollbar {
+  width: 8px;
+}
+
+.disclosure-sections
+  > .mantine-Accordion-item[data-active]
+  .mantine-Accordion-panel::-webkit-scrollbar-thumb {
+  background-color: var(--inspector-scrollbar-thumb);
+  border-radius: 8px;
+}
+
+.disclosure-sections
+  > .mantine-Accordion-item[data-active]
+  .mantine-Accordion-panel::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 /* ── List item hover ────────────────────────────────────── */

--- a/clients/web/src/components/screens/ResourcesScreen/ResourcesScreen.stories.tsx
+++ b/clients/web/src/components/screens/ResourcesScreen/ResourcesScreen.stories.tsx
@@ -256,7 +256,8 @@ export const ManyResources: Story = {
     expect(tops[0]).toBeLessThan(tops[1]);
     expect(tops[1]).toBeLessThan(tops[2]);
 
-    // The long URIs section scrolls within its own panel.
+    // The long URIs section scrolls within its own panel, with a thin styled
+    // scrollbar matching the Mantine ScrollArea look (#1466).
     const urisPanel = canvasElement.querySelector(
       ".disclosure-sections .mantine-Accordion-panel",
     );
@@ -264,6 +265,7 @@ export const ManyResources: Story = {
       throw new Error("URIs panel not found");
     }
     expect(urisPanel.scrollHeight).toBeGreaterThan(urisPanel.clientHeight);
+    expect(getComputedStyle(urisPanel).scrollbarWidth).toBe("thin");
   },
 };
 

--- a/clients/web/src/components/screens/ResourcesScreen/ResourcesScreen.stories.tsx
+++ b/clients/web/src/components/screens/ResourcesScreen/ResourcesScreen.stories.tsx
@@ -265,7 +265,12 @@ export const ManyResources: Story = {
       throw new Error("URIs panel not found");
     }
     expect(urisPanel.scrollHeight).toBeGreaterThan(urisPanel.clientHeight);
-    expect(getComputedStyle(urisPanel).scrollbarWidth).toBe("thin");
+    const panelStyle = getComputedStyle(urisPanel);
+    expect(panelStyle.scrollbarWidth).toBe("thin");
+    // The themed translucent thumb resolves (the `--inspector-scrollbar-thumb`
+    // token, an rgba value, vs. a transparent track). WebKit pseudo-element
+    // styles aren't queryable, so `scrollbar-color` is the assertable proxy.
+    expect(panelStyle.scrollbarColor).toContain("rgba");
   },
 };
 


### PR DESCRIPTION
Closes #1466

## Background

In #1462, the Resources controls accordion was reworked so each open section's panel scrolls within its own (item-count-weighted) share of the height, with pinned headers. That per-section scroll used a **native** scrollbar, which looked inconsistent with the Mantine `ScrollArea` used elsewhere in the app.

## Finding: a Mantine `ScrollArea` component can't be used here

The issue originally proposed wrapping each panel in a Mantine `ScrollArea`. I confirmed in a real browser that this **breaks** #1462:

- The per-section sizing relies on each panel's `flex-basis: auto` measuring its **full content height** (so a long section yields space to short ones, and nothing scrolls until the panel is full).
- A Mantine `ScrollArea` viewport has **no intrinsic height** — it collapses the panel's content-based basis to ~0, so the sections stop sizing to their content (panels would show no items, or the distribution degrades).

So the correct way to "match the Mantine scrollbar style" while preserving #1462 is to **style the native scrollbar**, not swap in the component. This is documented inline in `App.css`.

## Change

- New `--inspector-scrollbar-thumb` token: `rgba(0,0,0,.4)` (light) / `rgba(255,255,255,.4)` (dark) — mirroring Mantine ScrollArea's thumb color.
- Style the accordion panel scrollbar: `scrollbar-width: thin` + `scrollbar-color` (Firefox) and `::-webkit-scrollbar` / `-thumb` / `-track` rules (Chromium/WebKit) — thin, rounded, translucent thumb on a transparent track.

## Verification (real browser, Playwright)

- Scrollbar: `scrollbar-width: thin`, `scrollbar-color` resolves to the themed thumb in both light and dark.
- #1462 preserved: item heights still distribute by count (550/223/49 for 40+3+0), headers pinned in order, URIs scrolls within its own panel.

## Tests

- `ResourcesScreen` `ManyResources` story now also asserts `scrollbar-width: thin` on the scrolling panel (real Chromium).
- `npm run validate` ✅ · `npm run test:storybook` ✅ (357).

> Note: on macOS the native scrollbar is an overlay (fades when idle), matching Mantine's hover behavior; on Windows/Linux it shows as a persistent thin themed bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)