### PR TITLE
fix(ci): link e2e PR summary to Playwright artifact download (#1259)

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -51,6 +51,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload Playwright Report and Screenshots
+        id: playwright-report
         uses: actions/upload-artifact@v7
         if: steps.playwright-tests.conclusion != 'skipped'
         with:
@@ -74,5 +75,5 @@ jobs:
             **Test Environment:** Ubuntu Latest, Node.js ${{ steps.setup_node.outputs.node-version }}
             **Browsers:** Chromium, Firefox
 
-            📊 [View Detailed HTML Report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) (download artifacts)
+            📊 [Download HTML Report + traces](${{ steps.playwright-report.outputs.artifact-url }})
           test-command: "npm run test:e2e"


### PR DESCRIPTION
## Summary

Fix the Playwright e2e PR summary link so it downloads the uploaded HTML report artifact instead of the workflow run page.

- Add `id: playwright-report` to the `actions/upload-artifact@v7` step so its outputs are addressable.
- Point `daun/playwright-report-summary` `custom-info` at `${{ steps.playwright-report.outputs.artifact-url }}` (direct artifact zip URL per [upload-artifact outputs](https://github.com/actions/upload-artifact?tab=readme-ov-file#outputs)).
- Update link text to **Download HTML Report + traces** and drop the misleading "(download artifacts)" parenthetical.

Fixes #1259

## Test plan

- [x] Validated `.github/workflows/e2e_tests.yml` parses as YAML locally.
- [ ] CI: Playwright workflow runs on this PR; confirm the auto-posted summary link resolves to the artifact download.
