### PR TITLE
test(web): cover standalone response entry in HistoryEntry status tests

### DIFF
--- a/clients/web/src/components/groups/HistoryEntry/HistoryEntry.test.tsx
+++ b/clients/web/src/components/groups/HistoryEntry/HistoryEntry.test.tsx
@@ -107,6 +107,21 @@ const notificationEntry: MessageEntry = {
   },
 };
 
+// A standalone direction:"response" entry (e.g. the client's answer to a
+// server→client request such as roots/list or sampling) — no request-style
+// status badge should appear; "Pending" in particular would be misleading.
+const standaloneResponseEntry: MessageEntry = {
+  id: "resp-1",
+  timestamp: new Date("2026-03-17T10:37:00Z"),
+  direction: "response",
+  origin: "client",
+  message: {
+    jsonrpc: "2.0",
+    id: 10,
+    result: { roots: [] },
+  },
+};
+
 const baseProps = {
   isPinned: false,
   isListExpanded: false,
@@ -148,6 +163,17 @@ describe("HistoryEntry", () => {
     // The method badge still labels it; there is no Pending/OK/Error badge,
     // since a fire-and-forget notification has no request lifecycle.
     expect(screen.getByText("notifications/message")).toBeInTheDocument();
+    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
+    expect(screen.queryByText("OK")).not.toBeInTheDocument();
+    expect(screen.queryByText("Error")).not.toBeInTheDocument();
+  });
+
+  it("renders no request-style status badge for a standalone response entry", () => {
+    renderWithMantine(
+      <HistoryEntry {...baseProps} entry={standaloneResponseEntry} />,
+    );
+    // A standalone direction:"response" (e.g. client answering roots/list or
+    // sampling) carries no request lifecycle — no Pending/OK/Error badge.
     expect(screen.queryByText("Pending")).not.toBeInTheDocument();
     expect(screen.queryByText("OK")).not.toBeInTheDocument();
     expect(screen.queryByText("Error")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

Adds the missing test for acceptance criterion #3 of #1439 — "a standalone `direction: "response"` entry must not show a request-style status badge (most importantly, not `Pending`)."

- The actual `extractStatus` fix (return `"none"` when `direction !== "request"`) already landed in `v2/main` via #1438.
- Notification entries (AC #1/#2) were already covered by existing tests.
- Only the fixture and test case for a standalone `response` entry — i.e. the client's reply to a server→client request such as `roots/list` or `sampling` — were missing. This PR adds them.

This is a test-only change (no behavior change) that guards against a regression of the badge logic.

## Test plan

`pnpm --filter @modelcontextprotocol/inspector-web test` — all green, including the new
`renders no request-style status badge for a standalone response entry`.

Closes #1439
