### PR TITLE
fix: support allOf and oneOf in tool input forms

### DIFF
--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -2,6 +2,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useMemo,
   useRef,
   forwardRef,
   useImperativeHandle,
@@ -10,7 +11,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import JsonEditor from "./JsonEditor";
 import { updateValueAtPath } from "@/utils/jsonUtils";
-import { generateDefaultValue } from "@/utils/schemaUtils";
+import {
+  generateDefaultValue,
+  mergeAllOf,
+  resolveRef,
+} from "@/utils/schemaUtils";
 import type {
   JsonValue,
   JsonSchemaType,
@@ -55,6 +60,44 @@ const isSimpleObject = (schema: JsonSchemaType): boolean => {
   return false;
 };
 
+// A oneOf whose members are full schemas is a variant union rendered with a
+// selector. oneOf members carrying const are titled enum options and keep
+// their existing select rendering, as do schemas that already render on
+// their own (a type other than a property-less object).
+const getVariantOptions = (schema: JsonSchemaType): JsonSchemaType[] | null => {
+  if (!schema.oneOf || schema.oneOf.length === 0) return null;
+  if (schema.oneOf.some((opt) => "const" in opt)) return null;
+  if (schema.type && !(schema.type === "object" && !schema.properties)) {
+    return null;
+  }
+  return schema.oneOf as JsonSchemaType[];
+};
+
+// Picks the variant whose properties best match the keys already present in
+// the value, so an existing value does not silently render the first variant
+const inferVariantIndex = (
+  variants: JsonSchemaType[],
+  value: JsonValue,
+): number | undefined => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const keys = Object.keys(value);
+  if (keys.length === 0) return undefined;
+
+  let bestIdx: number | undefined;
+  let bestScore = 0;
+  variants.forEach((variant, idx) => {
+    const props = variant.properties ?? {};
+    const score = keys.filter((key) => key in props).length;
+    if (score > bestScore) {
+      bestScore = score;
+      bestIdx = idx;
+    }
+  });
+  return bestIdx;
+};
+
 const getArrayItemDefault = (schema: JsonSchemaType): JsonValue => {
   if ("default" in schema && schema.default !== undefined) {
     return schema.default;
@@ -81,13 +124,19 @@ const getArrayItemDefault = (schema: JsonSchemaType): JsonValue => {
 
 const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
   ({ schema, value, onChange, maxDepth = 3 }, ref) => {
+    // Merge allOf branches up front so composed schemas render like flat ones
+    const resolvedSchema = useMemo(() => mergeAllOf(schema), [schema]);
+
     // Determine if we can render a form at the top level.
     // This is more permissive than isSimpleObject():
     // - Objects with any properties are form-capable (individual complex fields may still fallback to JSON)
     // - Arrays with defined items are form-capable
     // - Primitive types are form-capable
+    // - oneOf variant unions are form-capable via the variant selector
     const canRenderTopLevelForm = (s: JsonSchemaType): boolean => {
       const primitiveTypes = ["string", "number", "integer", "boolean", "null"];
+
+      if (getVariantOptions(s)) return true;
 
       const hasType = Array.isArray(s.type) ? s.type.length > 0 : !!s.type;
       if (!hasType) return false;
@@ -114,7 +163,7 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
       return false;
     };
 
-    const isOnlyJSON = !canRenderTopLevelForm(schema);
+    const isOnlyJSON = !canRenderTopLevelForm(resolvedSchema);
     const [isJsonMode, setIsJsonMode] = useState(isOnlyJSON);
     const [jsonError, setJsonError] = useState<string>();
     const [copiedJson, setCopiedJson] = useState<boolean>(false);
@@ -123,10 +172,13 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
     // Store the raw JSON string to allow immediate feedback during typing
     // while deferring parsing until the user stops typing
     const [rawJsonValue, setRawJsonValue] = useState<string>(
-      JSON.stringify(value ?? generateDefaultValue(schema), null, 2),
+      JSON.stringify(value ?? generateDefaultValue(resolvedSchema), null, 2),
     );
     const [numericInputDrafts, setNumericInputDrafts] = useState<
       Record<string, string>
+    >({});
+    const [variantSelections, setVariantSelections] = useState<
+      Record<string, number>
     >({});
 
     // Use a ref to manage debouncing timeouts to avoid parsing JSON
@@ -191,22 +243,26 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
             // Reset to default for clearly invalid JSON (not just incomplete typing)
             const trimmed = jsonString?.trim();
             if (trimmed && trimmed.length > 5 && !trimmed.match(/^[\s[{]/)) {
-              onChange(generateDefaultValue(schema));
+              onChange(generateDefaultValue(resolvedSchema));
             }
           }
         }, 300);
       },
-      [onChange, setJsonError, schema],
+      [onChange, setJsonError, resolvedSchema],
     );
 
     // Update rawJsonValue when value prop changes
     useEffect(() => {
       if (!isJsonMode) {
         setRawJsonValue(
-          JSON.stringify(value ?? generateDefaultValue(schema), null, 2),
+          JSON.stringify(
+            value ?? generateDefaultValue(resolvedSchema),
+            null,
+            2,
+          ),
         );
       }
-    }, [value, schema, isJsonMode]);
+    }, [value, resolvedSchema, isJsonMode]);
 
     const handleSwitchToFormMode = () => {
       if (isJsonMode) {
@@ -223,7 +279,11 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
       } else {
         // Update raw JSON value when switching to JSON mode
         setRawJsonValue(
-          JSON.stringify(value ?? generateDefaultValue(schema), null, 2),
+          JSON.stringify(
+            value ?? generateDefaultValue(resolvedSchema),
+            null,
+            2,
+          ),
         );
         setIsJsonMode(true);
       }
@@ -302,7 +362,81 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
       depth: number = 0,
       parentSchema?: JsonSchemaType,
       propertyName?: string,
+      variantDepth: number = 0,
     ) => {
+      if (propSchema.allOf) {
+        propSchema = mergeAllOf(propSchema, resolvedSchema);
+      }
+
+      const variants = getVariantOptions(propSchema);
+      if (variants) {
+        // variantDepth keeps directly nested selectors (a variant that is
+        // itself a oneOf) from sharing one state slot at the same path
+        const selectorKey = `${variantDepth}:${getPathKey(path)}`;
+        const selectedIdx = Math.min(
+          variantSelections[selectorKey] ??
+            inferVariantIndex(variants, currentValue) ??
+            0,
+          variants.length - 1,
+        );
+        const resolveVariant = (idx: number): JsonSchemaType => {
+          const variant = mergeAllOf(
+            resolveRef(variants[idx] ?? {}, resolvedSchema),
+            resolvedSchema,
+          );
+          // properties without an explicit type is a common object shorthand
+          if (!variant.type && variant.properties) {
+            return { ...variant, type: "object" };
+          }
+          return variant;
+        };
+        return (
+          <div className="space-y-2">
+            {propSchema.description && (
+              <p className="text-sm text-gray-600">{propSchema.description}</p>
+            )}
+            <select
+              value={selectedIdx}
+              onChange={(e) => {
+                const idx = Number(e.target.value);
+                setVariantSelections((prev) => ({
+                  ...prev,
+                  [selectorKey]: idx,
+                }));
+                // Values from another variant rarely validate, so reset
+                handleFieldChange(
+                  path,
+                  generateDefaultValue(
+                    resolveVariant(idx),
+                    propertyName,
+                    parentSchema,
+                  ),
+                );
+              }}
+              aria-label={
+                propertyName ? `Select ${propertyName} option` : "Select option"
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+            >
+              {variants.map((option, idx) => (
+                <option key={idx} value={idx}>
+                  {option.title ?? `Option ${idx + 1}`}
+                </option>
+              ))}
+            </select>
+            {renderFormFields(
+              resolveVariant(selectedIdx),
+              currentValue,
+              path,
+              depth,
+              parentSchema,
+              propertyName,
+              variantDepth + 1,
+            )}
+          </div>
+        );
+      }
+
       if (
         depth >= maxDepth &&
         (propSchema.type === "object" || propSchema.type === "array")
@@ -347,8 +481,7 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
           // Titled single-select using oneOf/anyOf with const/title pairs
           const titledOptions = (
             (propSchema.oneOf ?? propSchema.anyOf) as
-              | (JsonSchemaType | JsonSchemaConst)[]
-              | undefined
+              (JsonSchemaType | JsonSchemaConst)[] | undefined
           )?.filter((opt): opt is JsonSchemaConst => "const" in opt);
 
           if (titledOptions && titledOptions.length > 0) {
@@ -606,8 +739,7 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
 
           const titledMulti = (
             (itemSchema.anyOf ?? itemSchema.oneOf) as
-              | (JsonSchemaType | JsonSchemaConst)[]
-              | undefined
+              (JsonSchemaType | JsonSchemaConst)[] | undefined
           )?.filter((opt): opt is JsonSchemaConst => "const" in opt);
 
           if (titledMulti && titledMulti.length > 0) {
@@ -766,8 +898,10 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
     };
 
     const shouldUseJsonMode =
-      schema.type === "object" &&
-      (!schema.properties || Object.keys(schema.properties).length === 0);
+      resolvedSchema.type === "object" &&
+      (!resolvedSchema.properties ||
+        Object.keys(resolvedSchema.properties).length === 0) &&
+      !getVariantOptions(resolvedSchema);
 
     useEffect(() => {
       if (shouldUseJsonMode && !isJsonMode) {
@@ -825,11 +959,11 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
               debouncedUpdateParent(newValue);
             }}
             error={jsonError}
-            placeholder={schema.description}
+            placeholder={resolvedSchema.description}
           />
         ) : // If schema type is object but value is not an object or is empty, and we have actual JSON data,
         // render a simple representation of the JSON data
-        schema.type === "object" &&
+        resolvedSchema.type === "object" &&
           (typeof value !== "object" ||
             value === null ||
             Object.keys(value).length === 0) &&
@@ -848,7 +982,7 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
             </p>
           </div>
         ) : (
-          renderFormFields(schema, value)
+          renderFormFields(resolvedSchema, value)
         )}
       </div>
     );

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -17,6 +17,7 @@ import type { JsonValue, JsonSchemaType } from "@/utils/jsonUtils";
 import {
   generateDefaultValue,
   isPropertyRequired,
+  mergeAllOf,
   normalizeUnionType,
   resolveRef,
 } from "@/utils/schemaUtils";
@@ -225,23 +226,27 @@ const ToolsTab = ({
   };
 
   useEffect(() => {
-    const params = Object.entries(
-      selectedTool?.inputSchema.properties ?? [],
-    ).map(([key, value]) => {
-      // First resolve any $ref references
-      const resolvedValue = resolveRef(
-        value as JsonSchemaType,
-        selectedTool?.inputSchema as JsonSchemaType,
-      );
-      return [
-        key,
-        generateDefaultValue(
-          resolvedValue,
+    // Merge allOf branches so composed schemas expose their properties
+    const inputSchema = selectedTool
+      ? mergeAllOf(selectedTool.inputSchema as JsonSchemaType)
+      : undefined;
+    const params = Object.entries(inputSchema?.properties ?? []).map(
+      ([key, value]) => {
+        // First resolve any $ref references
+        const resolvedValue = resolveRef(
+          value as JsonSchemaType,
+          inputSchema as JsonSchemaType,
+        );
+        return [
           key,
-          selectedTool?.inputSchema as JsonSchemaType,
-        ),
-      ];
-    });
+          generateDefaultValue(
+            mergeAllOf(resolvedValue, inputSchema),
+            key,
+            inputSchema as JsonSchemaType,
+          ),
+        ];
+      },
+    );
     setParams(Object.fromEntries(params));
     const toolTaskSupport = serverSupportsTaskRequests
       ? getTaskSupport(selectedTool)
@@ -273,6 +278,11 @@ const ToolsTab = ({
   const taskSupport = serverSupportsTaskRequests
     ? getTaskSupport(selectedTool)
     : "forbidden";
+
+  // Merge allOf branches so composed schemas expose their properties
+  const inputSchema = selectedTool
+    ? mergeAllOf(selectedTool.inputSchema as JsonSchemaType)
+    : undefined;
 
   return (
     <TabsContent value="tools">
@@ -343,19 +353,24 @@ const ToolsTab = ({
                       : undefined
                   }
                 />
-                {Object.entries(selectedTool.inputSchema.properties ?? []).map(
+                {Object.entries(inputSchema?.properties ?? []).map(
                   ([key, value]) => {
                     // First resolve any $ref references
                     const resolvedValue = resolveRef(
                       value as JsonSchemaType,
-                      selectedTool.inputSchema as JsonSchemaType,
+                      inputSchema as JsonSchemaType,
                     );
-                    const prop = normalizeUnionType(resolvedValue);
-                    const inputSchema =
-                      selectedTool.inputSchema as JsonSchemaType;
-                    const required = isPropertyRequired(key, inputSchema);
+                    const prop = normalizeUnionType(
+                      mergeAllOf(resolvedValue, inputSchema),
+                    );
+                    const required = isPropertyRequired(
+                      key,
+                      inputSchema as JsonSchemaType,
+                    );
+                    // Key by tool too, so form state never leaks between
+                    // tools that share a property name
                     return (
-                      <div key={key}>
+                      <div key={`${selectedTool.name}-${key}`}>
                         <div className="flex justify-between">
                           <Label
                             htmlFor={key}
@@ -500,6 +515,8 @@ const ToolsTab = ({
                                   properties: prop.properties,
                                   description: prop.description,
                                   items: prop.items,
+                                  required: prop.required,
+                                  oneOf: prop.oneOf,
                                 }}
                                 value={
                                   (params[key] as JsonValue) ??
@@ -563,6 +580,8 @@ const ToolsTab = ({
                                   properties: prop.properties,
                                   description: prop.description,
                                   items: prop.items,
+                                  required: prop.required,
+                                  oneOf: prop.oneOf,
                                 }}
                                 value={params[key] as JsonValue}
                                 onChange={(newValue: JsonValue) => {

--- a/client/src/components/__tests__/DynamicJsonForm.test.tsx
+++ b/client/src/components/__tests__/DynamicJsonForm.test.tsx
@@ -994,3 +994,228 @@ describe("DynamicJsonForm Validation Functionality", () => {
     });
   });
 });
+
+describe("DynamicJsonForm allOf Fields", () => {
+  it("should render form fields for an allOf composed object schema", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      allOf: [
+        { properties: { name: { type: "string" } }, required: ["name"] },
+        { properties: { count: { type: "integer" } } },
+      ],
+    };
+    render(<DynamicJsonForm schema={schema} value={{}} onChange={jest.fn()} />);
+
+    expect(screen.getByText("name")).toBeInTheDocument();
+    expect(screen.getByText("count")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton")).toBeInTheDocument();
+  });
+
+  it("should update values for fields merged from allOf branches", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      allOf: [{ properties: { name: { type: "string" } }, required: ["name"] }],
+    };
+    const onChange = jest.fn();
+    render(<DynamicJsonForm schema={schema} value={{}} onChange={onChange} />);
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "hello" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({ name: "hello" });
+  });
+
+  it("should render nested allOf property schemas as forms", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      properties: {
+        config: {
+          allOf: [
+            {
+              type: "object",
+              properties: { mode: { type: "string" } },
+              required: ["mode"],
+            },
+          ],
+        },
+      },
+    };
+    render(<DynamicJsonForm schema={schema} value={{}} onChange={jest.fn()} />);
+
+    expect(screen.getByText("config")).toBeInTheDocument();
+    expect(screen.getByText("mode")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+});
+
+describe("DynamicJsonForm oneOf Variant Fields", () => {
+  const variantSchema: JsonSchemaType = {
+    oneOf: [
+      {
+        title: "Email",
+        type: "object",
+        properties: { email: { type: "string" } },
+        required: ["email"],
+      },
+      {
+        title: "Phone",
+        type: "object",
+        properties: { phone: { type: "string" } },
+        required: ["phone"],
+      },
+    ],
+  };
+
+  it("should render a selector listing each variant by title", () => {
+    render(
+      <DynamicJsonForm
+        schema={variantSchema}
+        value={{}}
+        onChange={jest.fn()}
+      />,
+    );
+
+    const options = screen.getAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual(["Email", "Phone"]);
+  });
+
+  it("should render the first variant's fields by default", () => {
+    render(
+      <DynamicJsonForm
+        schema={variantSchema}
+        value={{}}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("email")).toBeInTheDocument();
+    expect(screen.queryByText("phone")).not.toBeInTheDocument();
+  });
+
+  it("should switch fields and reset the value when another variant is selected", () => {
+    const onChange = jest.fn();
+    render(
+      <DynamicJsonForm schema={variantSchema} value={{}} onChange={onChange} />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "1" } });
+
+    expect(screen.getByText("phone")).toBeInTheDocument();
+    expect(screen.queryByText("email")).not.toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith({ phone: "" });
+  });
+
+  it("should label untitled variants by position", () => {
+    const schema: JsonSchemaType = {
+      oneOf: [
+        { type: "object", properties: { a: { type: "string" } } },
+        { type: "object", properties: { b: { type: "string" } } },
+      ],
+    };
+    render(<DynamicJsonForm schema={schema} value={{}} onChange={jest.fn()} />);
+
+    const options = screen.getAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual(["Option 1", "Option 2"]);
+  });
+
+  it("should render a variant selector for oneOf nested in a property", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      properties: {
+        contact: variantSchema,
+      },
+    };
+    render(<DynamicJsonForm schema={schema} value={{}} onChange={jest.fn()} />);
+
+    expect(screen.getByText("contact")).toBeInTheDocument();
+    const options = screen.getAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual(["Email", "Phone"]);
+  });
+});
+
+describe("DynamicJsonForm oneOf Variant Edge Cases", () => {
+  const variantSchema: JsonSchemaType = {
+    oneOf: [
+      {
+        title: "Email",
+        type: "object",
+        properties: { email: { type: "string" } },
+        required: ["email"],
+      },
+      {
+        title: "Phone",
+        type: "object",
+        properties: { phone: { type: "string" } },
+        required: ["phone"],
+      },
+    ],
+  };
+
+  it("should render fields for variants that omit type but define properties", () => {
+    const schema: JsonSchemaType = {
+      oneOf: [
+        { title: "A", properties: { alpha: { type: "string" } } },
+        { title: "B", properties: { beta: { type: "string" } } },
+      ],
+    };
+    render(<DynamicJsonForm schema={schema} value={{}} onChange={jest.fn()} />);
+
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("should open on the variant matching the existing value", () => {
+    render(
+      <DynamicJsonForm
+        schema={variantSchema}
+        value={{ phone: "555-1234" }}
+        onChange={jest.fn()}
+      />,
+    );
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("1");
+    expect(screen.getByText("phone")).toBeInTheDocument();
+    expect(screen.queryByText("email")).not.toBeInTheDocument();
+  });
+
+  it("should keep directly nested variant selectors independent", () => {
+    const schema: JsonSchemaType = {
+      oneOf: [
+        {
+          title: "Composite",
+          oneOf: [
+            {
+              title: "Inner A",
+              type: "object",
+              properties: { a: { type: "string" } },
+            },
+            {
+              title: "Inner B",
+              type: "object",
+              properties: { b: { type: "string" } },
+            },
+          ],
+        },
+        {
+          title: "Simple",
+          type: "object",
+          properties: { s: { type: "string" } },
+        },
+      ],
+    };
+    render(<DynamicJsonForm schema={schema} value={{}} onChange={jest.fn()} />);
+
+    const selects = screen.getAllByRole("combobox") as HTMLSelectElement[];
+    expect(selects).toHaveLength(2);
+
+    fireEvent.change(selects[1], { target: { value: "1" } });
+
+    const updated = screen.getAllByRole("combobox") as HTMLSelectElement[];
+    expect(updated[0].value).toBe("0");
+    expect(updated[1].value).toBe("1");
+    expect(screen.getByText("b")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/client/src/components/__tests__/ToolsTab.test.tsx
@@ -215,6 +215,117 @@ describe("ToolsTab", () => {
     );
   });
 
+  it("should render fields for a tool whose inputSchema uses allOf", async () => {
+    const allOfTool: Tool = {
+      name: "allOfTool",
+      description: "Tool with allOf schema",
+      inputSchema: {
+        type: "object" as const,
+        required: ["operation"],
+        allOf: [
+          {
+            properties: {
+              operation: { type: "string" as const },
+              count: { type: "number" as const },
+            },
+            required: ["count"],
+          },
+        ],
+      } as Tool["inputSchema"],
+    };
+    renderToolsTab({ tools: [allOfTool], selectedTool: allOfTool });
+
+    expect(screen.getByText("operation")).toBeInTheDocument();
+    expect(screen.getByText("count")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton")).toBeInTheDocument();
+    // required merges from both the schema and its allOf branch
+    expect(screen.getAllByText("*")).toHaveLength(2);
+  });
+
+  it("should render a variant selector for a oneOf property", async () => {
+    const oneOfTool: Tool = {
+      name: "oneOfTool",
+      description: "Tool with oneOf property",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          target: {
+            oneOf: [
+              {
+                title: "By id",
+                type: "object",
+                properties: { id: { type: "string" } },
+              },
+              {
+                title: "By name",
+                type: "object",
+                properties: { name: { type: "string" } },
+              },
+            ],
+          },
+        },
+      } as Tool["inputSchema"],
+    };
+    renderToolsTab({ tools: [oneOfTool], selectedTool: oneOfTool });
+
+    const options = screen.getAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual(["By id", "By name"]);
+    expect(screen.getByText("id")).toBeInTheDocument();
+  });
+
+  it("should not leak variant selection between tools sharing a property name", async () => {
+    const makeTool = (name: string, titles: [string, string]): Tool => ({
+      name,
+      description: `${name} description`,
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          config: {
+            oneOf: [
+              {
+                title: titles[0],
+                type: "object",
+                properties: { a: { type: "string" } },
+              },
+              {
+                title: titles[1],
+                type: "object",
+                properties: { b: { type: "string" } },
+              },
+            ],
+          },
+        },
+      } as Tool["inputSchema"],
+    });
+    const toolOne = makeTool("toolOne", ["One A", "One B"]);
+    const toolTwo = makeTool("toolTwo", ["Two A", "Two B"]);
+
+    const { rerender } = renderToolsTab({
+      tools: [toolOne, toolTwo],
+      selectedTool: toolOne,
+    });
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    await act(async () => {
+      fireEvent.change(select, { target: { value: "1" } });
+    });
+    expect(select.value).toBe("1");
+
+    rerender(
+      <Tabs defaultValue="tools">
+        <ToolsTab
+          {...defaultProps}
+          tools={[toolOne, toolTwo]}
+          selectedTool={toolTwo}
+        />
+      </Tabs>,
+    );
+
+    const newSelect = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(newSelect.value).toBe("0");
+  });
+
   it("should allow typing negative numbers", async () => {
     renderToolsTab({
       selectedTool: mockTools[0],

--- a/client/src/utils/__tests__/schemaUtils.test.ts
+++ b/client/src/utils/__tests__/schemaUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   generateDefaultValue,
   formatFieldLabel,
+  mergeAllOf,
   normalizeUnionType,
   cacheToolOutputSchemas,
   getToolOutputValidator,
@@ -600,5 +601,138 @@ describe("Output Schema Validation", () => {
     test("returns false for non-existent tools", () => {
       expect(hasOutputSchema("nonExistentTool")).toBe(false);
     });
+  });
+});
+
+describe("mergeAllOf", () => {
+  test("returns a schema without allOf unchanged", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      properties: { name: { type: "string" } },
+    };
+    expect(mergeAllOf(schema)).toBe(schema);
+  });
+
+  test("merges properties and required from an allOf branch", () => {
+    // Shape from issue #496: properties live only inside allOf
+    const schema: JsonSchemaType = {
+      type: "object",
+      required: ["operation"],
+      allOf: [
+        {
+          properties: {
+            operation: { type: "string" },
+            verbose: { type: "boolean" },
+          },
+          required: ["verbose"],
+        },
+      ],
+    };
+
+    const merged = mergeAllOf(schema);
+
+    expect(merged.allOf).toBeUndefined();
+    expect(merged.type).toBe("object");
+    expect(Object.keys(merged.properties ?? {}).sort()).toEqual([
+      "operation",
+      "verbose",
+    ]);
+    expect(merged.required).toEqual(
+      expect.arrayContaining(["operation", "verbose"]),
+    );
+  });
+
+  test("combines properties across multiple branches", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      allOf: [
+        { properties: { first: { type: "string" } }, required: ["first"] },
+        { properties: { second: { type: "number" } }, required: ["second"] },
+      ],
+    };
+
+    const merged = mergeAllOf(schema);
+
+    expect(Object.keys(merged.properties ?? {}).sort()).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(merged.required?.sort()).toEqual(["first", "second"]);
+  });
+
+  test("keeps the schema's own keywords over branch values", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      description: "own description",
+      allOf: [{ type: "string", description: "branch description" }],
+    };
+
+    const merged = mergeAllOf(schema);
+
+    expect(merged.type).toBe("object");
+    expect(merged.description).toBe("own description");
+  });
+
+  test("flattens allOf nested inside a branch", () => {
+    const schema: JsonSchemaType = {
+      type: "object",
+      allOf: [{ allOf: [{ properties: { inner: { type: "string" } } }] }],
+    };
+
+    expect(mergeAllOf(schema).properties).toHaveProperty("inner");
+  });
+
+  test("resolves $ref branches against the root schema", () => {
+    const schema = {
+      type: "object",
+      allOf: [{ $ref: "#/$defs/base" }],
+      $defs: {
+        base: {
+          properties: { name: { type: "string" } },
+          required: ["name"],
+        },
+      },
+    } as JsonSchemaType;
+
+    const merged = mergeAllOf(schema);
+
+    expect(merged.properties).toHaveProperty("name");
+    expect(merged.required).toEqual(["name"]);
+  });
+});
+
+describe("mergeAllOf circular references", () => {
+  test("does not recurse forever on circular $ref chains in allOf", () => {
+    const schema = {
+      type: "object",
+      allOf: [{ $ref: "#/$defs/a" }],
+      $defs: {
+        a: {
+          properties: { fromA: { type: "string" } },
+          allOf: [{ $ref: "#/$defs/b" }],
+        },
+        b: {
+          properties: { fromB: { type: "string" } },
+          allOf: [{ $ref: "#/$defs/a" }],
+        },
+      },
+    } as JsonSchemaType;
+
+    const merged = mergeAllOf(schema);
+
+    expect(merged.properties).toHaveProperty("fromA");
+    expect(merged.properties).toHaveProperty("fromB");
+  });
+
+  test("allows sibling branches to reference the same definition", () => {
+    const schema = {
+      type: "object",
+      allOf: [{ $ref: "#/$defs/shared" }, { $ref: "#/$defs/shared" }],
+      $defs: {
+        shared: { properties: { common: { type: "string" } } },
+      },
+    } as JsonSchemaType;
+
+    expect(mergeAllOf(schema).properties).toHaveProperty("common");
   });
 });

--- a/client/src/utils/jsonUtils.ts
+++ b/client/src/utils/jsonUtils.ts
@@ -51,6 +51,7 @@ export type JsonSchemaType = {
   // Non-standard legacy support: titles for enum values
   enumNames?: string[];
   const?: JsonValue;
+  allOf?: JsonSchemaType[];
   oneOf?: (JsonSchemaType | JsonSchemaConst)[];
   anyOf?: (JsonSchemaType | JsonSchemaConst)[];
   $ref?: string;

--- a/client/src/utils/schemaUtils.ts
+++ b/client/src/utils/schemaUtils.ts
@@ -230,6 +230,62 @@ export function resolveRef(
 }
 
 /**
+ * Merges allOf branches into a single flat schema for form rendering.
+ * Properties from all branches are combined, required arrays are unioned,
+ * and for other keywords the schema's own values win over branch values
+ * (earlier branches win over later ones).
+ * @param schema The schema that may contain allOf
+ * @param rootSchema The root schema to resolve $ref branches against
+ * @param visitedRefs Set of visited $ref paths to detect circular references
+ * @returns A flattened schema without allOf
+ */
+export function mergeAllOf(
+  schema: JsonSchemaType,
+  rootSchema: JsonSchemaType = schema,
+  visitedRefs: Set<string> = new Set(),
+): JsonSchemaType {
+  if (!Array.isArray(schema.allOf)) {
+    return schema;
+  }
+
+  const { allOf, ...base } = schema;
+  let merged: JsonSchemaType = base;
+
+  for (const branch of allOf) {
+    if (typeof branch !== "object" || branch === null) {
+      continue;
+    }
+    // Each branch gets its own copy so sibling branches can share refs
+    // while circular chains through nested allOf still terminate
+    const branchRefs = new Set(visitedRefs);
+    const resolvedBranch = resolveRef(branch, rootSchema, branchRefs);
+    if (resolvedBranch.$ref) {
+      continue;
+    }
+    const resolved = mergeAllOf(resolvedBranch, rootSchema, branchRefs);
+    const properties =
+      merged.properties || resolved.properties
+        ? { ...resolved.properties, ...merged.properties }
+        : undefined;
+    const required =
+      merged.required || resolved.required
+        ? Array.from(
+            new Set([...(merged.required ?? []), ...(resolved.required ?? [])]),
+          )
+        : undefined;
+    merged = { ...resolved, ...merged };
+    if (properties) {
+      merged.properties = properties;
+    }
+    if (required) {
+      merged.required = required;
+    }
+  }
+
+  return merged;
+}
+
+/**
  * Normalizes union types (like string|null from FastMCP) to simple types for form rendering
  * @param schema The JSON schema to normalize
  * @returns A normalized schema or the original schema


### PR DESCRIPTION
## Summary

Tool input schemas that compose their properties with `allOf` rendered an empty form, because both `ToolsTab` and `DynamicJsonForm` only look at top-level `properties`. `oneOf` unions of full schemas rendered nothing at all. This makes both work.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `client/src/utils/schemaUtils.ts` adds `mergeAllOf()`, which flattens `allOf` branches before a form renders. Properties are merged, `required` arrays are unioned, `$ref` branches resolve against the root schema, and circular ref chains terminate.
- `client/src/components/ToolsTab.tsx` merges the input schema before iterating its properties, passes `required` and `oneOf` through to nested forms (both were dropped when the schema object was rebuilt), and keys per-property form state by tool name so state cannot leak between tools that share a property name.
- `client/src/components/DynamicJsonForm.tsx` merges `allOf` at the top level and per property, and renders a variant selector for `oneOf` members that are full schemas. The selector infers the initial variant from the current value, keeps nested selectors independent, and treats `properties`-without-`type` members as objects. Options carrying `const` keep the existing titled enum select from #952 untouched.
- `client/src/utils/jsonUtils.ts` adds `allOf` to `JsonSchemaType`.

## Related Issues

Fixes #496

## Testing

- [x] Added/updated automated tests

### Test Results and/or Instructions

22 new tests across `schemaUtils.test.ts`, `DynamicJsonForm.test.tsx`, and `ToolsTab.test.tsx`, including the exact schema shape from the issue. Full client suite passes (557 tests, 32 suites) and the Playwright e2e suite passes.

To see the original bug, point the inspector at a server whose tool wraps `properties` in a top-level `allOf` (the schema in #496). On main the tool form renders no fields; on this branch the fields render with their required markers.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None.

## Additional Context

`resolveRef` still only recurses into `anyOf`, so `$ref` support inside `oneOf` branches beyond what the variant selector resolves stays with #445.
