### PR TITLE
fix(web): give History/Network/Logging list scrollbars a gutter, hide when idle (#1474)

### DIFF
--- a/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.stories.tsx
+++ b/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { MessageEntry } from "../../../../../../core/mcp/types.js";
-import { expect, fn } from "storybook/test";
+import { fn } from "storybook/test";
 import { HistoryListPanel } from "./HistoryListPanel.js";
+import { expectScrollbarGutterIdleHidden } from "../../../test/scrollAreaStoryAssertions";
 
 const meta: Meta<typeof HistoryListPanel> = {
   title: "Groups/HistoryListPanel",
@@ -106,22 +107,7 @@ export const WithEntries: Story = {
   // bar never overlays the cards, and uses type="scroll" so it stays hidden
   // when idle rather than appearing on hover (#1474).
   play: async ({ canvasElement }) => {
-    const viewport = canvasElement.querySelector(
-      ".mantine-ScrollArea-viewport",
-    );
-    if (!(viewport instanceof HTMLElement)) {
-      throw new Error("scroll viewport not found");
-    }
-    // offsetScrollbars reserves a non-zero inline-end gutter for the scrollbar.
-    const pad = parseFloat(getComputedStyle(viewport).paddingInlineEnd);
-    expect(pad).toBeGreaterThan(0);
-    // type="scroll" → scrollbars are hidden until the user scrolls.
-    const scrollbars = canvasElement.querySelectorAll(
-      ".mantine-ScrollArea-scrollbar",
-    );
-    for (const bar of scrollbars) {
-      expect(bar.getAttribute("data-state")).toBe("hidden");
-    }
+    expectScrollbarGutterIdleHidden(canvasElement);
   },
 };
 

--- a/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.stories.tsx
+++ b/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { MessageEntry } from "../../../../../../core/mcp/types.js";
-import { fn } from "storybook/test";
+import { expect, fn } from "storybook/test";
 import { HistoryListPanel } from "./HistoryListPanel.js";
 
 const meta: Meta<typeof HistoryListPanel> = {
@@ -101,6 +101,27 @@ export const WithEntries: Story = {
   args: {
     entries: sampleEntries,
     pinnedIds: new Set(["req-4"]),
+  },
+  // The list ScrollArea reserves a scrollbar gutter (offsetScrollbars) so the
+  // bar never overlays the cards, and uses type="scroll" so it stays hidden
+  // when idle rather than appearing on hover (#1474).
+  play: async ({ canvasElement }) => {
+    const viewport = canvasElement.querySelector(
+      ".mantine-ScrollArea-viewport",
+    );
+    if (!(viewport instanceof HTMLElement)) {
+      throw new Error("scroll viewport not found");
+    }
+    // offsetScrollbars reserves a non-zero inline-end gutter for the scrollbar.
+    const pad = parseFloat(getComputedStyle(viewport).paddingInlineEnd);
+    expect(pad).toBeGreaterThan(0);
+    // type="scroll" → scrollbars are hidden until the user scrolls.
+    const scrollbars = canvasElement.querySelectorAll(
+      ".mantine-ScrollArea-scrollbar",
+    );
+    for (const bar of scrollbars) {
+      expect(bar.getAttribute("data-state")).toBe("hidden");
+    }
   },
 };
 

--- a/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
+++ b/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
@@ -264,6 +264,8 @@ export function HistoryListPanel({
         <ScrollArea.Autosize
           viewportRef={viewportRef}
           mah="calc(100vh - var(--app-shell-header-height, 0px) - 150px)"
+          type="scroll"
+          offsetScrollbars
         >
           <Stack gap="md">
             {pinnedEntries.length > 0 && (

--- a/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.stories.tsx
+++ b/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.stories.tsx
@@ -3,6 +3,7 @@ import type { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
 import { fn } from "storybook/test";
 import { LogStreamPanel } from "./LogStreamPanel";
 import type { LogEntryData } from "../../elements/LogEntry/LogEntry";
+import { expectScrollbarGutterIdleHidden } from "../../../test/scrollAreaStoryAssertions";
 
 const meta: Meta<typeof LogStreamPanel> = {
   title: "Groups/LogStreamPanel",
@@ -73,5 +74,9 @@ const entries: LogEntryData[] = Array.from({ length: 30 }, (_, i) => {
 export const WithEntries: Story = {
   args: {
     entries,
+  },
+  // List scrollbar reserves a gutter and stays hidden when idle (#1474).
+  play: async ({ canvasElement }) => {
+    expectScrollbarGutterIdleHidden(canvasElement);
   },
 };

--- a/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
+++ b/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
@@ -110,6 +110,8 @@ export function LogStreamPanel({
         <ScrollArea.Autosize
           viewportRef={viewportRef}
           mah="calc(100vh - var(--app-shell-header-height, 0px) - 150px)"
+          type="scroll"
+          offsetScrollbars
         >
           <Stack gap="xs">
             {filteredEntries.map((entry, index) => (

--- a/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.stories.tsx
+++ b/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 import type { FetchRequestEntry } from "../../../../../../core/mcp/types.js";
 import { NetworkStreamPanel } from "./NetworkStreamPanel";
+import { expectScrollbarGutterIdleHidden } from "../../../test/scrollAreaStoryAssertions";
 
 const meta: Meta<typeof NetworkStreamPanel> = {
   title: "Groups/NetworkStreamPanel",
@@ -47,6 +48,10 @@ const sample: FetchRequestEntry[] = [
 
 export const WithEntries: Story = {
   args: { entries: sample },
+  // List scrollbar reserves a gutter and stays hidden when idle (#1474).
+  play: async ({ canvasElement }) => {
+    expectScrollbarGutterIdleHidden(canvasElement);
+  },
 };
 
 export const Empty: Story = {

--- a/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
+++ b/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
@@ -137,6 +137,8 @@ export function NetworkStreamPanel({
         <ScrollArea.Autosize
           viewportRef={viewportRef}
           mah="calc(100vh - var(--app-shell-header-height, 0px) - 150px)"
+          type="scroll"
+          offsetScrollbars
         >
           <Stack gap="md">
             {filteredEntries.map((entry) => (

--- a/clients/web/src/test/scrollAreaStoryAssertions.ts
+++ b/clients/web/src/test/scrollAreaStoryAssertions.ts
@@ -14,10 +14,13 @@ export function expectScrollbarGutterIdleHidden(canvasElement: HTMLElement) {
   // offsetScrollbars reserves a non-zero inline-end gutter for the scrollbar.
   const pad = parseFloat(getComputedStyle(viewport).paddingInlineEnd);
   expect(pad).toBeGreaterThan(0);
-  // type="scroll" → scrollbars are hidden until the user scrolls.
+  // type="scroll" → scrollbars are mounted but hidden until the user scrolls.
+  // Assert at least one exists first so the loop isn't trivially-true if a
+  // future change stops rendering the scrollbar element.
   const scrollbars = canvasElement.querySelectorAll(
     ".mantine-ScrollArea-scrollbar",
   );
+  expect(scrollbars.length).toBeGreaterThan(0);
   for (const bar of scrollbars) {
     expect(bar.getAttribute("data-state")).toBe("hidden");
   }

--- a/clients/web/src/test/scrollAreaStoryAssertions.ts
+++ b/clients/web/src/test/scrollAreaStoryAssertions.ts
@@ -1,0 +1,24 @@
+import { expect } from "storybook/test";
+
+/**
+ * Assert a list `ScrollArea.Autosize` reserves a scrollbar gutter
+ * (`offsetScrollbars`, so the bar never overlays the cards) and keeps the bar
+ * hidden when idle (`type="scroll"`, so it shows only while scrolling rather
+ * than on hover). Shared by the History/Network/Logging panel stories (#1474).
+ */
+export function expectScrollbarGutterIdleHidden(canvasElement: HTMLElement) {
+  const viewport = canvasElement.querySelector(".mantine-ScrollArea-viewport");
+  if (!(viewport instanceof HTMLElement)) {
+    throw new Error("scroll viewport not found");
+  }
+  // offsetScrollbars reserves a non-zero inline-end gutter for the scrollbar.
+  const pad = parseFloat(getComputedStyle(viewport).paddingInlineEnd);
+  expect(pad).toBeGreaterThan(0);
+  // type="scroll" → scrollbars are hidden until the user scrolls.
+  const scrollbars = canvasElement.querySelectorAll(
+    ".mantine-ScrollArea-scrollbar",
+  );
+  for (const bar of scrollbars) {
+    expect(bar.getAttribute("data-state")).toBe("hidden");
+  }
+}


### PR DESCRIPTION
Closes #1474

## Problem

The main-content list panels — **Requests/History**, **Network**, and **Logging** — rendered their list inside a Mantine `ScrollArea.Autosize` with the **default `type="hover"`** and **no `offsetScrollbars`**, so the scrollbar (a) popped in on hover and (b) overlaid the right edge of the cards, occluding the action icons / status badges.

## Change

Added two props to the `ScrollArea.Autosize` in `HistoryListPanel`, `NetworkStreamPanel`, and `LogStreamPanel`:
- **`offsetScrollbars`** — reserves a ~12px gutter so the scrollbar sits in its own space and never overlaps the cards.
- **`type="scroll"`** — the bar appears only during active scrolling, then fades (no hover-pop).

## Verification (real browser, Playwright)

- Viewport now has `padding-inline-end: 12px` (the reserved gutter) → cards no longer occluded.
- Scrollbars are `data-state="hidden"` / `display: none` when idle → no hover-pop; they show on scroll.

## Tests

- `HistoryListPanel` `WithEntries` story now asserts the reserved gutter (`paddingInlineEnd > 0`) and the idle-hidden scrollbar state (real Chromium).
- `npm run validate` ✅ · `npm run test:storybook` ✅ (357).

## Notes

Scoped to the three main-content stream panels flagged. Sidebar control lists (Tools/Prompts/Resources) are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)