### PR TITLE
fix(web): section-header hover outline + clear buttons out of tab order (#1487)

### DIFF
--- a/clients/web/src/App.css
+++ b/clients/web/src/App.css
@@ -283,14 +283,15 @@
 
 /* ── Filter toggle buttons (Logging / History / Network) ─────────
  *
- * Shared by the FilterToggleButton element. Unlike `.list-item`, hover is a
- * thin border rather than a background fill, and the active (on) state is the
- * filled background. Keeping the two states distinct means toggling a button
- * off while the cursor is still over it is immediately visible, instead of the
- * hover background masking the removal of the active background (issue #1460).
- * The 1px transparent border is reserved here (not as an inline style in the
- * theme variant — inline styles outrank stylesheet `:hover` rules) so the hover
- * border doesn't shift layout. */
+ * Shared by the FilterToggleButton element and the History list's collapsible
+ * section headers (the `sectionHeader` Group variant). Unlike `.list-item`,
+ * hover is a thin border rather than a background fill, and the active (on)
+ * state is the filled background. Keeping the two states distinct means
+ * toggling a button off while the cursor is still over it is immediately
+ * visible, instead of the hover background masking the removal of the active
+ * background (issue #1460). The 1px transparent border is reserved here (not as
+ * an inline style in the theme variant — inline styles outrank stylesheet
+ * `:hover` rules) so the hover border doesn't shift layout. */
 
 .filter-toggle {
   border: 1px solid transparent;

--- a/clients/web/src/App.css
+++ b/clients/web/src/App.css
@@ -283,8 +283,11 @@
 
 /* ── Filter toggle buttons (Logging / History / Network) ─────────
  *
- * Shared by the FilterToggleButton element and the History list's collapsible
- * section headers (the `sectionHeader` Group variant). Unlike `.list-item`,
+ * Shared by the FilterToggleButton element, the History list's collapsible
+ * section headers (the `sectionHeader` Group variant), and the Resources
+ * disclosure accordion controls (the `disclosure` Accordion variant). The
+ * active (on / open) state is keyed off `aria-pressed` for the toggle buttons
+ * and `aria-expanded` for the accordion controls. Unlike `.list-item`,
  * hover is a thin border rather than a background fill, and the active (on)
  * state is the filled background. Keeping the two states distinct means
  * toggling a button off while the cursor is still over it is immediately
@@ -302,7 +305,8 @@
   border-color: var(--inspector-brand-primary);
 }
 
-.filter-toggle[aria-pressed="true"] {
+.filter-toggle[aria-pressed="true"],
+.filter-toggle[aria-expanded="true"] {
   background-color: var(--mantine-primary-color-light);
 }
 
@@ -343,7 +347,11 @@
 
 /* ── Accordion button hover ─────────────────────────────── */
 
-.mantine-Accordion-control:hover {
+/* Default accordions (e.g. Server Settings) keep the background-fill hover.
+ * The Resources `disclosure` accordion opts out via `.filter-toggle` (added to
+ * its control slot in theme/Accordion.ts) so it gets the outline-on-hover
+ * treatment instead — see the `.filter-toggle` rules above. */
+.mantine-Accordion-control:not(.filter-toggle):hover {
   background-color: var(--mantine-primary-color-light-hover);
 }
 

--- a/clients/web/src/components/elements/ClearButton/ClearButton.stories.tsx
+++ b/clients/web/src/components/elements/ClearButton/ClearButton.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+import { ClearButton } from "./ClearButton";
+
+const meta: Meta<typeof ClearButton> = {
+  title: "Elements/ClearButton",
+  component: ClearButton,
+};
+
+export default meta;
+type Story = StoryObj<typeof ClearButton>;
+
+// Default: labelled "Clear", out of the tab order, but still mouse-clickable.
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = await canvas.findByRole("button", { name: "Clear" });
+    await expect(button).toHaveAttribute("tabindex", "-1");
+    await userEvent.click(button);
+  },
+};

--- a/clients/web/src/components/elements/ClearButton/ClearButton.test.tsx
+++ b/clients/web/src/components/elements/ClearButton/ClearButton.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { ClearButton } from "./ClearButton";
+
+describe("ClearButton", () => {
+  it('renders with the "Clear" accessible name', () => {
+    renderWithMantine(<ClearButton />);
+    expect(screen.getByRole("button", { name: "Clear" })).toBeInTheDocument();
+  });
+
+  it("is removed from the keyboard tab order", () => {
+    renderWithMantine(<ClearButton />);
+    expect(screen.getByRole("button", { name: "Clear" })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+  });
+
+  it("invokes onClick when clicked", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    renderWithMantine(<ClearButton onClick={onClick} />);
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows the accessible name to be overridden", () => {
+    renderWithMantine(<ClearButton aria-label="Clear search" />);
+    expect(
+      screen.getByRole("button", { name: "Clear search" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/clients/web/src/components/elements/ClearButton/ClearButton.tsx
+++ b/clients/web/src/components/elements/ClearButton/ClearButton.tsx
@@ -1,0 +1,14 @@
+import { CloseButton } from "@mantine/core";
+
+/**
+ * The clear (×) affordance shown in a populated text input's right section
+ * (`rightSection`). Wraps Mantine's `CloseButton` with a fixed
+ * `aria-label="Clear"` and `tabIndex={-1}`, so the button stays mouse-clickable
+ * but is skipped during keyboard tab navigation — tabbing through a form lands
+ * on the next field, not on the clear button (see #1487). Pass `onClick` to
+ * reset the field's value to "". Both presets can still be overridden per-site.
+ */
+export const ClearButton = CloseButton.withProps({
+  "aria-label": "Clear",
+  tabIndex: -1,
+});

--- a/clients/web/src/components/groups/AppControls/AppControls.tsx
+++ b/clients/web/src/components/groups/AppControls/AppControls.tsx
@@ -1,5 +1,4 @@
 import {
-  CloseButton,
   Group,
   ScrollArea,
   Stack,
@@ -7,6 +6,7 @@ import {
   TextInput,
   Title,
 } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { ListChangedIndicator } from "../../elements/ListChangedIndicator/ListChangedIndicator";
 import { AppListItem } from "../AppListItem/AppListItem";
@@ -64,13 +64,7 @@ export function AppControls({
         onChange={(e) => onSearchChange(e.currentTarget.value)}
         rightSectionPointerEvents="auto"
         rightSection={
-          searchText ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
-              onClick={() => onSearchChange("")}
-            />
-          ) : null
+          searchText ? <ClearButton onClick={() => onSearchChange("")} /> : null
         }
       />
       <ScrollArea.Autosize viewportRef={viewportRef} mah={LIST_MAX_HEIGHT}>

--- a/clients/web/src/components/groups/AppControls/AppControls.tsx
+++ b/clients/web/src/components/groups/AppControls/AppControls.tsx
@@ -67,6 +67,7 @@ export function AppControls({
           searchText ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() => onSearchChange("")}
             />
           ) : null

--- a/clients/web/src/components/groups/ExperimentalFeaturesPanel/ExperimentalFeaturesPanel.tsx
+++ b/clients/web/src/components/groups/ExperimentalFeaturesPanel/ExperimentalFeaturesPanel.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   Card,
   Checkbox,
-  CloseButton,
   Divider,
   Group,
   Stack,
@@ -15,6 +14,7 @@ import {
   Textarea,
   Title,
 } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type {
   ClientCapabilities,
   JSONRPCErrorResponse,
@@ -248,9 +248,7 @@ export function ExperimentalFeaturesPanel({
             rightSectionPointerEvents="auto"
             rightSection={
               header.key ? (
-                <CloseButton
-                  aria-label="Clear"
-                  tabIndex={-1}
+                <ClearButton
                   onClick={() => onHeaderChange(index, "", header.value)}
                 />
               ) : null
@@ -265,9 +263,7 @@ export function ExperimentalFeaturesPanel({
             rightSectionPointerEvents="auto"
             rightSection={
               header.value ? (
-                <CloseButton
-                  aria-label="Clear"
-                  tabIndex={-1}
+                <ClearButton
                   onClick={() => onHeaderChange(index, header.key, "")}
                 />
               ) : null
@@ -293,11 +289,7 @@ export function ExperimentalFeaturesPanel({
         rightSectionPointerEvents="auto"
         rightSection={
           requestDraft ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
-              onClick={() => onRequestChange("")}
-            />
+            <ClearButton onClick={() => onRequestChange("")} />
           ) : null
         }
       />

--- a/clients/web/src/components/groups/ExperimentalFeaturesPanel/ExperimentalFeaturesPanel.tsx
+++ b/clients/web/src/components/groups/ExperimentalFeaturesPanel/ExperimentalFeaturesPanel.tsx
@@ -250,6 +250,7 @@ export function ExperimentalFeaturesPanel({
               header.key ? (
                 <CloseButton
                   aria-label="Clear"
+                  tabIndex={-1}
                   onClick={() => onHeaderChange(index, "", header.value)}
                 />
               ) : null
@@ -266,6 +267,7 @@ export function ExperimentalFeaturesPanel({
               header.value ? (
                 <CloseButton
                   aria-label="Clear"
+                  tabIndex={-1}
                   onClick={() => onHeaderChange(index, header.key, "")}
                 />
               ) : null
@@ -293,6 +295,7 @@ export function ExperimentalFeaturesPanel({
           requestDraft ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() => onRequestChange("")}
             />
           ) : null

--- a/clients/web/src/components/groups/HistoryControls/HistoryControls.test.tsx
+++ b/clients/web/src/components/groups/HistoryControls/HistoryControls.test.tsx
@@ -45,6 +45,14 @@ describe("HistoryControls", () => {
     expect(onSearchChange).toHaveBeenCalledWith("");
   });
 
+  it("keeps the search Clear button out of the keyboard tab order", () => {
+    renderWithMantine(<HistoryControls {...baseProps} searchText="abc" />);
+    expect(screen.getByRole("button", { name: "Clear" })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+  });
+
   it("renders the method filter placeholder", () => {
     renderWithMantine(<HistoryControls {...baseProps} />);
     expect(screen.getByPlaceholderText("All methods")).toBeInTheDocument();

--- a/clients/web/src/components/groups/HistoryControls/HistoryControls.tsx
+++ b/clients/web/src/components/groups/HistoryControls/HistoryControls.tsx
@@ -1,4 +1,5 @@
-import { CloseButton, Select, Stack, TextInput, Title } from "@mantine/core";
+import { Select, Stack, TextInput, Title } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type {
   MessageMethod,
   MessageOrigin,
@@ -35,13 +36,7 @@ export function HistoryControls({
         onChange={(event) => onSearchChange(event.currentTarget.value)}
         rightSectionPointerEvents="auto"
         rightSection={
-          searchText ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
-              onClick={() => onSearchChange("")}
-            />
-          ) : null
+          searchText ? <ClearButton onClick={() => onSearchChange("")} /> : null
         }
       />
 

--- a/clients/web/src/components/groups/HistoryControls/HistoryControls.tsx
+++ b/clients/web/src/components/groups/HistoryControls/HistoryControls.tsx
@@ -38,6 +38,7 @@ export function HistoryControls({
           searchText ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() => onSearchChange("")}
             />
           ) : null

--- a/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
+++ b/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
@@ -58,8 +58,9 @@ const EmptyState = Text.withProps({
   py: "xl",
 });
 
-// The section header is a single "pleat" bar (rounded, hover-highlighted, with
-// the active background passed per instance via `bg`). Inside it sit the
+// The section header is a single "pleat" bar (rounded, with the filter-button
+// outline-on-hover treatment and the active background passed per instance via
+// `bg`). Inside it sit the
 // clickable toggle area (the title, filling the left) and the optional
 // Clear/Export actions on the right — so the actions live on the pleat itself,
 // not beside it. The toggle is its own button (the actions can't nest inside a

--- a/clients/web/src/components/groups/ImportServerJsonPanel/ImportServerJsonPanel.tsx
+++ b/clients/web/src/components/groups/ImportServerJsonPanel/ImportServerJsonPanel.tsx
@@ -92,7 +92,11 @@ export function ImportServerJsonPanel({
         rightSectionPointerEvents="auto"
         rightSection={
           draft.rawText ? (
-            <CloseButton aria-label="Clear" onClick={() => onJsonChange("")} />
+            <CloseButton
+              aria-label="Clear"
+              tabIndex={-1}
+              onClick={() => onJsonChange("")}
+            />
           ) : null
         }
       />
@@ -151,6 +155,7 @@ export function ImportServerJsonPanel({
                 envVar.value ? (
                   <CloseButton
                     aria-label="Clear"
+                    tabIndex={-1}
                     onClick={() => onEnvVarChange(envVar.name, "")}
                   />
                 ) : null
@@ -171,6 +176,7 @@ export function ImportServerJsonPanel({
           draft.nameOverride ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() => onServerNameChange("")}
             />
           ) : null

--- a/clients/web/src/components/groups/ImportServerJsonPanel/ImportServerJsonPanel.tsx
+++ b/clients/web/src/components/groups/ImportServerJsonPanel/ImportServerJsonPanel.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  CloseButton,
   Divider,
   Group,
   Radio,
@@ -10,6 +9,7 @@ import {
   Textarea,
   Title,
 } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { InspectorServerJsonDraft } from "@inspector/core/mcp/types.js";
 
 export interface ValidationResult {
@@ -92,11 +92,7 @@ export function ImportServerJsonPanel({
         rightSectionPointerEvents="auto"
         rightSection={
           draft.rawText ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
-              onClick={() => onJsonChange("")}
-            />
+            <ClearButton onClick={() => onJsonChange("")} />
           ) : null
         }
       />
@@ -153,9 +149,7 @@ export function ImportServerJsonPanel({
               rightSectionPointerEvents="auto"
               rightSection={
                 envVar.value ? (
-                  <CloseButton
-                    aria-label="Clear"
-                    tabIndex={-1}
+                  <ClearButton
                     onClick={() => onEnvVarChange(envVar.name, "")}
                   />
                 ) : null
@@ -174,11 +168,7 @@ export function ImportServerJsonPanel({
         rightSectionPointerEvents="auto"
         rightSection={
           draft.nameOverride ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
-              onClick={() => onServerNameChange("")}
-            />
+            <ClearButton onClick={() => onServerNameChange("")} />
           ) : null
         }
       />

--- a/clients/web/src/components/groups/LogControls/LogControls.tsx
+++ b/clients/web/src/components/groups/LogControls/LogControls.tsx
@@ -1,12 +1,5 @@
-import {
-  Button,
-  CloseButton,
-  Group,
-  Select,
-  Stack,
-  TextInput,
-  Title,
-} from "@mantine/core";
+import { Button, Group, Select, Stack, TextInput, Title } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
 import { FilterToggleButton } from "../../elements/FilterToggleButton/FilterToggleButton";
 
@@ -66,13 +59,7 @@ export function LogControls({
         onChange={(e) => onFilterChange(e.currentTarget.value)}
         rightSectionPointerEvents="auto"
         rightSection={
-          filterText ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
-              onClick={() => onFilterChange("")}
-            />
-          ) : null
+          filterText ? <ClearButton onClick={() => onFilterChange("")} /> : null
         }
       />
 

--- a/clients/web/src/components/groups/LogControls/LogControls.tsx
+++ b/clients/web/src/components/groups/LogControls/LogControls.tsx
@@ -69,6 +69,7 @@ export function LogControls({
           filterText ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() => onFilterChange("")}
             />
           ) : null

--- a/clients/web/src/components/groups/NetworkControls/NetworkControls.tsx
+++ b/clients/web/src/components/groups/NetworkControls/NetworkControls.tsx
@@ -50,6 +50,7 @@ export function NetworkControls({
           filterText ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() => onFilterChange("")}
             />
           ) : null

--- a/clients/web/src/components/groups/NetworkControls/NetworkControls.tsx
+++ b/clients/web/src/components/groups/NetworkControls/NetworkControls.tsx
@@ -1,11 +1,5 @@
-import {
-  Button,
-  CloseButton,
-  Group,
-  Stack,
-  TextInput,
-  Title,
-} from "@mantine/core";
+import { Button, Group, Stack, TextInput, Title } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { FetchRequestCategory } from "@inspector/core/mcp/types.js";
 import { FilterToggleButton } from "../../elements/FilterToggleButton/FilterToggleButton";
 
@@ -47,13 +41,7 @@ export function NetworkControls({
         onChange={(e) => onFilterChange(e.currentTarget.value)}
         rightSectionPointerEvents="auto"
         rightSection={
-          filterText ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
-              onClick={() => onFilterChange("")}
-            />
-          ) : null
+          filterText ? <ClearButton onClick={() => onFilterChange("")} /> : null
         }
       />
 

--- a/clients/web/src/components/groups/PromptArgumentsForm/PromptArgumentsForm.tsx
+++ b/clients/web/src/components/groups/PromptArgumentsForm/PromptArgumentsForm.tsx
@@ -2,13 +2,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Autocomplete,
   Button,
-  CloseButton,
   Group,
   Stack,
   Text,
   TextInput,
   Title,
 } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 
 export interface PromptArgumentsFormProps {
@@ -225,11 +225,7 @@ export function PromptArgumentsForm({
                   rightSectionPointerEvents="auto"
                   rightSection={
                     argumentValues[arg.name] ? (
-                      <CloseButton
-                        aria-label="Clear"
-                        tabIndex={-1}
-                        onClick={() => handleChange(arg.name, "")}
-                      />
+                      <ClearButton onClick={() => handleChange(arg.name, "")} />
                     ) : null
                   }
                 />

--- a/clients/web/src/components/groups/PromptArgumentsForm/PromptArgumentsForm.tsx
+++ b/clients/web/src/components/groups/PromptArgumentsForm/PromptArgumentsForm.tsx
@@ -227,6 +227,7 @@ export function PromptArgumentsForm({
                     argumentValues[arg.name] ? (
                       <CloseButton
                         aria-label="Clear"
+                        tabIndex={-1}
                         onClick={() => handleChange(arg.name, "")}
                       />
                     ) : null

--- a/clients/web/src/components/groups/PromptControls/PromptControls.tsx
+++ b/clients/web/src/components/groups/PromptControls/PromptControls.tsx
@@ -1,11 +1,5 @@
-import {
-  CloseButton,
-  Group,
-  ScrollArea,
-  Stack,
-  TextInput,
-  Title,
-} from "@mantine/core";
+import { Group, ScrollArea, Stack, TextInput, Title } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { ListChangedIndicator } from "../../elements/ListChangedIndicator/ListChangedIndicator";
 import { PromptListItem } from "../PromptListItem/PromptListItem";
@@ -56,13 +50,7 @@ export function PromptControls({
         onChange={(e) => onSearchChange(e.currentTarget.value)}
         rightSectionPointerEvents="auto"
         rightSection={
-          searchText ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
-              onClick={() => onSearchChange("")}
-            />
-          ) : null
+          searchText ? <ClearButton onClick={() => onSearchChange("")} /> : null
         }
       />
       <ScrollArea.Autosize viewportRef={viewportRef} mah={LIST_MAX_HEIGHT}>

--- a/clients/web/src/components/groups/PromptControls/PromptControls.tsx
+++ b/clients/web/src/components/groups/PromptControls/PromptControls.tsx
@@ -59,6 +59,7 @@ export function PromptControls({
           searchText ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() => onSearchChange("")}
             />
           ) : null

--- a/clients/web/src/components/groups/ResourceControls/ResourceControls.tsx
+++ b/clients/web/src/components/groups/ResourceControls/ResourceControls.tsx
@@ -1,11 +1,5 @@
-import {
-  Accordion,
-  CloseButton,
-  Group,
-  Stack,
-  TextInput,
-  Title,
-} from "@mantine/core";
+import { Accordion, Group, Stack, TextInput, Title } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import { RiArrowRightSLine } from "react-icons/ri";
 import type {
   Resource,
@@ -186,11 +180,7 @@ export function ResourceControls({
           rightSectionPointerEvents="auto"
           rightSection={
             searchText ? (
-              <CloseButton
-                aria-label="Clear"
-                tabIndex={-1}
-                onClick={() => onSearchChange("")}
-              />
+              <ClearButton onClick={() => onSearchChange("")} />
             ) : null
           }
         />

--- a/clients/web/src/components/groups/ResourceControls/ResourceControls.tsx
+++ b/clients/web/src/components/groups/ResourceControls/ResourceControls.tsx
@@ -188,6 +188,7 @@ export function ResourceControls({
             searchText ? (
               <CloseButton
                 aria-label="Clear"
+                tabIndex={-1}
                 onClick={() => onSearchChange("")}
               />
             ) : null

--- a/clients/web/src/components/groups/ResourceTemplatePanel/ResourceTemplatePanel.tsx
+++ b/clients/web/src/components/groups/ResourceTemplatePanel/ResourceTemplatePanel.tsx
@@ -267,6 +267,7 @@ export function ResourceTemplatePanel({
                 variables[varName] ? (
                   <CloseButton
                     aria-label="Clear"
+                    tabIndex={-1}
                     onClick={() => handleVariableChange(varName, "")}
                   />
                 ) : null

--- a/clients/web/src/components/groups/ResourceTemplatePanel/ResourceTemplatePanel.tsx
+++ b/clients/web/src/components/groups/ResourceTemplatePanel/ResourceTemplatePanel.tsx
@@ -2,13 +2,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Autocomplete,
   Button,
-  CloseButton,
   Group,
   Stack,
   Text,
   TextInput,
   Title,
 } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
 import { AnnotationBadge } from "../../elements/AnnotationBadge/AnnotationBadge";
 import { CopyButton } from "../../elements/CopyButton/CopyButton";
@@ -265,9 +265,7 @@ export function ResourceTemplatePanel({
               rightSectionPointerEvents="auto"
               rightSection={
                 variables[varName] ? (
-                  <CloseButton
-                    aria-label="Clear"
-                    tabIndex={-1}
+                  <ClearButton
                     onClick={() => handleVariableChange(varName, "")}
                   />
                 ) : null

--- a/clients/web/src/components/groups/RootsTable/RootsTable.tsx
+++ b/clients/web/src/components/groups/RootsTable/RootsTable.tsx
@@ -2,7 +2,6 @@ import {
   ActionIcon,
   Alert,
   Button,
-  CloseButton,
   Divider,
   Group,
   Stack,
@@ -11,6 +10,7 @@ import {
   TextInput,
   Title,
 } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { Root } from "@modelcontextprotocol/sdk/types.js";
 
 export type RootDraft = { name: string; uri: string };
@@ -94,9 +94,7 @@ export function RootsTable({
         rightSectionPointerEvents="auto"
         rightSection={
           newRootDraft.name ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
+            <ClearButton
               onClick={() =>
                 onNewRootDraftChange({ ...newRootDraft, name: "" })
               }
@@ -116,9 +114,7 @@ export function RootsTable({
         rightSectionPointerEvents="auto"
         rightSection={
           newRootDraft.uri ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
+            <ClearButton
               onClick={() => onNewRootDraftChange({ ...newRootDraft, uri: "" })}
             />
           ) : null

--- a/clients/web/src/components/groups/RootsTable/RootsTable.tsx
+++ b/clients/web/src/components/groups/RootsTable/RootsTable.tsx
@@ -96,6 +96,7 @@ export function RootsTable({
           newRootDraft.name ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() =>
                 onNewRootDraftChange({ ...newRootDraft, name: "" })
               }
@@ -117,6 +118,7 @@ export function RootsTable({
           newRootDraft.uri ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() => onNewRootDraftChange({ ...newRootDraft, uri: "" })}
             />
           ) : null

--- a/clients/web/src/components/groups/SamplingRequestPanel/SamplingRequestPanel.tsx
+++ b/clients/web/src/components/groups/SamplingRequestPanel/SamplingRequestPanel.tsx
@@ -1,7 +1,6 @@
 import {
   Badge,
   Button,
-  CloseButton,
   Divider,
   Group,
   Paper,
@@ -12,6 +11,7 @@ import {
   Textarea,
   Title,
 } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type {
   CreateMessageRequestParams,
   CreateMessageResult,
@@ -159,9 +159,7 @@ export function SamplingRequestPanel({
         rightSectionPointerEvents="auto"
         rightSection={
           draftResult.content.type === "text" && draftResult.content.text ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
+            <ClearButton
               onClick={() =>
                 onResultChange({
                   ...draftResult,
@@ -182,9 +180,7 @@ export function SamplingRequestPanel({
           rightSectionPointerEvents="auto"
           rightSection={
             draftResult.model ? (
-              <CloseButton
-                aria-label="Clear"
-                tabIndex={-1}
+              <ClearButton
                 onClick={() => onResultChange({ ...draftResult, model: "" })}
               />
             ) : null

--- a/clients/web/src/components/groups/SamplingRequestPanel/SamplingRequestPanel.tsx
+++ b/clients/web/src/components/groups/SamplingRequestPanel/SamplingRequestPanel.tsx
@@ -161,6 +161,7 @@ export function SamplingRequestPanel({
           draftResult.content.type === "text" && draftResult.content.text ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() =>
                 onResultChange({
                   ...draftResult,
@@ -183,6 +184,7 @@ export function SamplingRequestPanel({
             draftResult.model ? (
               <CloseButton
                 aria-label="Clear"
+                tabIndex={-1}
                 onClick={() => onResultChange({ ...draftResult, model: "" })}
               />
             ) : null

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
@@ -121,6 +121,7 @@ export function SchemaForm({
             rawValue ? (
               <CloseButton
                 aria-label="Clear"
+                tabIndex={-1}
                 onClick={() => handleFieldChange(fieldName, "")}
               />
             ) : null

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
@@ -1,6 +1,5 @@
 import {
   Checkbox,
-  CloseButton,
   JsonInput,
   MultiSelect,
   NumberInput,
@@ -9,6 +8,7 @@ import {
   Text,
   TextInput,
 } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { JsonSchemaType } from "../../../utils/jsonUtils";
 
 const FieldLabel = Text.withProps({
@@ -119,11 +119,7 @@ export function SchemaForm({
           rightSectionPointerEvents="auto"
           rightSection={
             rawValue ? (
-              <CloseButton
-                aria-label="Clear"
-                tabIndex={-1}
-                onClick={() => handleFieldChange(fieldName, "")}
-              />
+              <ClearButton onClick={() => handleFieldChange(fieldName, "")} />
             ) : null
           }
         />

--- a/clients/web/src/components/groups/ServerConfigModal/ServerConfigModal.tsx
+++ b/clients/web/src/components/groups/ServerConfigModal/ServerConfigModal.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   Button,
-  CloseButton,
   Group,
   Modal,
   Select,
@@ -10,6 +9,7 @@ import {
   TextInput,
   Textarea,
 } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type {
   MCPServerConfig,
   StdioServerConfig,
@@ -279,9 +279,7 @@ export function ServerConfigModal({
             rightSectionPointerEvents="auto"
             rightSection={
               form.id ? (
-                <CloseButton
-                  aria-label="Clear"
-                  tabIndex={-1}
+                <ClearButton
                   disabled={submitting}
                   onClick={() => setForm((f) => ({ ...f, id: "" }))}
                 />
@@ -322,9 +320,7 @@ export function ServerConfigModal({
                 rightSectionPointerEvents="auto"
                 rightSection={
                   form.command ? (
-                    <CloseButton
-                      aria-label="Clear"
-                      tabIndex={-1}
+                    <ClearButton
                       disabled={submitting}
                       onClick={() => setForm((f) => ({ ...f, command: "" }))}
                     />
@@ -346,9 +342,7 @@ export function ServerConfigModal({
                 rightSectionPointerEvents="auto"
                 rightSection={
                   form.argsText ? (
-                    <CloseButton
-                      aria-label="Clear"
-                      tabIndex={-1}
+                    <ClearButton
                       disabled={submitting}
                       onClick={() => setForm((f) => ({ ...f, argsText: "" }))}
                     />
@@ -370,9 +364,7 @@ export function ServerConfigModal({
                 rightSectionPointerEvents="auto"
                 rightSection={
                   form.envText ? (
-                    <CloseButton
-                      aria-label="Clear"
-                      tabIndex={-1}
+                    <ClearButton
                       disabled={submitting}
                       onClick={() => setForm((f) => ({ ...f, envText: "" }))}
                     />
@@ -391,9 +383,7 @@ export function ServerConfigModal({
                 rightSectionPointerEvents="auto"
                 rightSection={
                   form.cwd ? (
-                    <CloseButton
-                      aria-label="Clear"
-                      tabIndex={-1}
+                    <ClearButton
                       disabled={submitting}
                       onClick={() => setForm((f) => ({ ...f, cwd: "" }))}
                     />
@@ -415,9 +405,7 @@ export function ServerConfigModal({
               rightSectionPointerEvents="auto"
               rightSection={
                 form.url ? (
-                  <CloseButton
-                    aria-label="Clear"
-                    tabIndex={-1}
+                  <ClearButton
                     disabled={submitting}
                     onClick={() => setForm((f) => ({ ...f, url: "" }))}
                   />

--- a/clients/web/src/components/groups/ServerConfigModal/ServerConfigModal.tsx
+++ b/clients/web/src/components/groups/ServerConfigModal/ServerConfigModal.tsx
@@ -281,6 +281,7 @@ export function ServerConfigModal({
               form.id ? (
                 <CloseButton
                   aria-label="Clear"
+                  tabIndex={-1}
                   disabled={submitting}
                   onClick={() => setForm((f) => ({ ...f, id: "" }))}
                 />
@@ -323,6 +324,7 @@ export function ServerConfigModal({
                   form.command ? (
                     <CloseButton
                       aria-label="Clear"
+                      tabIndex={-1}
                       disabled={submitting}
                       onClick={() => setForm((f) => ({ ...f, command: "" }))}
                     />
@@ -346,6 +348,7 @@ export function ServerConfigModal({
                   form.argsText ? (
                     <CloseButton
                       aria-label="Clear"
+                      tabIndex={-1}
                       disabled={submitting}
                       onClick={() => setForm((f) => ({ ...f, argsText: "" }))}
                     />
@@ -369,6 +372,7 @@ export function ServerConfigModal({
                   form.envText ? (
                     <CloseButton
                       aria-label="Clear"
+                      tabIndex={-1}
                       disabled={submitting}
                       onClick={() => setForm((f) => ({ ...f, envText: "" }))}
                     />
@@ -389,6 +393,7 @@ export function ServerConfigModal({
                   form.cwd ? (
                     <CloseButton
                       aria-label="Clear"
+                      tabIndex={-1}
                       disabled={submitting}
                       onClick={() => setForm((f) => ({ ...f, cwd: "" }))}
                     />
@@ -412,6 +417,7 @@ export function ServerConfigModal({
                 form.url ? (
                   <CloseButton
                     aria-label="Clear"
+                    tabIndex={-1}
                     disabled={submitting}
                     onClick={() => setForm((f) => ({ ...f, url: "" }))}
                   />

--- a/clients/web/src/components/groups/ServerSettingsForm/ServerSettingsForm.tsx
+++ b/clients/web/src/components/groups/ServerSettingsForm/ServerSettingsForm.tsx
@@ -93,6 +93,7 @@ function KeyValueRows({
               item.key ? (
                 <CloseButton
                   aria-label="Clear"
+                  tabIndex={-1}
                   onClick={() => onChange(index, "", item.value)}
                 />
               ) : null
@@ -107,6 +108,7 @@ function KeyValueRows({
               item.value ? (
                 <CloseButton
                   aria-label="Clear"
+                  tabIndex={-1}
                   onClick={() => onChange(index, item.key, "")}
                 />
               ) : null
@@ -147,6 +149,7 @@ function RootRows({
               root.uri ? (
                 <CloseButton
                   aria-label="Clear"
+                  tabIndex={-1}
                   onClick={() => onChange(index, "", root.name ?? "")}
                 />
               ) : null
@@ -161,6 +164,7 @@ function RootRows({
               root.name ? (
                 <CloseButton
                   aria-label="Clear"
+                  tabIndex={-1}
                   onClick={() => onChange(index, root.uri, "")}
                 />
               ) : null
@@ -374,6 +378,7 @@ export function ServerSettingsForm({
                 settings.oauthClientId ? (
                   <CloseButton
                     aria-label="Clear"
+                    tabIndex={-1}
                     onClick={() =>
                       onOAuthChange({ ...currentOAuth(), clientId: "" })
                     }
@@ -396,6 +401,7 @@ export function ServerSettingsForm({
                 settings.oauthClientSecret ? (
                   <CloseButton
                     aria-label="Clear"
+                    tabIndex={-1}
                     onClick={() =>
                       onOAuthChange({ ...currentOAuth(), clientSecret: "" })
                     }
@@ -417,6 +423,7 @@ export function ServerSettingsForm({
                 settings.oauthScopes ? (
                   <CloseButton
                     aria-label="Clear"
+                    tabIndex={-1}
                     onClick={() =>
                       onOAuthChange({ ...currentOAuth(), scopes: "" })
                     }

--- a/clients/web/src/components/groups/ServerSettingsForm/ServerSettingsForm.tsx
+++ b/clients/web/src/components/groups/ServerSettingsForm/ServerSettingsForm.tsx
@@ -3,13 +3,13 @@ import {
   ActionIcon,
   Button,
   Checkbox,
-  CloseButton,
   Group,
   NumberInput,
   Stack,
   Text,
   TextInput,
 } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type {
   InspectorServerSettings,
   OAuthSettings,
@@ -91,11 +91,7 @@ function KeyValueRows({
             rightSectionPointerEvents="auto"
             rightSection={
               item.key ? (
-                <CloseButton
-                  aria-label="Clear"
-                  tabIndex={-1}
-                  onClick={() => onChange(index, "", item.value)}
-                />
+                <ClearButton onClick={() => onChange(index, "", item.value)} />
               ) : null
             }
           />
@@ -106,11 +102,7 @@ function KeyValueRows({
             rightSectionPointerEvents="auto"
             rightSection={
               item.value ? (
-                <CloseButton
-                  aria-label="Clear"
-                  tabIndex={-1}
-                  onClick={() => onChange(index, item.key, "")}
-                />
+                <ClearButton onClick={() => onChange(index, item.key, "")} />
               ) : null
             }
           />
@@ -147,9 +139,7 @@ function RootRows({
             rightSectionPointerEvents="auto"
             rightSection={
               root.uri ? (
-                <CloseButton
-                  aria-label="Clear"
-                  tabIndex={-1}
+                <ClearButton
                   onClick={() => onChange(index, "", root.name ?? "")}
                 />
               ) : null
@@ -162,11 +152,7 @@ function RootRows({
             rightSectionPointerEvents="auto"
             rightSection={
               root.name ? (
-                <CloseButton
-                  aria-label="Clear"
-                  tabIndex={-1}
-                  onClick={() => onChange(index, root.uri, "")}
-                />
+                <ClearButton onClick={() => onChange(index, root.uri, "")} />
               ) : null
             }
           />
@@ -376,9 +362,7 @@ export function ServerSettingsForm({
               rightSectionPointerEvents="auto"
               rightSection={
                 settings.oauthClientId ? (
-                  <CloseButton
-                    aria-label="Clear"
-                    tabIndex={-1}
+                  <ClearButton
                     onClick={() =>
                       onOAuthChange({ ...currentOAuth(), clientId: "" })
                     }
@@ -399,9 +383,7 @@ export function ServerSettingsForm({
               rightSectionPointerEvents="auto"
               rightSection={
                 settings.oauthClientSecret ? (
-                  <CloseButton
-                    aria-label="Clear"
-                    tabIndex={-1}
+                  <ClearButton
                     onClick={() =>
                       onOAuthChange({ ...currentOAuth(), clientSecret: "" })
                     }
@@ -421,9 +403,7 @@ export function ServerSettingsForm({
               rightSectionPointerEvents="auto"
               rightSection={
                 settings.oauthScopes ? (
-                  <CloseButton
-                    aria-label="Clear"
-                    tabIndex={-1}
+                  <ClearButton
                     onClick={() =>
                       onOAuthChange({ ...currentOAuth(), scopes: "" })
                     }

--- a/clients/web/src/components/groups/TaskControls/TaskControls.tsx
+++ b/clients/web/src/components/groups/TaskControls/TaskControls.tsx
@@ -53,6 +53,7 @@ export function TaskControls({
           searchText ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() => onSearchChange("")}
             />
           ) : null

--- a/clients/web/src/components/groups/TaskControls/TaskControls.tsx
+++ b/clients/web/src/components/groups/TaskControls/TaskControls.tsx
@@ -1,12 +1,5 @@
-import {
-  Button,
-  CloseButton,
-  Group,
-  Select,
-  Stack,
-  TextInput,
-  Title,
-} from "@mantine/core";
+import { Button, Group, Select, Stack, TextInput, Title } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { TaskStatus } from "@modelcontextprotocol/sdk/types.js";
 
 const STATUS_OPTIONS: TaskStatus[] = [
@@ -50,13 +43,7 @@ export function TaskControls({
         onChange={(event) => onSearchChange(event.currentTarget.value)}
         rightSectionPointerEvents="auto"
         rightSection={
-          searchText ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
-              onClick={() => onSearchChange("")}
-            />
-          ) : null
+          searchText ? <ClearButton onClick={() => onSearchChange("")} /> : null
         }
       />
 

--- a/clients/web/src/components/groups/ToolControls/ToolControls.tsx
+++ b/clients/web/src/components/groups/ToolControls/ToolControls.tsx
@@ -1,11 +1,5 @@
-import {
-  CloseButton,
-  Group,
-  ScrollArea,
-  Stack,
-  TextInput,
-  Title,
-} from "@mantine/core";
+import { Group, ScrollArea, Stack, TextInput, Title } from "@mantine/core";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { ListChangedIndicator } from "../../elements/ListChangedIndicator/ListChangedIndicator";
 import { ToolListItem } from "../ToolListItem/ToolListItem";
@@ -57,13 +51,7 @@ export function ToolControls({
         onChange={(e) => onSearchChange(e.currentTarget.value)}
         rightSectionPointerEvents="auto"
         rightSection={
-          searchText ? (
-            <CloseButton
-              aria-label="Clear"
-              tabIndex={-1}
-              onClick={() => onSearchChange("")}
-            />
-          ) : null
+          searchText ? <ClearButton onClick={() => onSearchChange("")} /> : null
         }
       />
       <ScrollArea.Autosize viewportRef={viewportRef} mah={LIST_MAX_HEIGHT}>

--- a/clients/web/src/components/groups/ToolControls/ToolControls.tsx
+++ b/clients/web/src/components/groups/ToolControls/ToolControls.tsx
@@ -60,6 +60,7 @@ export function ToolControls({
           searchText ? (
             <CloseButton
               aria-label="Clear"
+              tabIndex={-1}
               onClick={() => onSearchChange("")}
             />
           ) : null

--- a/clients/web/src/theme/Accordion.ts
+++ b/clients/web/src/theme/Accordion.ts
@@ -1,17 +1,25 @@
 import { Accordion } from "@mantine/core";
 
 export const ThemeAccordion = Accordion.extend({
-  // The `disclosure` variant drives two behaviours via App.css (see #1462):
+  // The `disclosure` variant drives three behaviours via App.css (see #1462):
   //   - `disclosure-chevron` on the chevron slot rotates a right-pointing arrow
   //     90° (right → down) on open, instead of Mantine's default 180° flip.
   //   - `disclosure-sections` on the root makes the accordion a full-height
   //     flex column: section headers stay pinned and each open section's panel
   //     scrolls within its own (item-count-weighted) share of the space, so
   //     nothing scrolls until the panel is full.
+  //   - `filter-toggle` on the control gives the section headers the same
+  //     outline-on-hover treatment as the FilterToggleButton and the History
+  //     section headers: a thin border on hover (rather than a background fill)
+  //     and a filled background when the section is open (`aria-expanded`).
   // Pair it with `chevron={<RiArrowRightSLine />}` and per-item `flex` weights.
   classNames: (_theme, props) => {
     if (props.variant === "disclosure")
-      return { root: "disclosure-sections", chevron: "disclosure-chevron" };
+      return {
+        root: "disclosure-sections",
+        chevron: "disclosure-chevron",
+        control: "filter-toggle",
+      };
     return {};
   },
 });

--- a/clients/web/src/theme/Autocomplete.ts
+++ b/clients/web/src/theme/Autocomplete.ts
@@ -8,5 +8,9 @@ export const ThemeAutocomplete = Autocomplete.extend({
     // collapses any open dropdown automatically. Per-site `clearable={false}`
     // can opt out where a clear button doesn't make sense.
     clearable: true,
+    // Keep the clear button out of the keyboard tab order so tabbing through a
+    // form moves to the next field, not onto the clear button (it stays
+    // mouse-clickable).
+    clearButtonProps: { tabIndex: -1 },
   },
 });

--- a/clients/web/src/theme/Group.ts
+++ b/clients/web/src/theme/Group.ts
@@ -1,17 +1,16 @@
 import { Group } from "@mantine/core";
 
 export const ThemeGroup = Group.extend({
-  // `sectionHeader` styles a Group as a collapsible-section header "pleat":
-  // rounded, with the same hover highlight as the listItem toggles. The active
-  // (open) background is passed per-instance via the `bg` prop.
+  // `sectionHeader` styles a Group as a collapsible-section header "pleat". It
+  // shares the `.filter-toggle` treatment used by the FilterToggleButton: a thin
+  // outline on hover (rather than a background fill) so hover stays visually
+  // distinct from the active state. The active (open) background is passed
+  // per-instance via the `bg` prop. The border-radius and the reserved
+  // transparent border both come from `.filter-toggle` in App.css — the border
+  // must NOT be set here as an inline style, since inline styles outrank the
+  // stylesheet `:hover` rule (see #1460).
   classNames: (_theme, props) => {
-    if (props.variant === "sectionHeader") return { root: "list-item" };
+    if (props.variant === "sectionHeader") return { root: "filter-toggle" };
     return {};
-  },
-  styles: (_theme, props) => {
-    if (props.variant === "sectionHeader") {
-      return { root: { borderRadius: "var(--mantine-radius-md)" } };
-    }
-    return { root: {} };
   },
 });


### PR DESCRIPTION
Closes #1487.

## Summary

Three small button-behavior adjustments in the web client, all converging on one shared hover treatment (`.filter-toggle`: thin outline on hover, filled background when active/open).

### 1. History section headers — filter-button hover style

The collapsible **Pinned Requests** / **History** section-header pleats used the `list-item` background-fill hover. They now use the `.filter-toggle` outline-on-hover style (via the `sectionHeader` Group variant), keeping the filled background for the open section.

### 2. Resources accordion headers — same style

The Resources screen `disclosure` accordion controls (URIs / Templates / Subscriptions) previously used a background-fill hover. They now share the `.filter-toggle` treatment: a thin outline on hover and a filled background when the section is open (keyed off `aria-expanded`). The default-variant accordion (Server Settings) is unaffected — it keeps its background-fill hover via a `:not(.filter-toggle)` guard.

### 3. Input clear buttons out of the tab order

PR #1448 added a clear (×) button to many text inputs via `rightSection`. They were in the keyboard tab order, so Tab-ing through a form landed on the clear button instead of the next field. Added `tabIndex={-1}` to:

- every `aria-label="Clear"` `CloseButton` clear button app-wide (34 sites across 17 files), and
- the `Autocomplete` clear button enabled in #1448, via `clearButtonProps` in `theme/Autocomplete.ts`.

Buttons remain mouse-clickable. The `Select` `clearable` clear buttons predate #1448 and are left as-is.

## Testing

- `npm run validate` ✅ (2319 unit tests pass)
- `npm run test:storybook` ✅ (361 pass)
- Added a tab-order assertion to `HistoryControls.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)