### PR TITLE
fix(web): re-enable other server cards when a connection errors (#1521)

### DIFF
--- a/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
@@ -920,6 +920,76 @@ describe("InspectorView", () => {
     ).toBeInTheDocument();
   });
 
+  it("dims the other server cards while a connection is live", () => {
+    const betaServer: ServerEntry = {
+      id: "beta",
+      name: "Beta",
+      config: { type: "stdio", command: "echo" },
+      connection: { status: "disconnected" },
+    };
+    renderWithMantine(
+      <InspectorView
+        {...makeProps({
+          servers: [sampleServer, betaServer],
+          activeServer: "alpha",
+          connectionStatus: "connected",
+          initializeResult: connectedInit,
+        })}
+      />,
+    );
+    // The non-active card is inert while alpha holds a live session, so the
+    // user can't start a second connection mid-session.
+    const betaCard = screen.getByText("Beta").closest(".mantine-Card-root");
+    expect(betaCard?.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("re-enables the other server cards when the active connection goes to error (#1521)", () => {
+    const betaServer: ServerEntry = {
+      id: "beta",
+      name: "Beta",
+      config: { type: "stdio", command: "echo" },
+      connection: { status: "disconnected" },
+    };
+    // Live session on alpha → beta starts out dimmed/inert.
+    const { rerender } = renderWithMantine(
+      <InspectorView
+        {...makeProps({
+          servers: [sampleServer, betaServer],
+          activeServer: "alpha",
+          connectionStatus: "connected",
+          initializeResult: connectedInit,
+        })}
+      />,
+    );
+    expect(
+      screen
+        .getByText("Beta")
+        .closest(".mantine-Card-root")
+        ?.getAttribute("aria-disabled"),
+    ).toBe("true");
+
+    // alpha's connection errors. App does NOT clear `activeServer` here — a
+    // terminal `error` fires no InspectorClient `disconnect` event — so the
+    // id still points at alpha. The other cards must re-enable anyway; only a
+    // *live* session should dim them.
+    rerender(
+      <InspectorView
+        {...makeProps({
+          servers: [sampleServer, betaServer],
+          activeServer: "alpha",
+          connectionStatus: "error",
+          initializeResult: undefined,
+        })}
+      />,
+    );
+    expect(
+      screen
+        .getByText("Beta")
+        .closest(".mantine-Card-root")
+        ?.getAttribute("aria-disabled"),
+    ).toBeNull();
+  });
+
   describe("listChanged indicator wiring (#1402)", () => {
     // The indicator only mounts on the active screen, so each case connects,
     // navigates to the target tab, and asserts the "List updated" affordance.

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -18,6 +18,7 @@ import type {
   MessageEntry,
   ServerEntry,
 } from "@inspector/core/mcp/types.js";
+import { isTerminalStatus } from "@inspector/core/mcp/types.js";
 import { isAppTool } from "@inspector/core/mcp/apps.js";
 import { ViewHeader } from "../../groups/ViewHeader/ViewHeader";
 import { ServerListScreen } from "../../screens/ServerListScreen/ServerListScreen";
@@ -587,10 +588,12 @@ export function InspectorView({
   // others. The errored card itself still shows its real status via the
   // merged `servers` list above (keyed off the real `activeServer`), so
   // passing `undefined` here lifts only the *other* cards' dimming, not the
-  // error indicator on the active one.
-  const sessionLive =
-    connectionStatus === "connecting" || connectionStatus === "connected";
-  const dimCardsAgainst = sessionLive ? activeServer : undefined;
+  // error indicator on the active one. `isTerminalStatus` (the #1490 teardown
+  // convention) is the single source of truth for "session is over" so this
+  // gate can't silently desync from a future status addition.
+  const dimCardsAgainst = isTerminalStatus(connectionStatus)
+    ? undefined
+    : activeServer;
 
   return (
     // padding={0}: each screen fills `calc(100dvh - header)` and supplies its

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -576,6 +576,22 @@ export function InspectorView({
     [serversInput, activeServer, connectionStatus, initializeResult],
   );
 
+  // The other server cards are dimmed/`inert` only while a connection is
+  // actively live (connecting or connected), so the user can't kick off a
+  // second connection mid-session. Once the active session settles into a
+  // terminal state — `disconnected` or `error` — the rest must re-enable
+  // (#1521). A connect-time handshake failure (and a mid-session transport
+  // `onerror`) resolves to `error` *without* firing the InspectorClient
+  // `disconnect` event that App uses to clear `activeServerId`, so the id
+  // lingers; gating the dim source on liveness here is what un-dims the
+  // others. The errored card itself still shows its real status via the
+  // merged `servers` list above (keyed off the real `activeServer`), so
+  // passing `undefined` here lifts only the *other* cards' dimming, not the
+  // error indicator on the active one.
+  const sessionLive =
+    connectionStatus === "connecting" || connectionStatus === "connected";
+  const dimCardsAgainst = sessionLive ? activeServer : undefined;
+
   return (
     // padding={0}: each screen fills `calc(100dvh - header)` and supplies its
     // own `xl` padding, so Main must contribute only the fixed-header offset.
@@ -612,7 +628,7 @@ export function InspectorView({
             <ServerListScreen
               servers={servers}
               writable={serverListWritable}
-              activeServer={activeServer}
+              activeServer={dimCardsAgainst}
               onAddManually={onServerAdd}
               onImportConfig={onServerImportConfig}
               onImportServerJson={onServerImportJson}


### PR DESCRIPTION
## Summary

Fixes #1521. When a server's connection settled into the terminal **Error** state, the *other* server cards stayed dimmed/`inert` — their Connect toggles and action buttons disabled — so the user couldn't interact with any other server.

<img width="1920" height="592" alt="error-should-re-enable-servers" src="https://github.com/user-attachments/assets/597f8c1b-f58c-4252-ba75-261c8433d0cd" />

## Root cause

`ServerCard` dims any card whose id differs from `activeServer`:

```ts
// ServerCard.tsx
const isDimmed = activeServer !== undefined && activeServer !== id;
```

`activeServer` (= `activeServerId` in `App.tsx`) is cleared **only** on the InspectorClient `disconnect` event (App.tsx, the effect at ~line 889). But a terminal **`error`** state does not always fire `disconnect`:

- a connect-time handshake failure sets `status = "error"` and re-throws, dispatching only `statusChange` (InspectorClient `connect()` catch), and
- a mid-session transport `onerror` that fires *without* an accompanying `onclose` dispatches `error` + `statusChange` only.

In those cases `activeServerId` lingers, so every other card stays inert. We can't simply clear `activeServerId` on error — the errored card's status, the connected header, and the connection-info modal are all keyed off it.

## Fix

Dim the other cards only while the active session is genuinely **live** (`connecting` or `connected`). `InspectorView` now passes the active id to `ServerListScreen` as the dim source only when `connectionStatus` is `connecting`/`connected`; once the session reaches a terminal state (`error` or `disconnected`) the other cards re-enable. The errored card itself still reflects its real status via the merged `servers` list, which keys off the real `activeServer` — so the "Error" indicator is unaffected.

One-line behavioural change; everything else (the merged status list, the connected header, the modal) keeps using the real `activeServer`.

## Testing

- New regression test (`InspectorView.test.tsx`): with `connectionStatus === "error"` and `activeServer` still set, the non-active card is **not** `aria-disabled`; with `connectionStatus === "connected"` it **is**. Verified the test **fails without the fix** and passes with it.
- `npm run validate` (web): format, lint, build, 2000 unit tests pass; 370 Storybook play-function tests pass.

## Manual verification

Drove the app against a 3-server catalog. Confirmed the intended dimming during a live session (one connecting → the other two correctly greyed/disabled) and that cards re-enable once the session is no longer live. Note: the three error triggers I could reproduce with the test servers (stdio connect-timeout, SDK request-timeout, HTTP server kill) all fire `onclose` → `disconnect` and self-recover via the existing reset; the persistent-`error`-without-`disconnect` state from the issue is exercised by the unit regression test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)