### PR TITLE
fix: preserve OAuth DCR client info

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -285,6 +285,9 @@ const App = () => {
   });
 
   const updateAuthState = (updates: Partial<AuthDebuggerState>) => {
+    if (updates.oauthClientInfo?.client_id) {
+      setOauthClientId(updates.oauthClientInfo.client_id);
+    }
     setAuthState((prev) => ({ ...prev, ...updates }));
   };
 

--- a/client/src/__tests__/App.routing.test.tsx
+++ b/client/src/__tests__/App.routing.test.tsx
@@ -1,4 +1,5 @@
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import App from "../App";
 import { useConnection } from "../lib/hooks/useConnection";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -79,7 +80,35 @@ jest.mock("../lib/hooks/useDraggablePane", () => ({
 
 jest.mock("../components/Sidebar", () => ({
   __esModule: true,
-  default: () => <div>Sidebar</div>,
+  default: ({ oauthClientId }: { oauthClientId: string }) => (
+    <div>
+      <div data-testid="sidebar-oauth-client-id">{oauthClientId}</div>
+    </div>
+  ),
+}));
+
+jest.mock("../components/AuthDebugger", () => ({
+  __esModule: true,
+  default: ({
+    updateAuthState,
+  }: {
+    updateAuthState: (
+      updates: Partial<import("../lib/auth-types").AuthDebuggerState>,
+    ) => void;
+  }) => (
+    <button
+      onClick={() =>
+        updateAuthState({
+          oauthClientInfo: {
+            client_id: "dcr_client_id",
+            redirect_uris: ["http://localhost:3000/oauth/callback/debug"],
+          },
+        })
+      }
+    >
+      simulate dcr client
+    </button>
+  ),
 }));
 
 // Mock fetch
@@ -95,6 +124,8 @@ describe("App - URL Fragment Routing", () => {
 
   beforeEach(() => {
     jest.restoreAllMocks();
+    localStorage.clear();
+    window.location.hash = "";
 
     // Inspector starts disconnected.
     mockUseConnection.mockReturnValue(disconnectedConnectionState);
@@ -156,6 +187,24 @@ describe("App - URL Fragment Routing", () => {
     // Should clear the hash when disconnected
     await waitFor(() => {
       expect(window.location.hash).toBe("");
+    });
+  });
+
+  test("syncs dynamically registered OAuth client ID into the sidebar field", async () => {
+    render(<App />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /open auth settings/i }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /simulate dcr client/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sidebar-oauth-client-id")).toHaveTextContent(
+        "dcr_client_id",
+      );
+      expect(localStorage.getItem("lastOauthClientId")).toBe("dcr_client_id");
     });
   });
 });

--- a/client/src/components/__tests__/AuthDebugger.test.tsx
+++ b/client/src/components/__tests__/AuthDebugger.test.tsx
@@ -683,6 +683,46 @@ describe("AuthDebugger", () => {
     });
   });
 
+  describe("Token Request behavior", () => {
+    it("uses OAuth client information restored with auth state when storage is empty", async () => {
+      sessionStorageMock.getItem.mockImplementation(() => null);
+      mockExchangeAuthorization.mockResolvedValueOnce(mockOAuthTokens);
+
+      const updateAuthState = jest.fn();
+
+      await act(async () => {
+        renderAuthDebugger({
+          updateAuthState,
+          authState: {
+            ...defaultAuthState,
+            isInitiatingAuth: false,
+            oauthStep: "token_request",
+            oauthMetadata: mockOAuthMetadata as unknown as OAuthMetadata,
+            oauthClientInfo: mockOAuthClientInfo,
+            authorizationCode: "test_authorization_code",
+          },
+        });
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Continue"));
+      });
+
+      expect(mockExchangeAuthorization).toHaveBeenCalledWith(
+        defaultProps.serverUrl,
+        expect.objectContaining({
+          metadata: mockOAuthMetadata,
+          clientInformation: mockOAuthClientInfo,
+          authorizationCode: "test_authorization_code",
+        }),
+      );
+      expect(updateAuthState).toHaveBeenCalledWith({
+        oauthTokens: mockOAuthTokens,
+        oauthStep: "complete",
+      });
+    });
+  });
+
   describe("OAuth State Persistence", () => {
     it("should store auth state to sessionStorage before redirect in Quick OAuth Flow", async () => {
       const updateAuthState = jest.fn();

--- a/client/src/lib/oauth-state-machine.ts
+++ b/client/src/lib/oauth-state-machine.ts
@@ -175,16 +175,27 @@ export const oauthTransitions: Record<OAuthStep, StateTransition> = {
 
   token_request: {
     canTransition: async (context) => {
+      const metadata =
+        context.provider.getServerMetadata() ?? context.state.oauthMetadata;
+      const clientInformation =
+        (await context.provider.clientInformation()) ??
+        context.state.oauthClientInfo;
+
       return (
-        !!context.state.authorizationCode &&
-        !!context.provider.getServerMetadata() &&
-        !!(await context.provider.clientInformation())
+        !!context.state.authorizationCode && !!metadata && !!clientInformation
       );
     },
     execute: async (context) => {
       const codeVerifier = context.provider.codeVerifier();
-      const metadata = context.provider.getServerMetadata()!;
-      const clientInformation = (await context.provider.clientInformation())!;
+      const metadata =
+        context.provider.getServerMetadata() ?? context.state.oauthMetadata;
+      const clientInformation =
+        (await context.provider.clientInformation()) ??
+        context.state.oauthClientInfo;
+
+      if (!metadata || !clientInformation) {
+        throw new Error("Missing OAuth metadata or client information");
+      }
 
       const tokens = await exchangeAuthorization(context.serverUrl, {
         metadata,


### PR DESCRIPTION
## Summary

Fixes the OAuth DCR callback flow so dynamically registered client information is kept through token exchange and the returned `client_id` is reflected in the Auth Settings sidebar.

> **Note:** Inspector V2 is under development to address architectural and UX improvements. During this time, V1 contributions should focus on **bug fixes and MCP spec compliance**. See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test updates
- [ ] Build/CI improvements

## Changes Made

- Use OAuth metadata/client information restored with auth debugger state during `token_request` when provider storage is empty on callback.
- Sync the dynamically registered `client_id` into the sidebar/localStorage OAuth Client ID field.
- Add regression coverage for token exchange fallback and Client ID field sync.

## Related Issues

Fixes #910

## Testing

- [ ] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [ ] Manual testing performed

### Test Results and/or Instructions

- `npm test -- --runTestsByPath src/components/__tests__/AuthDebugger.test.tsx src/__tests__/App.routing.test.tsx --runInBand` - 2 suites passed, 25 tests passed
- `npm run lint` - passed
- `npm run build-client` - passed
- `git diff --check HEAD~1 HEAD` - passed

## Checklist

- [x] Code follows the style guidelines (`npm run lint`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (not applicable)

## Breaking Changes

None.

## Additional Context

The issue reports that DCR returns a `client_id`, but the Auth Settings field stays blank and token exchange can run without the registered client information after callback state restoration.
