### PR TITLE
fix(web): keep server cards a fixed height (#1528)

### DIFF
--- a/clients/web/src/components/elements/ContentViewer/ContentViewer.test.tsx
+++ b/clients/web/src/components/elements/ContentViewer/ContentViewer.test.tsx
@@ -134,9 +134,17 @@ describe("ContentViewer", () => {
     const { container } = renderWithMantine(
       <ContentViewer block={block} wrap={false} />,
     );
-    expect(container.querySelector(".mantine-Code-root")).toHaveAttribute(
-      "data-variant",
-      "nowrap",
+    const code = container.querySelector(".mantine-Code-root");
+    expect(code).toHaveAttribute("data-variant", "nowrap");
+    // Full value exposed on hover since it may be clipped with an ellipsis.
+    expect(code).toHaveAttribute("title", "some long command");
+  });
+
+  it("does not set a title tooltip when wrapping (default)", () => {
+    const block: ContentBlock = { type: "text", text: "some long command" };
+    const { container } = renderWithMantine(<ContentViewer block={block} />);
+    expect(container.querySelector(".mantine-Code-root")).not.toHaveAttribute(
+      "title",
     );
   });
 

--- a/clients/web/src/components/elements/ContentViewer/ContentViewer.test.tsx
+++ b/clients/web/src/components/elements/ContentViewer/ContentViewer.test.tsx
@@ -120,6 +120,26 @@ describe("ContentViewer", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
+  it("renders plain text in a wrapping code block by default", () => {
+    const block: ContentBlock = { type: "text", text: "some long command" };
+    const { container } = renderWithMantine(<ContentViewer block={block} />);
+    expect(container.querySelector(".mantine-Code-root")).toHaveAttribute(
+      "data-variant",
+      "wrapping",
+    );
+  });
+
+  it("renders plain text in a non-wrapping code block when wrap is false", () => {
+    const block: ContentBlock = { type: "text", text: "some long command" };
+    const { container } = renderWithMantine(
+      <ContentViewer block={block} wrap={false} />,
+    );
+    expect(container.querySelector(".mantine-Code-root")).toHaveAttribute(
+      "data-variant",
+      "nowrap",
+    );
+  });
+
   it("renders text as markdown when mimeType is text/markdown", () => {
     const block: ContentBlock = {
       type: "text",

--- a/clients/web/src/components/elements/ContentViewer/ContentViewer.tsx
+++ b/clients/web/src/components/elements/ContentViewer/ContentViewer.tsx
@@ -14,6 +14,14 @@ export interface ContentViewerProps {
    * instead of as preformatted code.
    */
   mimeType?: string;
+  /**
+   * Whether long plain-text content wraps onto multiple lines. When `false`,
+   * text is kept to a single line (overflow clipped with an ellipsis) so the
+   * viewer keeps a fixed height — used by hosts like the server card where the
+   * box height must stay constant regardless of command/URL length. The full
+   * value remains available via the copy button. Defaults to `true`.
+   */
+  wrap?: boolean;
 }
 
 function formatJson(content: string): string {
@@ -66,6 +74,7 @@ export function ContentViewer({
   block,
   copyable = false,
   mimeType,
+  wrap = true,
 }: ContentViewerProps) {
   switch (block.type) {
     case "text": {
@@ -93,7 +102,7 @@ export function ContentViewer({
       return (
         <Stack gap="xs">
           <ContentWrapper>
-            <Code block p={36} variant="wrapping">
+            <Code block p={36} variant={wrap ? "wrapping" : "nowrap"}>
               {displayText}
             </Code>
             {copyable && (

--- a/clients/web/src/components/elements/ContentViewer/ContentViewer.tsx
+++ b/clients/web/src/components/elements/ContentViewer/ContentViewer.tsx
@@ -19,7 +19,12 @@ export interface ContentViewerProps {
    * text is kept to a single line (overflow clipped with an ellipsis) so the
    * viewer keeps a fixed height — used by hosts like the server card where the
    * box height must stay constant regardless of command/URL length. The full
-   * value remains available via the copy button. Defaults to `true`.
+   * value remains available via the copy button (and a native `title`
+   * tooltip). Defaults to `true`.
+   *
+   * Intended for single-line values only: `false` applies `white-space:
+   * nowrap`, which collapses embedded newlines (e.g. pretty-printed JSON) onto
+   * one line — don't pass it for multi-line content.
    */
   wrap?: boolean;
 }
@@ -102,7 +107,14 @@ export function ContentViewer({
       return (
         <Stack gap="xs">
           <ContentWrapper>
-            <Code block p={36} variant={wrap ? "wrapping" : "nowrap"}>
+            <Code
+              block
+              p={36}
+              variant={wrap ? "wrapping" : "nowrap"}
+              // When not wrapping, the value may be clipped with an ellipsis;
+              // expose the full text on hover so it's readable without copying.
+              title={wrap ? undefined : displayText}
+            >
               {displayText}
             </Code>
             {copyable && (

--- a/clients/web/src/components/groups/ServerCard/ServerCard.tsx
+++ b/clients/web/src/components/groups/ServerCard/ServerCard.tsx
@@ -202,6 +202,7 @@ export function ServerCard({
             <ContentViewer
               block={{ type: "text", text: commandOrUrl }}
               copyable
+              wrap={false}
             />
 
             <Group justify="space-between">

--- a/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
+++ b/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
@@ -148,12 +148,14 @@ export function ServerListScreen({
   const grid = (
     <SimpleGrid
       // Container queries (not viewport) so column count tracks the actual
-      // space the grid occupies. Thresholds are set so each card stays ≥ ~500px
-      // wide at every column count: below ~500px a connected card's action row
+      // space the grid occupies. The 2- and 3-column thresholds (1040px /
+      // 1560px) keep each card ≥ ~505px wide at the switch point: container =
+      // N·card + (N−1)·gap with gap = lg spacing (20px), i.e. 1040 = 2·510+20
+      // and 1560 = 3·507+40. Below ~500px a connected card's action row
       // (Clone/Edit/Remove + Connection Info/Settings, ~440px with padding)
-      // wraps and stacks, making that card taller than its neighbours. Dropping
-      // to fewer, wider columns instead keeps every card the same height. The
-      // thresholds are 2*500+gap and 3*500+2*gap respectively. (#1528)
+      // wraps and stacks, making that card taller than its neighbours; dropping
+      // to fewer, wider columns instead keeps every card the same height.
+      // (#1528)
       type="container"
       cols={{ base: 1, "1040px": 2, "1560px": 3 }}
       spacing="lg"

--- a/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
+++ b/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
@@ -147,7 +147,15 @@ export function ServerListScreen({
 
   const grid = (
     <SimpleGrid
-      cols={{ base: 1, sm: 2, lg: 3 }}
+      // Container queries (not viewport) so column count tracks the actual
+      // space the grid occupies. Thresholds are set so each card stays ≥ ~500px
+      // wide at every column count: below ~500px a connected card's action row
+      // (Clone/Edit/Remove + Connection Info/Settings, ~440px with padding)
+      // wraps and stacks, making that card taller than its neighbours. Dropping
+      // to fewer, wider columns instead keeps every card the same height. The
+      // thresholds are 2*500+gap and 3*500+2*gap respectively. (#1528)
+      type="container"
+      cols={{ base: 1, "1040px": 2, "1560px": 3 }}
       spacing="lg"
       className="grid-align-start"
     >

--- a/clients/web/src/theme/Code.ts
+++ b/clients/web/src/theme/Code.ts
@@ -9,6 +9,14 @@ export const ThemeCode = Code.extend({
       root.wordBreak = "break-all";
       root.whiteSpace = "pre-wrap";
     }
+    if (props.variant === "nowrap") {
+      // Single line, fixed height: clip overflow with an ellipsis rather than
+      // wrapping onto new lines (which would grow the container's height). The
+      // full value stays available via the adjacent copy button.
+      root.whiteSpace = "nowrap";
+      root.overflow = "hidden";
+      root.textOverflow = "ellipsis";
+    }
     return { root };
   },
 });


### PR DESCRIPTION
Closes #1528

## Problem
Server cards on the Servers tab didn't keep a consistent height, making the grid look ragged. Two distinct causes:

1. **Command/URL box wrapped.** Long commands/URLs wrapped onto multiple lines, growing the box (and card) taller.
2. **Action links wrapped/stacked at ~1000–1500px.** The grid packed cards narrow enough that a *connected* card's action row (Clone/Edit/Remove + Connection Info/Settings) wrapped onto two rows, making that card taller than its neighbours.

## Changes
- **`theme/Code.ts`** — add a `nowrap` `Code` variant: single line, `overflow: hidden`, ellipsis.
- **`ContentViewer.tsx`** — new `wrap?: boolean` prop (default `true`) selecting `wrapping` vs `nowrap` for plain text. Shared default unchanged, so every other panel still wraps.
- **`ServerCard.tsx`** — passes `wrap={false}`. The command/URL box is now fixed-height; the full value remains available via the existing copy button.
- **`ServerListScreen.tsx`** — switch the `SimpleGrid` to **container queries** (`type="container"`) with thresholds `{ base: 1, "1040px": 2, "1560px": 3 }`. Measured the connected action row at ~403px content (~443px with padding); thresholds keep each card ≥ ~500px wide at every column count, so the grid drops to fewer/wider columns instead of wrapping.

## Verification (Playwright, with a connected card)
| viewport | columns | tightest card | action row |
|---|---|---|---|
| 1006px | 1 | full width | no wrap (was 2-col + wrapped) |
| 1130px | 2 | 517px | no wrap |
| 1500px | 2 | 702px | no wrap |
| 1640px | 3 | 508px | no wrap |

All cards stay equal height at every width.

## Tests
- Added 2 `ContentViewer` tests for the `wrap` prop.
- Full web suite (2007 unit + 370 storybook) passes; `npm run validate` passes across all clients. Changed-file coverage meets the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)