### PR TITLE
fix(client): preserve Request options in proxy fetch

### DIFF
--- a/client/src/lib/__tests__/proxyFetch.test.ts
+++ b/client/src/lib/__tests__/proxyFetch.test.ts
@@ -241,4 +241,87 @@ describe("createProxyFetch", () => {
     const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(callBody.url).toBe("https://example.com/from-request");
   });
+
+  it("preserves method, headers, and body from Request input", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: "",
+        }),
+    });
+
+    const fetchFn = createProxyFetch(configWithProxy);
+    await fetchFn(
+      new Request("https://example.com/oauth/token", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "X-Test": "1",
+        },
+        body: "grant_type=authorization_code&code=abc",
+      }),
+    );
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(callBody).toEqual({
+      url: "https://example.com/oauth/token",
+      init: {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "x-test": "1",
+        },
+        body: "grant_type=authorization_code&code=abc",
+      },
+    });
+  });
+
+  it("lets explicit init override Request defaults", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: "",
+        }),
+    });
+
+    const fetchFn = createProxyFetch(configWithProxy);
+    await fetchFn(
+      new Request("https://example.com/oauth/token", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "X-Request": "request",
+        },
+        body: "from=request",
+      }),
+      {
+        method: "PUT",
+        headers: { "X-Init": "init" },
+        body: "from=init",
+      },
+    );
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(callBody).toEqual({
+      url: "https://example.com/oauth/token",
+      init: {
+        method: "PUT",
+        headers: {
+          "content-type": "text/plain;charset=UTF-8",
+          "x-init": "init",
+        },
+        body: "from=init",
+      },
+    });
+  });
 });

--- a/client/src/lib/proxyFetch.ts
+++ b/client/src/lib/proxyFetch.ts
@@ -92,25 +92,10 @@ export function createProxyFetch(config: InspectorConfig): typeof fetch {
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> => {
-    const url =
-      typeof input === "string"
-        ? input
-        : input instanceof Request
-          ? input.url
-          : input.toString();
-
-    // Serialize body for JSON transport. URLSearchParams and similar don't
-    // JSON-serialize (they become {}), so we must convert to string first.
-    let serializedBody: string | undefined;
-    if (init?.body != null) {
-      if (typeof init.body === "string") {
-        serializedBody = init.body;
-      } else if (init.body instanceof URLSearchParams) {
-        serializedBody = init.body.toString();
-      } else {
-        serializedBody = String(init.body);
-      }
-    }
+    const request = new Request(input, init);
+    const serializedBody = request.body
+      ? await request.clone().text()
+      : undefined;
 
     const proxyResponse = await fetch(`${proxyAddress}/fetch`, {
       method: "POST",
@@ -119,12 +104,10 @@ export function createProxyFetch(config: InspectorConfig): typeof fetch {
         [header]: `Bearer ${token}`,
       },
       body: JSON.stringify({
-        url,
+        url: request.url,
         init: {
-          method: init?.method,
-          headers: init?.headers
-            ? Object.fromEntries(new Headers(init.headers))
-            : undefined,
+          method: request.method,
+          headers: Object.fromEntries(request.headers),
           body: serializedBody,
         },
       }),


### PR DESCRIPTION
## Summary
- Normalize proxy fetch inputs with `new Request(input, init)` before serializing them for `/fetch`
- Preserve `Request` method, headers, and body instead of forwarding only `Request.url`
- Add regression coverage for `Request` inputs and explicit `init` overrides

Closes #1207.

## Validation
- `git diff --check`
- `/home/ubuntu/modelcontextprotocol-inspector/clients/web/node_modules/.bin/prettier --check client/src/lib/proxyFetch.ts client/src/lib/__tests__/proxyFetch.test.ts`
- Manual Node 24 check that `new Request()` preserves POST method, lower-cased headers, and text body for the reported Request-input case

I attempted the focused Jest command `npm test -- --runTestsByPath src/lib/__tests__/proxyFetch.test.ts --runInBand`, but this fresh worktree did not have `jest` installed. A scoped `npm ci --workspace=client --include-workspace-root=false --ignore-scripts` then failed on registry download with `ECONNRESET` for `xml-name-validator-4.0.0.tgz`, so I did not keep retrying registry downloads.