### PR TITLE
feat: support initial connection type via query param and CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,11 +357,11 @@ npx @modelcontextprotocol/inspector --config mcp.json
 
 > **Tip:** You can easily generate this configuration format using the **Server Entry** and **Servers File** buttons in the Inspector UI, as described in the Servers File Export section above.
 
-You can also set the initial `transport` type, `serverUrl`, `serverCommand`, and `serverArgs` via query params, for example:
+You can also set the initial `transport` type, `serverUrl`, `connectionType`, `serverCommand`, and `serverArgs` via query params, for example:
 
 ```
 http://localhost:6274/?transport=sse&serverUrl=http://localhost:8787/sse
-http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:8787/mcp
+http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:8787/mcp&connectionType=direct
 http://localhost:6274/?transport=stdio&serverCommand=npx&serverArgs=arg1%20arg2
 ```
 

--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -36,6 +36,7 @@ async function startDevServer(serverOptions) {
     abort,
     transport,
     serverUrl,
+    connectionType,
   } = serverOptions;
   const serverCommand = "npx";
   const serverArgs = ["tsx", "watch", "--clear-screen=false", "src/index.ts"];
@@ -51,6 +52,7 @@ async function startDevServer(serverOptions) {
       MCP_ENV_VARS: JSON.stringify(envVars),
       ...(transport ? { MCP_TRANSPORT: transport } : {}),
       ...(serverUrl ? { MCP_SERVER_URL: serverUrl } : {}),
+      ...(connectionType ? { MCP_CONNECTION_TYPE: connectionType } : {}),
     },
     signal: abort.signal,
     echoOutput: true,
@@ -91,6 +93,7 @@ async function startProdServer(serverOptions) {
     mcpServerArgs,
     transport,
     serverUrl,
+    connectionType,
   } = serverOptions;
   const inspectorServerPath = resolve(
     __dirname,
@@ -110,6 +113,7 @@ async function startProdServer(serverOptions) {
         : []),
       ...(transport ? [`--transport=${transport}`] : []),
       ...(serverUrl ? [`--server-url=${serverUrl}`] : []),
+      ...(connectionType ? [`--connection-type=${connectionType}`] : []),
     ],
     {
       env: {
@@ -233,6 +237,7 @@ async function main() {
   let isDev = false;
   let transport = null;
   let serverUrl = null;
+  let connectionType = null;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -254,6 +259,11 @@ async function main() {
 
     if (parsingFlags && arg === "--server-url" && i + 1 < args.length) {
       serverUrl = args[++i];
+      continue;
+    }
+
+    if (parsingFlags && arg === "--connection-type" && i + 1 < args.length) {
+      connectionType = args[++i];
       continue;
     }
 
@@ -310,6 +320,7 @@ async function main() {
       mcpServerArgs,
       transport,
       serverUrl,
+      connectionType,
     };
 
     const result = isDev

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -87,6 +87,7 @@ import {
   getInitialTransportType,
   getInitialCommand,
   getInitialArgs,
+  getInitialConnectionType,
   initializeInspectorConfig,
   saveInspectorConfig,
   getMCPTaskTtl,
@@ -179,13 +180,9 @@ const App = () => {
     "stdio" | "sse" | "streamable-http"
   >(getInitialTransportType);
   const [connectionType, setConnectionType] = useState<"direct" | "proxy">(
-    () => {
-      return (
-        (localStorage.getItem("lastConnectionType") as "direct" | "proxy") ||
-        "proxy"
-      );
-    },
+    getInitialConnectionType,
   );
+
   const [logLevel, setLogLevel] = useState<LoggingLevel>("debug");
   const [notifications, setNotifications] = useState<ServerNotification[]>([]);
   const [roots, setRoots] = useState<Root[]>([]);
@@ -738,6 +735,12 @@ const App = () => {
         }
         if (data.defaultServerUrl) {
           setSseUrl(data.defaultServerUrl);
+        }
+        if (
+          data.defaultConnectionType === "direct" ||
+          data.defaultConnectionType === "proxy"
+        ) {
+          setConnectionType(data.defaultConnectionType);
         }
       })
       .catch((error) =>

--- a/client/src/__tests__/App.config.test.tsx
+++ b/client/src/__tests__/App.config.test.tsx
@@ -33,6 +33,7 @@ jest.mock("../utils/configUtils", () => ({
   getInitialSseUrl: jest.fn(() => "http://localhost:3001/sse"),
   getInitialCommand: jest.fn(() => "mcp-server-everything"),
   getInitialArgs: jest.fn(() => ""),
+  getInitialConnectionType: jest.fn(() => "proxy"),
   initializeInspectorConfig: jest.fn(() => DEFAULT_INSPECTOR_CONFIG),
   saveInspectorConfig: jest.fn(),
 }));
@@ -208,6 +209,62 @@ describe("App - Config Endpoint", () => {
         }),
       }),
     );
+  });
+
+  test("applies defaultConnectionType from /config response", async () => {
+    const mockConfig = {
+      ...DEFAULT_INSPECTOR_CONFIG,
+      MCP_PROXY_AUTH_TOKEN: {
+        ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+        value: "test-proxy-token",
+      },
+    };
+    mockInitializeInspectorConfig.mockReturnValue(mockConfig);
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          defaultEnvironment: {},
+          defaultConnectionType: "direct",
+        }),
+    });
+
+    localStorage.setItem("lastConnectionType", "proxy");
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(localStorage.getItem("lastConnectionType")).toBe("direct");
+    });
+  });
+
+  test("ignores invalid defaultConnectionType values from /config", async () => {
+    const mockConfig = {
+      ...DEFAULT_INSPECTOR_CONFIG,
+      MCP_PROXY_AUTH_TOKEN: {
+        ...DEFAULT_INSPECTOR_CONFIG.MCP_PROXY_AUTH_TOKEN,
+        value: "test-proxy-token",
+      },
+    };
+    mockInitializeInspectorConfig.mockReturnValue(mockConfig);
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          defaultEnvironment: {},
+          defaultConnectionType: "bogus",
+        }),
+    });
+
+    localStorage.setItem("lastConnectionType", "proxy");
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    expect(localStorage.getItem("lastConnectionType")).toBe("proxy");
   });
 
   test("handles config endpoint errors gracefully", async () => {

--- a/client/src/utils/__tests__/configUtils.test.ts
+++ b/client/src/utils/__tests__/configUtils.test.ts
@@ -1,4 +1,4 @@
-import { getMCPProxyAuthToken } from "../configUtils";
+import { getMCPProxyAuthToken, getInitialConnectionType } from "../configUtils";
 import { DEFAULT_INSPECTOR_CONFIG } from "../../lib/constants";
 import { InspectorConfig } from "../../lib/configurationTypes";
 
@@ -67,6 +67,55 @@ describe("configUtils", () => {
         token: null,
         header: "X-MCP-Proxy-Auth",
       });
+    });
+  });
+
+  describe("getInitialConnectionType", () => {
+    const originalLocation = window.location;
+
+    const setLocation = (search: string) => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: new URL(`http://localhost:6274/${search}`),
+      });
+    };
+
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    });
+
+    test("returns 'direct' when query param is 'direct'", () => {
+      setLocation("?connectionType=direct");
+      expect(getInitialConnectionType()).toBe("direct");
+    });
+
+    test("returns 'proxy' when query param is 'proxy'", () => {
+      setLocation("?connectionType=proxy");
+      expect(getInitialConnectionType()).toBe("proxy");
+    });
+
+    test("falls back to localStorage when query param is missing", () => {
+      setLocation("");
+      localStorage.setItem("lastConnectionType", "direct");
+      expect(getInitialConnectionType()).toBe("direct");
+    });
+
+    test("ignores invalid query param values and falls back to localStorage", () => {
+      setLocation("?connectionType=bogus");
+      localStorage.setItem("lastConnectionType", "direct");
+      expect(getInitialConnectionType()).toBe("direct");
+    });
+
+    test("defaults to 'proxy' when nothing is set", () => {
+      setLocation("");
+      expect(getInitialConnectionType()).toBe("proxy");
     });
   });
 });

--- a/client/src/utils/configUtils.ts
+++ b/client/src/utils/configUtils.ts
@@ -92,6 +92,17 @@ export const getInitialArgs = (): string => {
   return localStorage.getItem("lastArgs") || "";
 };
 
+export const getInitialConnectionType = (): "direct" | "proxy" => {
+  const param = getSearchParam("connectionType");
+  if (param === "proxy" || param === "direct") {
+    return param;
+  }
+  return (
+    (localStorage.getItem("lastConnectionType") as "direct" | "proxy") ||
+    "proxy"
+  );
+};
+
 // Returns a map of config key -> value from query params if present
 export const getConfigOverridesFromQueryParams = (
   defaultConfig: InspectorConfig,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,6 +53,7 @@ const { values } = parseArgs({
     command: { type: "string", default: "" },
     transport: { type: "string", default: "" },
     "server-url": { type: "string", default: "" },
+    "connection-type": { type: "string", default: "" },
   },
 });
 
@@ -922,6 +923,7 @@ app.get("/config", originValidationMiddleware, authMiddleware, (req, res) => {
       defaultArgs: values.args,
       defaultTransport: values.transport,
       defaultServerUrl: values["server-url"],
+      defaultConnectionType: values["connection-type"],
     });
   } catch (error) {
     console.error("Error in /config route:", error);


### PR DESCRIPTION
## Summary

Adds an "initial connection type" configuration knob (`"direct"` or `"proxy"`), mirroring the existing `transport` / `serverUrl` plumbing already supported on `main`:

- `?connectionType=direct|proxy` query param (URL-mode)
- `--connection-type <direct|proxy>` CLI flag, forwarded by `client/bin/start.js`
- `defaultConnectionType` field on the `/config` response, consumed by the client

Values are whitelisted to `"direct" | "proxy"` at every read site (`getInitialConnectionType` and the `/config` handler). Unknown values fall through to the previous behavior: `localStorage.lastConnectionType`, defaulting to `"proxy"` — so there is **no behavior change unless a user opts in**.

This is parity work, not a new concept: the same plumbing was added for `transport` / `serverUrl` in 7ea47c0c.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

- **`server/src/index.ts`**: register `--connection-type` in `parseArgs`; expose `defaultConnectionType` on the `/config` response.
- **`client/bin/start.js`**: accept `--connection-type` CLI flag; forward as `MCP_CONNECTION_TYPE` env var in dev mode and as `--connection-type=...` arg in prod mode (matching the existing `transport` / `serverUrl` handling).
- **`client/src/utils/configUtils.ts`**: new `getInitialConnectionType()` helper — reads `?connectionType=` query param, falls back to `localStorage.lastConnectionType`, defaults to `"proxy"`.
- **`client/src/App.tsx`**: use `getInitialConnectionType` as the `useState` initializer; apply `defaultConnectionType` from `/config` when valid (`"direct" | "proxy"` only).
- **`README.md`**: document the new `connectionType` query param.
- **Tests**: see Testing section.

## Related Issues

None found

## Testing

- [x] Tested in UI mode
- [ ] Tested in CLI mode
  - Didn't manage to get it to pick up the argument. Even with `--transport` or `--server-url`
- [ ] Tested with STDIO transport
  - N/A. connection-type doesn't apply
- [ ] Tested with SSE transport
- [x] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

1. Start the dev app with `npm run dev`
2. Navigate to http://localhost:6274/?connectionType=proxy or http://localhost:6274/?connectionType=direct and validate that the connection type is correctly switched to the correct value

<img width="304" height="621" alt="Screenshot 2026-06-18 at 09 13 45" src="https://github.com/user-attachments/assets/1d9c1b7c-7535-46cf-99f7-a9fef0322b21" />

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [x] Documentation updated (README, comments, etc.)

## Breaking Changes

None

## Additional Context

This is additive UX and not a strict bug fix or spec-compliance change, so I understand if it's deferred to V2. Framing the diff as a extension of an existing pattern (`transport` / `serverUrl` -> `connectionType`).