### PR TITLE
refactor: migrate to RemoteOAuthStorage for web OAuth handling

### DIFF
--- a/clients/tui/src/App.tsx
+++ b/clients/tui/src/App.tsx
@@ -896,7 +896,7 @@ function App({
 
   const handleClearOAuth = useCallback(async () => {
     if (!selectedInspectorClient) return;
-    selectedInspectorClient.clearOAuthTokens();
+    await selectedInspectorClient.clearOAuthTokens();
     setOauthStatus("idle");
     setOauthMessage(null);
     setConnectError(null);

--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -86,7 +86,7 @@ import { useServers } from "@inspector/core/react/useServers.js";
 import { useSettingsDraft } from "@inspector/core/react/useSettingsDraft.js";
 import { useClientSettingsDraft } from "@inspector/core/react/useClientSettingsDraft.js";
 import { useEmaIdpLoginState } from "@inspector/core/react/useEmaIdpLoginState.js";
-import { getBrowserOAuthStorage } from "@inspector/core/auth/browser/index.js";
+import { getWebRemoteOAuthStorage } from "./lib/remoteOAuthStorage";
 import { useManagedTools } from "@inspector/core/react/useManagedTools.js";
 import { useManagedPrompts } from "@inspector/core/react/useManagedPrompts.js";
 import { useManagedResources } from "@inspector/core/react/useManagedResources.js";
@@ -1428,6 +1428,13 @@ function App() {
     [messages],
   );
 
+  // Shared OAuth runtime store (oauth.json via /api/storage/oauth). Memoized so
+  // connect, EMA IdP session, and per-server clear share one in-memory view.
+  const webOAuthStorage = useMemo(
+    () => getWebRemoteOAuthStorage(getAuthToken()),
+    [],
+  );
+
   // Backend-backed session storage used to carry the fetch (Network) log
   // across the OAuth full-page redirect. The auth handshake's first half —
   // protected-resource + auth-server discovery and Dynamic Client
@@ -2098,9 +2105,10 @@ function App() {
   // `onToggleConnection` unloaded the previous one), so all React state is
   // reset and we recover the initiating server from sessionStorage. We wait for
   // `servers` to hydrate before acting; the ref guard keeps the exchange to a
-  // single run. The persisted PKCE verifier + DCR client info live in
-  // `BrowserOAuthStorage` and survive the redirect, so `completeOAuthFlow`
-  // exchanges the code without needing the original in-memory state machine.
+  // single run. The persisted PKCE verifier + DCR client info live in shared
+  // `RemoteOAuthStorage` (`oauth.json`) and survive the redirect, so
+  // `completeOAuthFlow` exchanges the code without needing the original
+  // in-memory state machine.
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (window.location.pathname !== OAUTH_CALLBACK_PATH) return;
@@ -3239,10 +3247,9 @@ function App() {
 
   const clientSettingsModalValue = clientSettingsDraft ?? EMPTY_CLIENT_SETTINGS;
 
-  const emaOAuthStorage = useMemo(() => getBrowserOAuthStorage(), []);
   const { loginState: emaIdpLoginState, logout: logoutEmaIdp } =
     useEmaIdpLoginState(
-      emaOAuthStorage,
+      webOAuthStorage,
       clientSettingsModalValue.emaEnabled
         ? clientSettingsModalValue.issuer
         : undefined,
@@ -3270,6 +3277,7 @@ function App() {
         config: server.config,
         inspectorClient: isActive ? inspectorClient : null,
         isActiveConnection: isActive,
+        oauthStorage: webOAuthStorage,
       });
       if (!cleared) return;
 
@@ -3295,6 +3303,7 @@ function App() {
     [
       activeServerId,
       inspectorClient,
+      webOAuthStorage,
       finalizeExplicitDisconnect,
       clearOAuthResumeOnExplicitDisconnect,
     ],

--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -2191,7 +2191,15 @@ function App() {
     }
 
     void (async () => {
-      await webOAuthStorage.load();
+      try {
+        await webOAuthStorage.load();
+      } catch (err) {
+        connectStartRef.current = undefined;
+        queueMicrotask(() => {
+          showReAuthBanner(server.id, err instanceof Error ? err : String(err));
+        });
+        return;
+      }
       const client = setupClientForServer(server, sessionId);
       setActiveServerId(server.id);
       try {

--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -2191,6 +2191,7 @@ function App() {
     }
 
     void (async () => {
+      await webOAuthStorage.load();
       const client = setupClientForServer(server, sessionId);
       setActiveServerId(server.id);
       try {
@@ -2246,7 +2247,7 @@ function App() {
         });
       }
     })();
-  }, [servers, setupClientForServer, showReAuthBanner]);
+  }, [servers, setupClientForServer, showReAuthBanner, webOAuthStorage]);
 
   const onToggleConnection = useCallback(
     async (id: string) => {
@@ -3273,7 +3274,7 @@ function App() {
   const clearServerOAuthAndDisconnect = useCallback(
     async (server: { id: string; name: string; config: MCPServerConfig }) => {
       const isActive = server.id === activeServerId;
-      const cleared = clearServerOAuthState({
+      const cleared = await clearServerOAuthState({
         config: server.config,
         inspectorClient: isActive ? inspectorClient : null,
         isActiveConnection: isActive,

--- a/clients/web/src/lib/environmentFactory.test.ts
+++ b/clients/web/src/lib/environmentFactory.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BrowserNavigation } from "@inspector/core/auth/browser/index.js";
+import { MutableRedirectUrlProvider } from "@inspector/core/auth/providers.js";
+import { createWebEnvironment } from "./environmentFactory";
+import {
+  getWebRemoteOAuthStorage,
+  resetWebRemoteOAuthStorageCacheForTests,
+} from "./remoteOAuthStorage";
+
+describe("createWebEnvironment", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window", {
+      location: {
+        protocol: "http:",
+        host: "127.0.0.1:6299",
+      },
+    });
+  });
+
+  afterEach(() => {
+    resetWebRemoteOAuthStorageCacheForTests();
+    vi.unstubAllGlobals();
+  });
+
+  it("wires RemoteOAuthStorage shared with getWebRemoteOAuthStorage", () => {
+    const redirectUrlProvider = new MutableRedirectUrlProvider();
+    const first = createWebEnvironment("unit-test-token", redirectUrlProvider);
+    const second = createWebEnvironment("unit-test-token", redirectUrlProvider);
+
+    expect(first.environment.oauth).toBeDefined();
+    expect(second.environment.oauth).toBeDefined();
+    expect(second.environment.oauth!.storage).toBe(
+      first.environment.oauth!.storage,
+    );
+    expect(first.environment.oauth!.storage).toBe(
+      getWebRemoteOAuthStorage("unit-test-token"),
+    );
+  });
+
+  it("uses BrowserNavigation for oauth.navigation", () => {
+    const { environment } = createWebEnvironment(
+      undefined,
+      new MutableRedirectUrlProvider(),
+    );
+    expect(environment.oauth).toBeDefined();
+    expect(environment.oauth!.navigation).toBeInstanceOf(BrowserNavigation);
+  });
+
+  it("returns the same logger instance as environment.logger", () => {
+    const { environment, logger } = createWebEnvironment(
+      "tok",
+      new MutableRedirectUrlProvider(),
+    );
+    expect(logger).toBe(environment.logger);
+  });
+
+  it("passes redirectUrlProvider into oauth config", () => {
+    const redirectUrlProvider = new MutableRedirectUrlProvider();
+    redirectUrlProvider.redirectUrl = "http://127.0.0.1:6299/oauth/callback";
+    const { environment } = createWebEnvironment("tok", redirectUrlProvider);
+    if (!environment.oauth) {
+      throw new Error("expected oauth config");
+    }
+    const { redirectUrlProvider: oauthRedirect } = environment.oauth;
+    if (!oauthRedirect) {
+      throw new Error("expected redirectUrlProvider");
+    }
+    expect(oauthRedirect.getRedirectUrl()).toBe(
+      "http://127.0.0.1:6299/oauth/callback",
+    );
+  });
+
+  it("forwards onBeforeOAuthRedirect to BrowserNavigation", () => {
+    const onBeforeOAuthRedirect = vi.fn<(authorizationUrl: URL) => void>();
+    const { environment } = createWebEnvironment(
+      "tok",
+      new MutableRedirectUrlProvider(),
+      onBeforeOAuthRedirect,
+    );
+    if (!environment.oauth) {
+      throw new Error("expected oauth config");
+    }
+    const { navigation } = environment.oauth;
+    if (!navigation) {
+      throw new Error("expected navigation");
+    }
+    const authUrl = new URL("https://idp.example/authorize?state=abc");
+    navigation.navigateToAuthorization(authUrl);
+    expect(onBeforeOAuthRedirect).toHaveBeenCalledWith(authUrl);
+  });
+
+  it("routes fetch through the wrapped global fetch at the window origin", async () => {
+    const remoteBody = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "text/plain" },
+      body: "echoed",
+    };
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(
+      async () =>
+        new Response(JSON.stringify(remoteBody), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { environment } = createWebEnvironment(
+      "api-tok",
+      new MutableRedirectUrlProvider(),
+    );
+    fetchMock.mockClear();
+
+    const res = await environment.fetch!("http://upstream.test/mcp");
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("echoed");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "http://127.0.0.1:6299/api/fetch",
+    );
+  });
+});

--- a/clients/web/src/lib/environmentFactory.ts
+++ b/clients/web/src/lib/environmentFactory.ts
@@ -4,11 +4,9 @@ import {
   createRemoteFetch,
   createRemoteLogger,
 } from "@inspector/core/mcp/remote/index.js";
-import {
-  getBrowserOAuthStorage,
-  BrowserNavigation,
-} from "@inspector/core/auth/browser/index.js";
+import { BrowserNavigation } from "@inspector/core/auth/browser/index.js";
 import type { RedirectUrlProvider } from "@inspector/core/auth/index.js";
+import { getWebRemoteOAuthStorage } from "./remoteOAuthStorage.js";
 
 export interface WebEnvironmentResult {
   environment: InspectorClientEnvironment;
@@ -20,16 +18,17 @@ export interface WebEnvironmentResult {
  *   - transport / fetch / logger all routed through the in-process Hono
  *     backend at `window.location.origin` (the `clients/web/server`
  *     dev-backend wires this in `/api/*`).
- *   - OAuth storage + navigation use the `BrowserOAuthStorage` (sessionStorage)
- *     and `BrowserNavigation` (full-page redirect) adapters.
+ *   - OAuth storage uses `RemoteOAuthStorage` (shared `oauth.json` via
+ *     `/api/storage/oauth`); navigation uses `BrowserNavigation`.
  *
  * Returns both the assembled environment and the logger so callers can share
  * the same pino instance for any direct logging they need to do, instead of
  * reaching back through the client.
  *
- * `authToken` is read from a higher level (currently unused in this app since
- * v2 has no auth-token UI yet, but kept in the signature so the wiring is
- * ready when token plumbing lands).
+ * `authToken` is supplied by `App.tsx` (`getAuthToken()`) and forwarded to
+ * remote transport/fetch/logger and `getWebRemoteOAuthStorage` so every
+ * `/api/*` call (including `/api/storage/oauth`) carries `x-mcp-remote-auth`
+ * when the backend requires it.
  *
  * `onBeforeOAuthRedirect` runs synchronously immediately before the OAuth
  * full-page redirect (see `BrowserNavigation`). The app uses it to flush the
@@ -67,7 +66,7 @@ export function createWebEnvironment(
     }),
     logger,
     oauth: {
-      storage: getBrowserOAuthStorage(),
+      storage: getWebRemoteOAuthStorage(authToken),
       navigation: new BrowserNavigation(undefined, onBeforeOAuthRedirect),
       redirectUrlProvider,
     },

--- a/clients/web/src/lib/remoteOAuthStorage.test.ts
+++ b/clients/web/src/lib/remoteOAuthStorage.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getRemoteOAuthStorage,
+  getWebRemoteOAuthStorage,
+  resetWebRemoteOAuthStorageCacheForTests,
+} from "./remoteOAuthStorage";
+
+describe("remoteOAuthStorage", () => {
+  afterEach(() => {
+    resetWebRemoteOAuthStorageCacheForTests();
+  });
+
+  it("returns one RemoteOAuthStorage instance per cache key", () => {
+    const a = getRemoteOAuthStorage({
+      baseUrl: "http://127.0.0.1:6277",
+      authToken: "tok-a",
+    });
+    const aAgain = getRemoteOAuthStorage({
+      baseUrl: "http://127.0.0.1:6277",
+      authToken: "tok-a",
+    });
+    const b = getRemoteOAuthStorage({
+      baseUrl: "http://127.0.0.1:6277",
+      authToken: "tok-b",
+    });
+
+    expect(aAgain).toBe(a);
+    expect(b).not.toBe(a);
+  });
+
+  it("getWebRemoteOAuthStorage uses window.location origin", () => {
+    vi.stubGlobal("window", {
+      location: {
+        protocol: "http:",
+        host: "127.0.0.1:6299",
+      },
+    });
+
+    const storage = getWebRemoteOAuthStorage("smoke-web-token");
+    const again = getWebRemoteOAuthStorage("smoke-web-token");
+
+    expect(again).toBe(storage);
+    vi.unstubAllGlobals();
+  });
+
+  it("throws when window is unavailable", () => {
+    vi.stubGlobal("window", undefined);
+    expect(() => getWebRemoteOAuthStorage()).toThrow(
+      "getWebRemoteOAuthStorage requires a browser environment",
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it("creates a new instance after the test cache reset", () => {
+    const first = getRemoteOAuthStorage({
+      baseUrl: "http://127.0.0.1:6277",
+      authToken: "reset-me",
+    });
+    resetWebRemoteOAuthStorageCacheForTests();
+    const second = getRemoteOAuthStorage({
+      baseUrl: "http://127.0.0.1:6277",
+      authToken: "reset-me",
+    });
+    expect(second).not.toBe(first);
+  });
+});

--- a/clients/web/src/lib/remoteOAuthStorage.ts
+++ b/clients/web/src/lib/remoteOAuthStorage.ts
@@ -17,8 +17,12 @@ const defaultFetch: typeof fetch = (...args) => globalThis.fetch(...args);
  * Shared web OAuth store: `RemoteOAuthStorage` → `GET/POST /api/storage/oauth`
  * → `~/.mcp-inspector/storage/oauth.json` (same file as CLI/TUI).
  *
- * Memoized by `{ baseUrl, authToken }` so connect, EMA IdP session, and
- * per-server clear all mutate the same in-memory view.
+ * Caches a single instance keyed by `{ baseUrl, authToken }`: repeat calls with
+ * the same key return that instance, so connect, EMA IdP session, and per-server
+ * clear all mutate the same in-memory view. A call with a different key replaces
+ * the cached instance (cache of one). That is sufficient because the web app
+ * uses a stable origin + page-lifetime API token, so the key never changes
+ * within a session.
  */
 export function getRemoteOAuthStorage(
   options: WebRemoteOAuthStorageOptions,

--- a/clients/web/src/lib/remoteOAuthStorage.ts
+++ b/clients/web/src/lib/remoteOAuthStorage.ts
@@ -1,0 +1,55 @@
+import { RemoteOAuthStorage } from "@inspector/core/auth/remote/storage-remote.js";
+
+export interface WebRemoteOAuthStorageOptions {
+  baseUrl: string;
+  authToken?: string;
+}
+
+let cached: { cacheKey: string; storage: RemoteOAuthStorage } | undefined;
+
+function buildCacheKey(options: WebRemoteOAuthStorageOptions): string {
+  return `${options.baseUrl}\0${options.authToken ?? ""}`;
+}
+
+const defaultFetch: typeof fetch = (...args) => globalThis.fetch(...args);
+
+/**
+ * Shared web OAuth store: `RemoteOAuthStorage` → `GET/POST /api/storage/oauth`
+ * → `~/.mcp-inspector/storage/oauth.json` (same file as CLI/TUI).
+ *
+ * Memoized by `{ baseUrl, authToken }` so connect, EMA IdP session, and
+ * per-server clear all mutate the same in-memory view.
+ */
+export function getRemoteOAuthStorage(
+  options: WebRemoteOAuthStorageOptions,
+): RemoteOAuthStorage {
+  const cacheKey = buildCacheKey(options);
+  if (cached?.cacheKey === cacheKey) {
+    return cached.storage;
+  }
+  cached = {
+    cacheKey,
+    storage: new RemoteOAuthStorage({
+      baseUrl: options.baseUrl,
+      authToken: options.authToken,
+      fetchFn: defaultFetch,
+    }),
+  };
+  return cached.storage;
+}
+
+/** Current origin + optional API token (see `getAuthToken()` in App.tsx). */
+export function getWebRemoteOAuthStorage(
+  authToken?: string,
+): RemoteOAuthStorage {
+  if (typeof window === "undefined") {
+    throw new Error("getWebRemoteOAuthStorage requires a browser environment");
+  }
+  const baseUrl = `${window.location.protocol}//${window.location.host}`;
+  return getRemoteOAuthStorage({ baseUrl, authToken });
+}
+
+/** @internal Vitest isolation */
+export function resetWebRemoteOAuthStorageCacheForTests(): void {
+  cached = undefined;
+}

--- a/clients/web/src/test/core/auth/connection-state.test.ts
+++ b/clients/web/src/test/core/auth/connection-state.test.ts
@@ -22,6 +22,7 @@ function createStorage(
   }> = {},
 ): OAuthStorage {
   return {
+    load: vi.fn().mockResolvedValue(undefined),
     getTokens: vi.fn().mockResolvedValue(overrides.tokens),
     getClientInformation: vi.fn(async (_url, isPreregistered) =>
       isPreregistered ? overrides.preregistered : overrides.dynamic,

--- a/clients/web/src/test/core/auth/ema/emaFlow.test.ts
+++ b/clients/web/src/test/core/auth/ema/emaFlow.test.ts
@@ -43,6 +43,7 @@ function createMemoryStorage(
   const clientInfoByKey: Record<string, unknown> = {};
   const codeVerifierByKey: Record<string, string> = {};
   return {
+    load: vi.fn().mockResolvedValue(undefined),
     getIdpSession: vi.fn(async (issuer: string) => idpSessions[issuer]),
     saveIdpSession: vi.fn(async (issuer: string, updates) => {
       idpSessions[issuer] = { ...idpSessions[issuer], ...updates };

--- a/clients/web/src/test/core/auth/ema/idpOidc.test.ts
+++ b/clients/web/src/test/core/auth/ema/idpOidc.test.ts
@@ -29,6 +29,7 @@ describe("idpOidc refresh", () => {
   beforeEach(() => {
     Object.keys(idpSessions).forEach((k) => delete idpSessions[k]);
     storage = {
+      load: vi.fn().mockResolvedValue(undefined),
       getIdpSession: vi.fn(async (issuer: string) => idpSessions[issuer]),
       saveIdpSession: vi.fn(async (issuer: string, updates) => {
         idpSessions[issuer] = { ...idpSessions[issuer], ...updates };
@@ -264,6 +265,8 @@ describe("startIdpOidcAuthorization", () => {
   beforeEach(() => {
     Object.keys(saved).forEach((k) => delete saved[k]);
     storage = {
+      load: vi.fn().mockResolvedValue(undefined),
+      getServerMetadata: vi.fn(() => null),
       saveCodeVerifier: vi.fn(async (key: string, value: string) => {
         saved[`cv:${key}`] = value;
       }),
@@ -331,6 +334,7 @@ describe("completeIdpOidcAuthorization", () => {
 
   function buildStorage(overrides: Partial<OAuthStorage> = {}): OAuthStorage {
     return {
+      load: vi.fn().mockResolvedValue(undefined),
       getServerMetadata: vi.fn(() => minimalOAuthAsMetadata(IDP_ISSUER)),
       getClientInformation: vi.fn(async () => ({
         client_id: "idp-client",

--- a/clients/web/src/test/core/auth/ema/idpSession.test.ts
+++ b/clients/web/src/test/core/auth/ema/idpSession.test.ts
@@ -19,6 +19,7 @@ describe("idpSession", () => {
 
   beforeEach(() => {
     storage = {
+      load: vi.fn().mockResolvedValue(undefined),
       getIdpSession: vi.fn(),
       saveIdpSession: vi.fn(),
       clearIdpSession: vi.fn(),
@@ -73,15 +74,15 @@ describe("idpSession", () => {
     );
   });
 
-  it("clearEmaIdpSession clears idp session, leg-1 key, and tagged resource servers", () => {
-    clearEmaIdpSession(storage, "https://idp.test/");
+  it("clearEmaIdpSession clears idp session, leg-1 key, and tagged resource servers", async () => {
+    await clearEmaIdpSession(storage, "https://idp.test/");
     expect(storage.clearIdpSession).toHaveBeenCalledWith("https://idp.test");
     expect(storage.clear).toHaveBeenCalledWith("ema-idp:https://idp.test");
     expect(storage.clearEnterpriseManagedResourceServers).toHaveBeenCalled();
   });
 
-  it("clearEmaIdpSession no-ops when issuer normalizes to empty", () => {
-    clearEmaIdpSession(storage, "");
+  it("clearEmaIdpSession no-ops when issuer normalizes to empty", async () => {
+    await clearEmaIdpSession(storage, "");
     expect(storage.clearIdpSession).not.toHaveBeenCalled();
     expect(storage.clear).not.toHaveBeenCalled();
     expect(

--- a/clients/web/src/test/core/auth/providers.test.ts
+++ b/clients/web/src/test/core/auth/providers.test.ts
@@ -213,6 +213,7 @@ describe("OAuthNavigation", () => {
 
     function makeStorage(): OAuthStorage {
       return {
+        load: vi.fn().mockResolvedValue(undefined),
         getScope: vi.fn(() => undefined),
         getClientInformation: vi.fn(async () => undefined),
         saveClientInformation: vi.fn(async () => undefined),
@@ -240,11 +241,11 @@ describe("OAuthNavigation", () => {
       return new BaseOAuthClientProvider(SERVER, config);
     }
 
-    it("clear() delegates to storage.clear with the server url", () => {
+    it("clear() delegates to storage.clear with the server url", async () => {
       const storage = makeStorage();
       const provider = makeProvider(storage);
 
-      provider.clear();
+      await provider.clear();
 
       expect(storage.clear).toHaveBeenCalledWith(SERVER);
     });

--- a/clients/web/src/test/core/auth/storage-browser.test.ts
+++ b/clients/web/src/test/core/auth/storage-browser.test.ts
@@ -77,7 +77,7 @@ describe("BrowserOAuthStorage", () => {
         client_secret: "test-secret",
       };
 
-      storage.saveClientInformation(testServerUrl, clientInfo, {
+      await storage.saveClientInformation(testServerUrl, clientInfo, {
         registrationKind: "dcr",
       });
       const result = await storage.getClientInformation(testServerUrl);
@@ -93,7 +93,7 @@ describe("BrowserOAuthStorage", () => {
 
       // Use the storage API instead of manually setting sessionStorage
       // since BrowserOAuthStorage now uses Zustand with a different storage format
-      storage.savePreregisteredClientInformation(
+      await storage.savePreregisteredClientInformation(
         testServerUrl,
         preregisteredInfo,
       );
@@ -113,7 +113,7 @@ describe("BrowserOAuthStorage", () => {
         client_id: "test-client-id",
       };
 
-      storage.saveClientInformation(testServerUrl, clientInfo, {
+      await storage.saveClientInformation(testServerUrl, clientInfo, {
         registrationKind: "dcr",
       });
       const result = await storage.getClientInformation(testServerUrl);
@@ -130,10 +130,10 @@ describe("BrowserOAuthStorage", () => {
         client_id: "second-id",
       };
 
-      storage.saveClientInformation(testServerUrl, firstInfo, {
+      await storage.saveClientInformation(testServerUrl, firstInfo, {
         registrationKind: "dcr",
       });
-      storage.saveClientInformation(testServerUrl, secondInfo, {
+      await storage.saveClientInformation(testServerUrl, secondInfo, {
         registrationKind: "cimd",
       });
       const result = await storage.getClientInformation(testServerUrl);
@@ -163,7 +163,7 @@ describe("BrowserOAuthStorage", () => {
         expires_in: 3600,
       };
 
-      storage.saveTokens(testServerUrl, tokens);
+      await storage.saveTokens(testServerUrl, tokens);
       const result = await storage.getTokens(testServerUrl);
 
       expect(result).toEqual(tokens);
@@ -177,7 +177,7 @@ describe("BrowserOAuthStorage", () => {
         token_type: "Bearer",
       };
 
-      storage.saveTokens(testServerUrl, tokens);
+      await storage.saveTokens(testServerUrl, tokens);
       const result = await storage.getTokens(testServerUrl);
 
       expect(result).toEqual(tokens);
@@ -194,7 +194,7 @@ describe("BrowserOAuthStorage", () => {
       await storage.saveTokens(emaUrl, tokens, { enterpriseManaged: true });
       await storage.saveTokens(standardUrl, tokens);
 
-      storage.clearEnterpriseManagedResourceServers();
+      await storage.clearEnterpriseManagedResourceServers();
 
       expect(await storage.getTokens(emaUrl)).toBeUndefined();
       expect(await storage.getTokens(standardUrl)).toEqual(tokens);
@@ -210,7 +210,7 @@ describe("BrowserOAuthStorage", () => {
     it("should return stored code verifier", async () => {
       const codeVerifier = "test-code-verifier";
 
-      storage.saveCodeVerifier(testServerUrl, codeVerifier);
+      await storage.saveCodeVerifier(testServerUrl, codeVerifier);
       const result = await storage.getCodeVerifier(testServerUrl);
 
       expect(result).toBe(codeVerifier);
@@ -221,7 +221,7 @@ describe("BrowserOAuthStorage", () => {
     it("should save code verifier", async () => {
       const codeVerifier = "test-code-verifier";
 
-      storage.saveCodeVerifier(testServerUrl, codeVerifier);
+      await storage.saveCodeVerifier(testServerUrl, codeVerifier);
       const result = await storage.getCodeVerifier(testServerUrl);
 
       expect(result).toBe(codeVerifier);
@@ -237,7 +237,7 @@ describe("BrowserOAuthStorage", () => {
     it("should return stored scope", async () => {
       const scope = "read write";
 
-      storage.saveScope(testServerUrl, scope);
+      await storage.saveScope(testServerUrl, scope);
       const result = await storage.getScope(testServerUrl);
 
       expect(result).toBe(scope);
@@ -248,7 +248,7 @@ describe("BrowserOAuthStorage", () => {
     it("should save scope", async () => {
       const scope = "read write";
 
-      storage.saveScope(testServerUrl, scope);
+      await storage.saveScope(testServerUrl, scope);
       const result = await storage.getScope(testServerUrl);
 
       expect(result).toBe(scope);
@@ -269,7 +269,7 @@ describe("BrowserOAuthStorage", () => {
         response_types_supported: ["code"],
       };
 
-      storage.saveServerMetadata(testServerUrl, metadata);
+      await storage.saveServerMetadata(testServerUrl, metadata);
       const result = await storage.getServerMetadata(testServerUrl);
 
       expect(result).toEqual(metadata);
@@ -285,7 +285,7 @@ describe("BrowserOAuthStorage", () => {
         response_types_supported: ["code"],
       };
 
-      storage.saveServerMetadata(testServerUrl, metadata);
+      await storage.saveServerMetadata(testServerUrl, metadata);
       const result = await storage.getServerMetadata(testServerUrl);
 
       expect(result).toEqual(metadata);
@@ -294,7 +294,7 @@ describe("BrowserOAuthStorage", () => {
 
   describe("clearClientInformation", () => {
     it("removes the dynamically-registered client info by default", async () => {
-      storage.saveClientInformation(
+      await storage.saveClientInformation(
         testServerUrl,
         { client_id: "dyn" },
         { registrationKind: "dcr" },
@@ -302,18 +302,18 @@ describe("BrowserOAuthStorage", () => {
       expect(await storage.getClientInformation(testServerUrl)).toEqual({
         client_id: "dyn",
       });
-      storage.clearClientInformation(testServerUrl);
+      await storage.clearClientInformation(testServerUrl);
       expect(await storage.getClientInformation(testServerUrl)).toBeUndefined();
     });
 
     it("removes the preregistered client info when isPreregistered=true", async () => {
-      storage.savePreregisteredClientInformation(testServerUrl, {
+      await storage.savePreregisteredClientInformation(testServerUrl, {
         client_id: "pre",
       });
       expect(await storage.getClientInformation(testServerUrl, true)).toEqual({
         client_id: "pre",
       });
-      storage.clearClientInformation(testServerUrl, true);
+      await storage.clearClientInformation(testServerUrl, true);
       expect(
         await storage.getClientInformation(testServerUrl, true),
       ).toBeUndefined();
@@ -322,26 +322,26 @@ describe("BrowserOAuthStorage", () => {
 
   describe("individual clear methods", () => {
     it("clearTokens removes only tokens", async () => {
-      storage.saveTokens(testServerUrl, {
+      await storage.saveTokens(testServerUrl, {
         access_token: "t",
         token_type: "Bearer",
       });
       expect(await storage.getTokens(testServerUrl)).toBeDefined();
-      storage.clearTokens(testServerUrl);
+      await storage.clearTokens(testServerUrl);
       expect(await storage.getTokens(testServerUrl)).toBeUndefined();
     });
 
     it("clearCodeVerifier removes only the PKCE verifier", async () => {
-      storage.saveCodeVerifier(testServerUrl, "verifier");
+      await storage.saveCodeVerifier(testServerUrl, "verifier");
       expect(storage.getCodeVerifier(testServerUrl)).toBe("verifier");
-      storage.clearCodeVerifier(testServerUrl);
+      await storage.clearCodeVerifier(testServerUrl);
       expect(storage.getCodeVerifier(testServerUrl)).toBeUndefined();
     });
 
     it("clearScope removes only the scope", async () => {
-      storage.saveScope(testServerUrl, "read");
+      await storage.saveScope(testServerUrl, "read");
       expect(storage.getScope(testServerUrl)).toBe("read");
-      storage.clearScope(testServerUrl);
+      await storage.clearScope(testServerUrl);
       expect(storage.getScope(testServerUrl)).toBeUndefined();
     });
 
@@ -352,9 +352,9 @@ describe("BrowserOAuthStorage", () => {
         token_endpoint: "http://localhost:3000/token",
         response_types_supported: ["code"],
       };
-      storage.saveServerMetadata(testServerUrl, metadata);
+      await storage.saveServerMetadata(testServerUrl, metadata);
       expect(storage.getServerMetadata(testServerUrl)).toEqual(metadata);
-      storage.clearServerMetadata(testServerUrl);
+      await storage.clearServerMetadata(testServerUrl);
       expect(storage.getServerMetadata(testServerUrl)).toBeNull();
     });
   });
@@ -369,12 +369,12 @@ describe("BrowserOAuthStorage", () => {
         token_type: "Bearer",
       };
 
-      storage.saveClientInformation(testServerUrl, clientInfo, {
+      await storage.saveClientInformation(testServerUrl, clientInfo, {
         registrationKind: "dcr",
       });
-      storage.saveTokens(testServerUrl, tokens);
+      await storage.saveTokens(testServerUrl, tokens);
 
-      storage.clear(testServerUrl);
+      await storage.clear(testServerUrl);
 
       expect(await storage.getClientInformation(testServerUrl)).toBeUndefined();
       expect(await storage.getTokens(testServerUrl)).toBeUndefined();
@@ -386,14 +386,14 @@ describe("BrowserOAuthStorage", () => {
         client_id: "test-client-id",
       };
 
-      storage.saveClientInformation(testServerUrl, clientInfo, {
+      await storage.saveClientInformation(testServerUrl, clientInfo, {
         registrationKind: "dcr",
       });
-      storage.saveClientInformation(otherServerUrl, clientInfo, {
+      await storage.saveClientInformation(otherServerUrl, clientInfo, {
         registrationKind: "dcr",
       });
 
-      storage.clear(testServerUrl);
+      await storage.clear(testServerUrl);
 
       expect(await storage.getClientInformation(testServerUrl)).toBeUndefined();
       expect(await storage.getClientInformation(otherServerUrl)).toEqual(
@@ -415,10 +415,10 @@ describe("BrowserOAuthStorage", () => {
         client_id: "client-2",
       };
 
-      storage.saveClientInformation(server1Url, clientInfo1, {
+      await storage.saveClientInformation(server1Url, clientInfo1, {
         registrationKind: "dcr",
       });
-      storage.saveClientInformation(server2Url, clientInfo2, {
+      await storage.saveClientInformation(server2Url, clientInfo2, {
         registrationKind: "dcr",
       });
 

--- a/clients/web/src/test/core/auth/storage-browser.test.ts
+++ b/clients/web/src/test/core/auth/storage-browser.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { BrowserOAuthStorage } from "@inspector/core/auth/browser/storage.js";
+import {
+  BrowserOAuthStorage,
+  getBrowserOAuthStorage,
+} from "@inspector/core/auth/browser/storage.js";
 import type {
   OAuthClientInformation,
   OAuthTokens,
@@ -40,6 +43,14 @@ class MockSessionStorage implements Storage {
 const mockSessionStorage = new MockSessionStorage();
 (global as typeof globalThis & { sessionStorage?: Storage }).sessionStorage =
   mockSessionStorage;
+
+describe("getBrowserOAuthStorage", () => {
+  it("returns the same singleton on repeated calls", () => {
+    const first = getBrowserOAuthStorage();
+    const second = getBrowserOAuthStorage();
+    expect(second).toBe(first);
+  });
+});
 
 describe("BrowserOAuthStorage", () => {
   let storage: BrowserOAuthStorage;

--- a/clients/web/src/test/core/auth/storage-remote.test.ts
+++ b/clients/web/src/test/core/auth/storage-remote.test.ts
@@ -50,7 +50,7 @@ describe("RemoteOAuthStorage (unit, mocked fetch)", () => {
       { client_id: "dyn" },
       { registrationKind: "dcr" },
     );
-    storage.clearClientInformation(serverUrl);
+    await storage.clearClientInformation(serverUrl);
     expect(await storage.getClientInformation(serverUrl)).toBeUndefined();
   });
 
@@ -58,7 +58,7 @@ describe("RemoteOAuthStorage (unit, mocked fetch)", () => {
     await storage.savePreregisteredClientInformation(serverUrl, {
       client_id: "pre",
     });
-    storage.clearClientInformation(serverUrl, true);
+    await storage.clearClientInformation(serverUrl, true);
     expect(await storage.getClientInformation(serverUrl, true)).toBeUndefined();
   });
 
@@ -66,21 +66,21 @@ describe("RemoteOAuthStorage (unit, mocked fetch)", () => {
     const tokens = { access_token: "t", token_type: "Bearer" };
     await storage.saveTokens(serverUrl, tokens);
     expect(await storage.getTokens(serverUrl)).toEqual(tokens);
-    storage.clearTokens(serverUrl);
+    await storage.clearTokens(serverUrl);
     expect(await storage.getTokens(serverUrl)).toBeUndefined();
   });
 
   it("codeVerifier round-trip and clearCodeVerifier", async () => {
     await storage.saveCodeVerifier(serverUrl, "verifier");
     expect(storage.getCodeVerifier(serverUrl)).toBe("verifier");
-    storage.clearCodeVerifier(serverUrl);
+    await storage.clearCodeVerifier(serverUrl);
     expect(storage.getCodeVerifier(serverUrl)).toBeUndefined();
   });
 
   it("scope round-trip and clearScope", async () => {
     await storage.saveScope(serverUrl, "read write");
     expect(storage.getScope(serverUrl)).toBe("read write");
-    storage.clearScope(serverUrl);
+    await storage.clearScope(serverUrl);
     expect(storage.getScope(serverUrl)).toBeUndefined();
   });
 
@@ -93,7 +93,7 @@ describe("RemoteOAuthStorage (unit, mocked fetch)", () => {
     };
     await storage.saveServerMetadata(serverUrl, md);
     expect(storage.getServerMetadata(serverUrl)).toEqual(md);
-    storage.clearServerMetadata(serverUrl);
+    await storage.clearServerMetadata(serverUrl);
     expect(storage.getServerMetadata(serverUrl)).toBeNull();
   });
 
@@ -107,7 +107,7 @@ describe("RemoteOAuthStorage (unit, mocked fetch)", () => {
       access_token: "t",
       token_type: "Bearer",
     });
-    storage.clear(serverUrl);
+    await storage.clear(serverUrl);
     expect(await storage.getClientInformation(serverUrl)).toBeUndefined();
     expect(await storage.getTokens(serverUrl)).toBeUndefined();
   });
@@ -119,5 +119,40 @@ describe("RemoteOAuthStorage (unit, mocked fetch)", () => {
     });
     // No public accessor; constructing without throwing covers the default-branch.
     expect(s).toBeInstanceOf(RemoteOAuthStorage);
+  });
+
+  it("load() waits for remote GET before sync reads see persisted state", async () => {
+    const persisted = {
+      state: {
+        servers: {
+          [serverUrl]: { codeVerifier: "persisted-verifier" },
+        },
+        idpSessions: {},
+      },
+      version: 0,
+    };
+    let resolveFetch!: (value: Response) => void;
+    const delayedFetch = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    ) as unknown as typeof fetch;
+
+    const delayedStorage = new RemoteOAuthStorage({
+      baseUrl: "http://remote.example",
+      storeId: `delayed-${Math.random().toString(36).slice(2)}`,
+      fetchFn: delayedFetch,
+    });
+
+    const loadPromise = delayedStorage.load();
+    expect(delayedStorage.getCodeVerifier(serverUrl)).toBeUndefined();
+
+    resolveFetch(new Response(JSON.stringify(persisted), { status: 200 }));
+    await loadPromise;
+
+    expect(delayedStorage.getCodeVerifier(serverUrl)).toBe(
+      "persisted-verifier",
+    );
   });
 });

--- a/clients/web/src/test/core/auth/storage-remote.test.ts
+++ b/clients/web/src/test/core/auth/storage-remote.test.ts
@@ -142,12 +142,12 @@ describe("RemoteOAuthStorage (unit, mocked fetch)", () => {
       version: 0,
     };
     let resolveFetch!: (value: Response) => void;
-    const delayedFetch = vi.fn(
+    const delayedFetch = vi.fn<typeof fetch>(
       () =>
         new Promise<Response>((resolve) => {
           resolveFetch = resolve;
         }),
-    ) as unknown as typeof fetch;
+    );
 
     const delayedStorage = new RemoteOAuthStorage({
       baseUrl: "http://remote.example",
@@ -167,9 +167,9 @@ describe("RemoteOAuthStorage (unit, mocked fetch)", () => {
   });
 
   it("load() rejects when remote GET fails instead of hanging", async () => {
-    const failingFetch = vi.fn(
+    const failingFetch = vi.fn<typeof fetch>(
       async () => new Response("server error", { status: 500 }),
-    ) as unknown as typeof fetch;
+    );
 
     const failingStorage = new RemoteOAuthStorage({
       baseUrl: "http://remote.example",

--- a/clients/web/src/test/core/auth/storage-remote.test.ts
+++ b/clients/web/src/test/core/auth/storage-remote.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { RemoteOAuthStorage } from "@inspector/core/auth/remote/storage-remote.js";
+import {
+  type OAuthStore,
+  waitForOAuthStorePersistLoad,
+} from "@inspector/core/auth/store.js";
 
 const NOOP_FETCH = vi.fn(
   async () =>
@@ -121,6 +125,12 @@ describe("RemoteOAuthStorage (unit, mocked fetch)", () => {
     expect(s).toBeInstanceOf(RemoteOAuthStorage);
   });
 
+  it("waitForOAuthStorePersistLoad resolves for an unregistered store handle", async () => {
+    await expect(
+      waitForOAuthStorePersistLoad({} as OAuthStore),
+    ).resolves.toBeUndefined();
+  });
+
   it("load() waits for remote GET before sync reads see persisted state", async () => {
     const persisted = {
       state: {
@@ -153,6 +163,22 @@ describe("RemoteOAuthStorage (unit, mocked fetch)", () => {
 
     expect(delayedStorage.getCodeVerifier(serverUrl)).toBe(
       "persisted-verifier",
+    );
+  });
+
+  it("load() rejects when remote GET fails instead of hanging", async () => {
+    const failingFetch = vi.fn(
+      async () => new Response("server error", { status: 500 }),
+    ) as unknown as typeof fetch;
+
+    const failingStorage = new RemoteOAuthStorage({
+      baseUrl: "http://remote.example",
+      storeId: `fail-${Math.random().toString(36).slice(2)}`,
+      fetchFn: failingFetch,
+    });
+
+    await expect(failingStorage.load()).rejects.toThrow(
+      "Failed to read store: 500",
     );
   });
 });

--- a/clients/web/src/test/core/mcp/oauthManager.test.ts
+++ b/clients/web/src/test/core/mcp/oauthManager.test.ts
@@ -35,6 +35,7 @@ function createMockParams(
   const dispatchOAuthError = vi.fn();
 
   const storage = {
+    load: vi.fn().mockResolvedValue(undefined),
     getScope: vi.fn().mockReturnValue(undefined),
     getClientInformation: vi.fn().mockResolvedValue(undefined),
     getClientRegistrationKind: vi.fn().mockReturnValue(undefined),
@@ -45,7 +46,7 @@ function createMockParams(
     saveTokens: vi.fn().mockResolvedValue(undefined),
     getCodeVerifier: vi.fn().mockReturnValue("verifier"),
     saveCodeVerifier: vi.fn().mockResolvedValue(undefined),
-    clear: vi.fn(),
+    clear: vi.fn().mockResolvedValue(undefined),
     clearClientInformation: vi.fn(),
     clearTokens: vi.fn(),
     clearCodeVerifier: vi.fn(),
@@ -126,10 +127,10 @@ describe("OAuthManager", () => {
   });
 
   describe("clearOAuthTokens", () => {
-    it("calls storage.clear(serverUrl) when storage is configured", () => {
+    it("calls storage.clear(serverUrl) when storage is configured", async () => {
       const params = createMockParams();
       const manager = new OAuthManager(params);
-      manager.clearOAuthTokens();
+      await manager.clearOAuthTokens();
       expect(params.initialConfig.storage!.clear).toHaveBeenCalledWith(
         SERVER_URL,
       );
@@ -137,7 +138,7 @@ describe("OAuthManager", () => {
       expect(manager.getOAuthFlowStep()).toBeUndefined();
     });
 
-    it("no-ops when storage is not configured", () => {
+    it("no-ops when storage is not configured", async () => {
       const params = createMockParams({
         initialConfig: {
           redirectUrlProvider: {
@@ -147,7 +148,7 @@ describe("OAuthManager", () => {
         } as OAuthManagerConfig,
       });
       const manager = new OAuthManager(params);
-      manager.clearOAuthTokens();
+      await manager.clearOAuthTokens();
       expect(params.getServerUrl).not.toHaveBeenCalled();
     });
   });

--- a/clients/web/src/test/core/react/useEmaIdpLoginState.test.tsx
+++ b/clients/web/src/test/core/react/useEmaIdpLoginState.test.tsx
@@ -67,6 +67,58 @@ describe("useEmaIdpLoginState", () => {
     });
   });
 
+  it("logout swallows a clear failure without an unhandled rejection and keeps state", async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const payload = btoa(JSON.stringify({ exp }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    vi.mocked(storage.getIdpSession).mockResolvedValue({
+      idToken: `h.${payload}.s`,
+    });
+    vi.mocked(storage.clearIdpSession).mockRejectedValue(
+      new Error("storage backend unreachable"),
+    );
+    const unhandled = vi.fn();
+    const onUnhandled = (event: PromiseRejectionEvent) => {
+      event.preventDefault();
+      unhandled();
+    };
+    window.addEventListener("unhandledrejection", onUnhandled);
+
+    try {
+      const { result } = renderHook(() =>
+        useEmaIdpLoginState(storage, "https://idp.test", true),
+      );
+
+      await waitFor(() => {
+        expect(result.current.loginState).toBe("logged_in");
+      });
+
+      act(() => {
+        result.current.logout();
+      });
+
+      await waitFor(() => {
+        expect(storage.clearIdpSession).toHaveBeenCalledWith(
+          "https://idp.test",
+        );
+      });
+      // Give the rejected promise a turn to settle so any unhandled rejection
+      // would have fired.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Clear failed, so the session is still present: state stays "logged_in"
+      // and no unhandled rejection escaped.
+      expect(result.current.loginState).toBe("logged_in");
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("unhandledrejection", onUnhandled);
+    }
+  });
+
   it("reports 'expired' for an expired token with no refresh token", async () => {
     const exp = Math.floor(Date.now() / 1000) - 3600;
     const payload = btoa(JSON.stringify({ exp }))

--- a/clients/web/src/test/core/react/useEmaIdpLoginState.test.tsx
+++ b/clients/web/src/test/core/react/useEmaIdpLoginState.test.tsx
@@ -8,10 +8,13 @@ describe("useEmaIdpLoginState", () => {
 
   beforeEach(() => {
     storage = {
+      load: vi.fn().mockResolvedValue(undefined),
       getIdpSession: vi.fn().mockResolvedValue(undefined),
-      clearIdpSession: vi.fn(),
-      clear: vi.fn(),
-      clearEnterpriseManagedResourceServers: vi.fn(),
+      clearIdpSession: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+      clearEnterpriseManagedResourceServers: vi
+        .fn()
+        .mockResolvedValue(undefined),
     } as unknown as OAuthStorage;
   });
 
@@ -56,10 +59,12 @@ describe("useEmaIdpLoginState", () => {
       result.current.logout();
     });
 
-    expect(storage.clearIdpSession).toHaveBeenCalledWith("https://idp.test");
-    expect(storage.clear).toHaveBeenCalledWith("ema-idp:https://idp.test");
-    expect(storage.clearEnterpriseManagedResourceServers).toHaveBeenCalled();
-    expect(result.current.loginState).toBe("none");
+    await waitFor(() => {
+      expect(storage.clearIdpSession).toHaveBeenCalledWith("https://idp.test");
+      expect(storage.clear).toHaveBeenCalledWith("ema-idp:https://idp.test");
+      expect(storage.clearEnterpriseManagedResourceServers).toHaveBeenCalled();
+      expect(result.current.loginState).toBe("none");
+    });
   });
 
   it("reports 'expired' for an expired token with no refresh token", async () => {

--- a/clients/web/src/test/integration/auth/node/storage.test.ts
+++ b/clients/web/src/test/integration/auth/node/storage.test.ts
@@ -126,10 +126,10 @@ describe("NodeOAuthStorage", () => {
         client_id: "second-id",
       };
 
-      storage.saveClientInformation(testServerUrl, firstInfo, {
+      await storage.saveClientInformation(testServerUrl, firstInfo, {
         registrationKind: "dcr",
       });
-      storage.saveClientInformation(testServerUrl, secondInfo, {
+      await storage.saveClientInformation(testServerUrl, secondInfo, {
         registrationKind: "dcr",
       });
       const result = await storage.getClientInformation(testServerUrl);
@@ -310,7 +310,7 @@ describe("NodeOAuthStorage", () => {
       expect(await storage.getClientInformation(testServerUrl)).toEqual({
         client_id: "dyn",
       });
-      storage.clearClientInformation(testServerUrl);
+      await storage.clearClientInformation(testServerUrl);
       expect(await storage.getClientInformation(testServerUrl)).toBeUndefined();
     });
 
@@ -321,7 +321,7 @@ describe("NodeOAuthStorage", () => {
       expect(await storage.getClientInformation(testServerUrl, true)).toEqual({
         client_id: "pre",
       });
-      storage.clearClientInformation(testServerUrl, true);
+      await storage.clearClientInformation(testServerUrl, true);
       expect(
         await storage.getClientInformation(testServerUrl, true),
       ).toBeUndefined();
@@ -335,21 +335,21 @@ describe("NodeOAuthStorage", () => {
         token_type: "Bearer",
       });
       expect(await storage.getTokens(testServerUrl)).toBeDefined();
-      storage.clearTokens(testServerUrl);
+      await storage.clearTokens(testServerUrl);
       expect(await storage.getTokens(testServerUrl)).toBeUndefined();
     });
 
     it("clearCodeVerifier removes only the PKCE verifier", async () => {
       await storage.saveCodeVerifier(testServerUrl, "verifier");
       expect(storage.getCodeVerifier(testServerUrl)).toBe("verifier");
-      storage.clearCodeVerifier(testServerUrl);
+      await storage.clearCodeVerifier(testServerUrl);
       expect(storage.getCodeVerifier(testServerUrl)).toBeUndefined();
     });
 
     it("clearScope removes only the scope", async () => {
       await storage.saveScope(testServerUrl, "read write");
       expect(storage.getScope(testServerUrl)).toBe("read write");
-      storage.clearScope(testServerUrl);
+      await storage.clearScope(testServerUrl);
       expect(storage.getScope(testServerUrl)).toBeUndefined();
     });
 
@@ -362,7 +362,7 @@ describe("NodeOAuthStorage", () => {
       };
       await storage.saveServerMetadata(testServerUrl, metadata);
       expect(storage.getServerMetadata(testServerUrl)).toEqual(metadata);
-      storage.clearServerMetadata(testServerUrl);
+      await storage.clearServerMetadata(testServerUrl);
       expect(storage.getServerMetadata(testServerUrl)).toBeNull();
     });
   });
@@ -382,7 +382,7 @@ describe("NodeOAuthStorage", () => {
       });
       await storage.saveTokens(testServerUrl, tokens);
 
-      storage.clear(testServerUrl);
+      await storage.clear(testServerUrl);
 
       expect(await storage.getClientInformation(testServerUrl)).toBeUndefined();
       expect(await storage.getTokens(testServerUrl)).toBeUndefined();
@@ -401,7 +401,7 @@ describe("NodeOAuthStorage", () => {
         registrationKind: "dcr",
       });
 
-      storage.clear(testServerUrl);
+      await storage.clear(testServerUrl);
 
       expect(await storage.getClientInformation(testServerUrl)).toBeUndefined();
       const otherResult = await storage.getClientInformation(otherServerUrl);
@@ -424,10 +424,10 @@ describe("NodeOAuthStorage", () => {
         client_id: "client-2",
       };
 
-      storage.saveClientInformation(server1Url, clientInfo1, {
+      await storage.saveClientInformation(server1Url, clientInfo1, {
         registrationKind: "dcr",
       });
-      storage.saveClientInformation(server2Url, clientInfo2, {
+      await storage.saveClientInformation(server2Url, clientInfo2, {
         registrationKind: "dcr",
       });
 
@@ -547,7 +547,7 @@ describe("NodeOAuthStorage idpSessions (EMA)", () => {
     expect(session?.idToken).toBe("eyJ.id.token");
     expect(session?.refreshToken).toBe("rt-1");
 
-    storage.clearIdpSession(issuer);
+    await storage.clearIdpSession(issuer);
     await flushStoreFileWrites(testStatePath);
     expect(await storage.getIdpSession(issuer)).toBeUndefined();
   });
@@ -635,12 +635,10 @@ describe("NodeOAuthStorage with custom storagePath", () => {
     );
 
     try {
-      const defaultStore = getOAuthStore();
-      defaultStore.getState().setServerState(testServerUrl, {
-        tokens: {
-          access_token: "default-token",
-          token_type: "Bearer",
-        },
+      const defaultStorage = new NodeOAuthStorage();
+      await defaultStorage.saveTokens(testServerUrl, {
+        access_token: "default-token",
+        token_type: "Bearer",
       });
 
       const customStorage = new NodeOAuthStorage(customPath);
@@ -652,11 +650,10 @@ describe("NodeOAuthStorage with custom storagePath", () => {
       const fromCustom = await customStorage.getTokens(testServerUrl);
       expect(fromCustom?.access_token).toBe("custom-token");
 
-      const defaultStorage = new NodeOAuthStorage();
       const fromDefault = await defaultStorage.getTokens(testServerUrl);
       expect(fromDefault?.access_token).toBe("default-token");
 
-      defaultStore.getState().clearServerState(testServerUrl);
+      getOAuthStore().getState().clearServerState(testServerUrl);
     } finally {
       try {
         await fs.unlink(customPath);

--- a/clients/web/src/test/integration/mcp/inspectorClient-oauth-e2e.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient-oauth-e2e.test.ts
@@ -630,7 +630,7 @@ describe("InspectorClient OAuth E2E", () => {
         expect(client.getStatus()).toBe("connected");
 
         await client.disconnect();
-        client.clearOAuthTokens();
+        await client.clearOAuthTokens();
 
         const authUrlSecond = await client.authenticate();
         if (!authUrlSecond) throw new Error("Expected authorization URL");
@@ -995,7 +995,7 @@ describe("InspectorClient OAuth E2E", () => {
       expect(tokens?.access_token).toBeDefined();
       expect(await client.isOAuthAuthorized()).toBe(true);
 
-      client.clearOAuthTokens();
+      await client.clearOAuthTokens();
       expect(await client.isOAuthAuthorized()).toBe(false);
       expect(await client.getOAuthTokens()).toBeUndefined();
     });

--- a/clients/web/src/test/integration/mcp/inspectorClient-oauth.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient-oauth.test.ts
@@ -173,8 +173,8 @@ describe("InspectorClient OAuth", () => {
       expect(tokens).toBeUndefined();
     });
 
-    it("should clear OAuth tokens", () => {
-      client.clearOAuthTokens();
+    it("should clear OAuth tokens", async () => {
+      await client.clearOAuthTokens();
       // Should not throw
       expect(client).toBeDefined();
     });

--- a/clients/web/src/test/integration/mcp/inspectorClient.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient.test.ts
@@ -4949,7 +4949,7 @@ describe("InspectorClient", () => {
         expect(c.getOAuthFlowState()).toBeUndefined();
         await expect(c.getOAuthState()).resolves.toBeUndefined();
         // clearOAuthTokens is a no-op when there is no manager
-        expect(() => c.clearOAuthTokens()).not.toThrow();
+        await expect(c.clearOAuthTokens()).resolves.toBeUndefined();
       });
 
       it("setOAuthConfig throws when oauthManager is unset", () => {

--- a/clients/web/src/utils/clearServerOAuthState.test.ts
+++ b/clients/web/src/utils/clearServerOAuthState.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { BrowserOAuthStorage } from "@inspector/core/auth/browser/storage.js";
+import type { InspectorClient } from "@inspector/core/mcp/inspectorClient.js";
 import { clearServerOAuthState } from "./clearServerOAuthState";
 
 describe("clearServerOAuthState", () => {
   let storage: BrowserOAuthStorage;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     storage = new BrowserOAuthStorage();
-    storage.clear("https://mcp.example.com/mcp");
+    await storage.clear("https://mcp.example.com/mcp");
   });
 
   it("clears storage by server URL when not the active connection", async () => {
@@ -16,7 +17,7 @@ describe("clearServerOAuthState", () => {
       token_type: "Bearer",
     });
 
-    const cleared = clearServerOAuthState({
+    const cleared = await clearServerOAuthState({
       config: { type: "streamable-http", url: "https://mcp.example.com/mcp" },
       isActiveConnection: false,
       oauthStorage: storage,
@@ -28,11 +29,11 @@ describe("clearServerOAuthState", () => {
     ).toBeUndefined();
   });
 
-  it("uses the live client when clearing the active connection", () => {
-    const clearOAuthTokens = vi.fn<() => void>();
+  it("uses the live client when clearing the active connection", async () => {
+    const clearOAuthTokens = vi.fn<InspectorClient["clearOAuthTokens"]>();
     const inspectorClient = { clearOAuthTokens };
 
-    const cleared = clearServerOAuthState({
+    const cleared = await clearServerOAuthState({
       config: { type: "streamable-http", url: "https://mcp.example.com/mcp" },
       inspectorClient,
       isActiveConnection: true,
@@ -43,13 +44,13 @@ describe("clearServerOAuthState", () => {
     expect(clearOAuthTokens).toHaveBeenCalledTimes(1);
   });
 
-  it("returns false for stdio servers", () => {
-    expect(
+  it("returns false for stdio servers", async () => {
+    await expect(
       clearServerOAuthState({
         config: { type: "stdio", command: "node", args: [] },
         isActiveConnection: false,
         oauthStorage: storage,
       }),
-    ).toBe(false);
+    ).resolves.toBe(false);
   });
 });

--- a/clients/web/src/utils/clearServerOAuthState.test.ts
+++ b/clients/web/src/utils/clearServerOAuthState.test.ts
@@ -1,14 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { getBrowserOAuthStorage } from "@inspector/core/auth/browser/index.js";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { BrowserOAuthStorage } from "@inspector/core/auth/browser/storage.js";
 import { clearServerOAuthState } from "./clearServerOAuthState";
 
 describe("clearServerOAuthState", () => {
+  let storage: BrowserOAuthStorage;
+
   beforeEach(() => {
-    getBrowserOAuthStorage().clear("https://mcp.example.com/mcp");
+    storage = new BrowserOAuthStorage();
+    storage.clear("https://mcp.example.com/mcp");
   });
 
   it("clears storage by server URL when not the active connection", async () => {
-    const storage = getBrowserOAuthStorage();
     await storage.saveTokens("https://mcp.example.com/mcp", {
       access_token: "tok",
       token_type: "Bearer",
@@ -17,6 +19,7 @@ describe("clearServerOAuthState", () => {
     const cleared = clearServerOAuthState({
       config: { type: "streamable-http", url: "https://mcp.example.com/mcp" },
       isActiveConnection: false,
+      oauthStorage: storage,
     });
 
     expect(cleared).toBe(true);
@@ -26,18 +29,18 @@ describe("clearServerOAuthState", () => {
   });
 
   it("uses the live client when clearing the active connection", () => {
-    const inspectorClient = {
-      clearOAuthTokens: vi.fn(),
-    };
+    const clearOAuthTokens = vi.fn<() => void>();
+    const inspectorClient = { clearOAuthTokens };
 
     const cleared = clearServerOAuthState({
       config: { type: "streamable-http", url: "https://mcp.example.com/mcp" },
-      inspectorClient: inspectorClient as never,
+      inspectorClient,
       isActiveConnection: true,
+      oauthStorage: storage,
     });
 
     expect(cleared).toBe(true);
-    expect(inspectorClient.clearOAuthTokens).toHaveBeenCalledTimes(1);
+    expect(clearOAuthTokens).toHaveBeenCalledTimes(1);
   });
 
   it("returns false for stdio servers", () => {
@@ -45,6 +48,7 @@ describe("clearServerOAuthState", () => {
       clearServerOAuthState({
         config: { type: "stdio", command: "node", args: [] },
         isActiveConnection: false,
+        oauthStorage: storage,
       }),
     ).toBe(false);
   });

--- a/clients/web/src/utils/clearServerOAuthState.ts
+++ b/clients/web/src/utils/clearServerOAuthState.ts
@@ -1,4 +1,4 @@
-import { getBrowserOAuthStorage } from "@inspector/core/auth/browser/index.js";
+import type { OAuthStorage } from "@inspector/core/auth/storage.js";
 import { getOAuthServerUrl } from "@inspector/core/mcp/config.js";
 import type { InspectorClient } from "@inspector/core/mcp/inspectorClient.js";
 import type { MCPServerConfig } from "@inspector/core/mcp/types.js";
@@ -6,8 +6,10 @@ import type { MCPServerConfig } from "@inspector/core/mcp/types.js";
 export interface ClearServerOAuthStateParams {
   config: MCPServerConfig;
   /** When set and this server is the active connection, clear via the live client. */
-  inspectorClient?: InspectorClient | null;
+  inspectorClient?: Pick<InspectorClient, "clearOAuthTokens"> | null;
   isActiveConnection: boolean;
+  /** Shared web OAuth store; required so clear hits the same blob as connect. */
+  oauthStorage: OAuthStorage;
 }
 
 /**
@@ -26,7 +28,7 @@ export function clearServerOAuthState(
   if (params.isActiveConnection && params.inspectorClient) {
     params.inspectorClient.clearOAuthTokens();
   } else {
-    getBrowserOAuthStorage().clear(serverUrl);
+    params.oauthStorage.clear(serverUrl);
   }
   return true;
 }

--- a/clients/web/src/utils/clearServerOAuthState.ts
+++ b/clients/web/src/utils/clearServerOAuthState.ts
@@ -17,18 +17,18 @@ export interface ClearServerOAuthStateParams {
  * HTTP MCP server. When clearing the active connection, uses the live client so
  * in-memory flow state is reset too.
  */
-export function clearServerOAuthState(
+export async function clearServerOAuthState(
   params: ClearServerOAuthStateParams,
-): boolean {
+): Promise<boolean> {
   const serverUrl = getOAuthServerUrl(params.config);
   if (!serverUrl) {
     return false;
   }
 
   if (params.isActiveConnection && params.inspectorClient) {
-    params.inspectorClient.clearOAuthTokens();
+    await params.inspectorClient.clearOAuthTokens();
   } else {
-    params.oauthStorage.clear(serverUrl);
+    await params.oauthStorage.clear(serverUrl);
   }
   return true;
 }

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -100,6 +100,7 @@ export default defineConfig(({ command }) => {
       reporter: ['text', 'html', 'json-summary'],
       include: [
         'src/components/**/*.{ts,tsx}',
+        'src/lib/**/*.{ts,tsx}',
         'src/utils/**/*.{ts,tsx}',
         'clients/web/server/**/*.{ts,tsx}',
         path.join(repoRoot, 'core/mcp/**/*.{ts,tsx}'),

--- a/core/auth/ema/idpOidc.ts
+++ b/core/auth/ema/idpOidc.ts
@@ -34,6 +34,7 @@ async function resolveIdpMetadata(
   storage: OAuthStorage,
   fetchFn?: typeof fetch,
 ): Promise<OAuthMetadata> {
+  await storage.load();
   const storageKey = idpOAuthStorageKey(issuer);
   const cached = storage.getServerMetadata(storageKey);
   if (cached?.token_endpoint) {
@@ -63,7 +64,7 @@ export async function startIdpOidcAuthorization(params: {
   fetchFn?: typeof fetch;
 }): Promise<{ authorizationUrl: URL }> {
   const issuer = normalizeIdpIssuer(params.idp.issuer);
-  const metadata = await discoverIdpMetadata(issuer, params.fetchFn);
+  const metadata = await resolveIdpMetadata(issuer, params.storage, params.fetchFn);
   const clientInformation = idpClientInformation(params.idp);
   const storageKey = idpOAuthStorageKey(issuer);
   const state = generateOAuthState();
@@ -101,6 +102,7 @@ export async function completeIdpOidcAuthorization(params: {
 }> {
   const issuer = normalizeIdpIssuer(params.idp.issuer);
   const storageKey = idpOAuthStorageKey(issuer);
+  await params.storage.load();
   const metadata = params.storage.getServerMetadata(storageKey);
   if (!metadata) {
     throw new Error("IdP OAuth metadata not found — restart EMA IdP login");
@@ -131,7 +133,7 @@ export async function completeIdpOidcAuthorization(params: {
     throw new Error("IdP token response did not include an ID Token");
   }
 
-  params.storage.clearCodeVerifier(storageKey);
+  await params.storage.clearCodeVerifier(storageKey);
   const idTokenExpiresAt = jwtExpiresAtMs(idToken);
   await params.storage.saveIdpSession(issuer, {
     idToken,

--- a/core/auth/ema/idpSession.ts
+++ b/core/auth/ema/idpSession.ts
@@ -21,10 +21,13 @@ export async function getEmaIdpLoginState(
   return "expired";
 }
 
-export function clearEmaIdpSession(storage: OAuthStorage, issuer: string): void {
+export async function clearEmaIdpSession(
+  storage: OAuthStorage,
+  issuer: string,
+): Promise<void> {
   const normalized = normalizeIdpIssuer(issuer);
   if (!normalized) return;
-  storage.clearIdpSession(normalized);
-  storage.clear(idpOAuthStorageKey(normalized));
-  storage.clearEnterpriseManagedResourceServers();
+  await storage.clearIdpSession(normalized);
+  await storage.clear(idpOAuthStorageKey(normalized));
+  await storage.clearEnterpriseManagedResourceServers();
 }

--- a/core/auth/oauth-storage.ts
+++ b/core/auth/oauth-storage.ts
@@ -16,22 +16,48 @@ import type {
   SaveTokensOptions,
 } from "./storage.js";
 
+type OAuthStoreWithPersist = ReturnType<typeof createOAuthStore> & {
+  persist: {
+    hasHydrated: () => boolean;
+    onFinishHydration: (fn: () => void) => void;
+  };
+};
+
 /**
  * Concrete OAuthStorage implementation parameterized on a Zustand store.
  * The store carries the storage adapter (sessionStorage, file, remote HTTP, …),
  * so the same body works for browser, Node, and remote environments.
  */
 export class OAuthStorageBase implements OAuthStorage {
-  private readonly store: ReturnType<typeof createOAuthStore>;
+  private readonly store: OAuthStoreWithPersist;
+  private loadedPromise: Promise<void> | undefined;
 
   constructor(store: ReturnType<typeof createOAuthStore>) {
-    this.store = store;
+    this.store = store as OAuthStoreWithPersist;
+  }
+
+  load(): Promise<void> {
+    if (!this.loadedPromise) {
+      this.loadedPromise = new Promise((resolve) => {
+        if (this.store.persist.hasHydrated()) {
+          resolve();
+          return;
+        }
+        this.store.persist.onFinishHydration(() => resolve());
+      });
+    }
+    return this.loadedPromise;
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    await this.load();
   }
 
   async getClientInformation(
     serverUrl: string,
     isPreregistered?: boolean,
   ): Promise<OAuthClientInformation | undefined> {
+    await this.ensureLoaded();
     const state = this.store.getState().getServerState(serverUrl);
     const clientInfo = isPreregistered
       ? state.preregisteredClientInformation
@@ -56,6 +82,7 @@ export class OAuthStorageBase implements OAuthStorage {
     clientInformation: OAuthClientInformation,
     options: SaveClientInformationOptions,
   ): Promise<void> {
+    await this.ensureLoaded();
     this.store.getState().setServerState(serverUrl, {
       clientInformation,
       clientRegistrationKind: options.registrationKind,
@@ -66,13 +93,18 @@ export class OAuthStorageBase implements OAuthStorage {
     serverUrl: string,
     clientInformation: OAuthClientInformation,
   ): Promise<void> {
+    await this.ensureLoaded();
     this.store.getState().setServerState(serverUrl, {
       preregisteredClientInformation: clientInformation,
       clientRegistrationKind: "static",
     });
   }
 
-  clearClientInformation(serverUrl: string, isPreregistered?: boolean): void {
+  async clearClientInformation(
+    serverUrl: string,
+    isPreregistered?: boolean,
+  ): Promise<void> {
+    await this.ensureLoaded();
     const updates: Partial<ServerOAuthState> = {};
 
     if (isPreregistered) {
@@ -86,6 +118,7 @@ export class OAuthStorageBase implements OAuthStorage {
   }
 
   async getTokens(serverUrl: string): Promise<OAuthTokens | undefined> {
+    await this.ensureLoaded();
     const state = this.store.getState().getServerState(serverUrl);
     if (!state.tokens) {
       return undefined;
@@ -99,13 +132,15 @@ export class OAuthStorageBase implements OAuthStorage {
     tokens: OAuthTokens,
     options?: SaveTokensOptions,
   ): Promise<void> {
+    await this.ensureLoaded();
     this.store.getState().setServerState(serverUrl, {
       tokens,
       ...(options?.enterpriseManaged === true && { enterpriseManaged: true }),
     });
   }
 
-  clearTokens(serverUrl: string): void {
+  async clearTokens(serverUrl: string): Promise<void> {
+    await this.ensureLoaded();
     this.store.getState().setServerState(serverUrl, { tokens: undefined });
   }
 
@@ -118,10 +153,12 @@ export class OAuthStorageBase implements OAuthStorage {
     serverUrl: string,
     codeVerifier: string,
   ): Promise<void> {
+    await this.ensureLoaded();
     this.store.getState().setServerState(serverUrl, { codeVerifier });
   }
 
-  clearCodeVerifier(serverUrl: string): void {
+  async clearCodeVerifier(serverUrl: string): Promise<void> {
+    await this.ensureLoaded();
     this.store
       .getState()
       .setServerState(serverUrl, { codeVerifier: undefined });
@@ -133,10 +170,12 @@ export class OAuthStorageBase implements OAuthStorage {
   }
 
   async saveScope(serverUrl: string, scope: string | undefined): Promise<void> {
+    await this.ensureLoaded();
     this.store.getState().setServerState(serverUrl, { scope });
   }
 
-  clearScope(serverUrl: string): void {
+  async clearScope(serverUrl: string): Promise<void> {
+    await this.ensureLoaded();
     this.store.getState().setServerState(serverUrl, { scope: undefined });
   }
 
@@ -149,22 +188,26 @@ export class OAuthStorageBase implements OAuthStorage {
     serverUrl: string,
     metadata: OAuthMetadata,
   ): Promise<void> {
+    await this.ensureLoaded();
     this.store
       .getState()
       .setServerState(serverUrl, { serverMetadata: metadata });
   }
 
-  clearServerMetadata(serverUrl: string): void {
+  async clearServerMetadata(serverUrl: string): Promise<void> {
+    await this.ensureLoaded();
     this.store
       .getState()
       .setServerState(serverUrl, { serverMetadata: undefined });
   }
 
-  clear(serverUrl: string): void {
+  async clear(serverUrl: string): Promise<void> {
+    await this.ensureLoaded();
     this.store.getState().clearServerState(serverUrl);
   }
 
   async getIdpSession(issuer: string): Promise<IdpSessionState | undefined> {
+    await this.ensureLoaded();
     const session = this.store.getState().getIdpSession(issuer);
     if (
       !session.idToken &&
@@ -180,14 +223,17 @@ export class OAuthStorageBase implements OAuthStorage {
     issuer: string,
     session: Partial<IdpSessionState>,
   ): Promise<void> {
+    await this.ensureLoaded();
     this.store.getState().setIdpSession(issuer, session);
   }
 
-  clearIdpSession(issuer: string): void {
+  async clearIdpSession(issuer: string): Promise<void> {
+    await this.ensureLoaded();
     this.store.getState().clearIdpSession(issuer);
   }
 
-  clearEnterpriseManagedResourceServers(): void {
+  async clearEnterpriseManagedResourceServers(): Promise<void> {
+    await this.ensureLoaded();
     this.store.getState().clearEnterpriseManagedResourceServers();
   }
 }

--- a/core/auth/oauth-storage.ts
+++ b/core/auth/oauth-storage.ts
@@ -8,7 +8,11 @@ import {
   OAuthTokensSchema,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { OAuthStorage } from "./storage.js";
-import { type createOAuthStore, type ServerOAuthState } from "./store.js";
+import {
+  type OAuthStore,
+  type ServerOAuthState,
+  waitForOAuthStorePersistLoad,
+} from "./store.js";
 import type {
   IdpSessionState,
   OAuthClientRegistrationKind,
@@ -16,10 +20,9 @@ import type {
   SaveTokensOptions,
 } from "./storage.js";
 
-type OAuthStoreWithPersist = ReturnType<typeof createOAuthStore> & {
+type OAuthStoreWithPersist = OAuthStore & {
   persist: {
     hasHydrated: () => boolean;
-    onFinishHydration: (fn: () => void) => void;
   };
 };
 
@@ -32,19 +35,18 @@ export class OAuthStorageBase implements OAuthStorage {
   private readonly store: OAuthStoreWithPersist;
   private loadedPromise: Promise<void> | undefined;
 
-  constructor(store: ReturnType<typeof createOAuthStore>) {
+  constructor(store: OAuthStore) {
     this.store = store as OAuthStoreWithPersist;
   }
 
   load(): Promise<void> {
     if (!this.loadedPromise) {
-      this.loadedPromise = new Promise((resolve) => {
+      this.loadedPromise = (async () => {
         if (this.store.persist.hasHydrated()) {
-          resolve();
           return;
         }
-        this.store.persist.onFinishHydration(() => resolve());
-      });
+        await waitForOAuthStorePersistLoad(this.store);
+      })();
     }
     return this.loadedPromise;
   }

--- a/core/auth/providers.ts
+++ b/core/auth/providers.ts
@@ -247,8 +247,8 @@ export class BaseOAuthClientProvider implements OAuthClientProvider {
     return verifier;
   }
 
-  clear(): void {
-    this.storage.clear(this.serverUrl);
+  async clear(): Promise<void> {
+    await this.storage.clear(this.serverUrl);
   }
 
   getServerMetadata(): OAuthMetadata | null {

--- a/core/auth/storage.ts
+++ b/core/auth/storage.ts
@@ -22,6 +22,13 @@ export interface SaveClientInformationOptions {
 
 export interface OAuthStorage {
   /**
+   * Load persisted OAuth state into memory. Resolves when the backing store
+   * (file, remote API, sessionStorage, …) has been read. Call before relying on
+   * sync reads, or await mutating methods which call this internally.
+   */
+  load(): Promise<void>;
+
+  /**
    * Get client information (preregistered or dynamically registered)
    */
   getClientInformation(
@@ -56,7 +63,10 @@ export interface OAuthStorage {
   /**
    * Clear client information
    */
-  clearClientInformation(serverUrl: string, isPreregistered?: boolean): void;
+  clearClientInformation(
+    serverUrl: string,
+    isPreregistered?: boolean,
+  ): Promise<void>;
 
   /**
    * Get OAuth tokens
@@ -75,7 +85,7 @@ export interface OAuthStorage {
   /**
    * Clear OAuth tokens
    */
-  clearTokens(serverUrl: string): void;
+  clearTokens(serverUrl: string): Promise<void>;
 
   /**
    * Get code verifier (for PKCE)
@@ -90,7 +100,7 @@ export interface OAuthStorage {
   /**
    * Clear code verifier
    */
-  clearCodeVerifier(serverUrl: string): void;
+  clearCodeVerifier(serverUrl: string): Promise<void>;
 
   /**
    * Get scope
@@ -105,7 +115,7 @@ export interface OAuthStorage {
   /**
    * Clear scope
    */
-  clearScope(serverUrl: string): void;
+  clearScope(serverUrl: string): Promise<void>;
 
   /**
    * Get server metadata discovered during OAuth
@@ -120,12 +130,12 @@ export interface OAuthStorage {
   /**
    * Clear server metadata
    */
-  clearServerMetadata(serverUrl: string): void;
+  clearServerMetadata(serverUrl: string): Promise<void>;
 
   /**
    * Clear all OAuth data for a server
    */
-  clear(serverUrl: string): void;
+  clear(serverUrl: string): Promise<void>;
 
   /**
    * Get cached IdP OIDC session for EMA (keyed by issuer).
@@ -143,12 +153,12 @@ export interface OAuthStorage {
   /**
    * Clear cached IdP session for an issuer.
    */
-  clearIdpSession(issuer: string): void;
+  clearIdpSession(issuer: string): Promise<void>;
 
   /**
    * Remove per-server OAuth state for MCP servers whose tokens were minted via EMA.
    */
-  clearEnterpriseManagedResourceServers(): void;
+  clearEnterpriseManagedResourceServers(): Promise<void>;
 }
 
 /**

--- a/core/auth/store.ts
+++ b/core/auth/store.ts
@@ -43,6 +43,23 @@ export interface OAuthStoreState {
   clearEnterpriseManagedResourceServers: () => void;
 }
 
+export type OAuthStore = ReturnType<typeof createOAuthStore>;
+
+const persistLoadByStore = new WeakMap<OAuthStore, Promise<void>>();
+
+/**
+ * Wait until the store's initial persist read has finished (success or failure).
+ * Used by {@link OAuthStorageBase.load}; resolves on success, rejects when the
+ * storage adapter's getItem fails (Zustand does not fire onFinishHydration on error).
+ */
+export function waitForOAuthStorePersistLoad(store: OAuthStore): Promise<void> {
+  const promise = persistLoadByStore.get(store);
+  if (!promise) {
+    return Promise.resolve();
+  }
+  return promise;
+}
+
 /**
  * Creates a Zustand store for OAuth state with the given storage adapter.
  * The storage adapter handles persistence (file, remote HTTP, sessionStorage, etc.).
@@ -53,7 +70,29 @@ export interface OAuthStoreState {
 export function createOAuthStore(
   storage: ReturnType<typeof createJSONStorage>,
 ) {
-  return createStore<OAuthStoreState>()(
+  let resolvePersistLoad!: () => void;
+  let rejectPersistLoad!: (error: unknown) => void;
+  let persistLoadSettled = false;
+
+  const persistLoadPromise = new Promise<void>((resolve, reject) => {
+    resolvePersistLoad = resolve;
+    rejectPersistLoad = reject;
+  });
+
+  const settlePersistLoad = (error?: unknown) => {
+    if (persistLoadSettled) {
+      /* v8 ignore next -- idempotent if persist signals completion more than once */
+      return;
+    }
+    persistLoadSettled = true;
+    if (error) {
+      rejectPersistLoad(error);
+      return;
+    }
+    resolvePersistLoad();
+  };
+
+  const store = createStore<OAuthStoreState>()(
     persist(
       (set, get) => ({
         servers: {},
@@ -118,7 +157,13 @@ export function createOAuthStore(
       {
         name: "mcp-inspector-oauth",
         storage,
+        onRehydrateStorage: () => (_state, error) => {
+          settlePersistLoad(error);
+        },
       },
     ),
   );
+
+  persistLoadByStore.set(store, persistLoadPromise);
+  return store;
 }

--- a/core/auth/store.ts
+++ b/core/auth/store.ts
@@ -78,6 +78,13 @@ export function createOAuthStore(
     resolvePersistLoad = resolve;
     rejectPersistLoad = reject;
   });
+  // Zustand kicks off async hydration as soon as the store is created, before
+  // any consumer calls `OAuthStorageBase.load()`. If that initial read fails
+  // and no one is awaiting yet, `persistLoadPromise` would reject with no
+  // handler and surface as an unhandled rejection. Attach a no-op handler so
+  // the promise is always "handled"; real awaiters still observe the rejection
+  // through the reference returned by `waitForOAuthStorePersistLoad`.
+  void persistLoadPromise.catch(() => {});
 
   const settlePersistLoad = (error?: unknown) => {
     if (persistLoadSettled) {

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -3064,8 +3064,8 @@ export class InspectorClient extends InspectorClientEventTarget {
   /**
    * Clears OAuth tokens and client information
    */
-  clearOAuthTokens(): void {
-    this.oauthManager?.clearOAuthTokens();
+  async clearOAuthTokens(): Promise<void> {
+    await this.oauthManager?.clearOAuthTokens();
   }
 
   /**

--- a/core/mcp/oauthManager.ts
+++ b/core/mcp/oauthManager.ts
@@ -282,6 +282,8 @@ export class OAuthManager {
     iss?: string,
   ): Promise<void> {
     try {
+      await this.requireStorage().load();
+
       if (this.isEnterpriseManaged()) {
         const scopeForMint =
           this.pendingAuthorizationScope ?? this.getEmaFlowConfig().scope;
@@ -387,13 +389,13 @@ export class OAuthManager {
     }
   }
 
-  clearOAuthTokens(): void {
+  async clearOAuthTokens(): Promise<void> {
     if (!this.oauthConfig?.storage) {
       return;
     }
 
     const serverUrl = this.getServerUrl();
-    this.oauthConfig.storage.clear(serverUrl);
+    await this.oauthConfig.storage.clear(serverUrl);
 
     this.oauthFlowState = null;
     this.pendingAuthorizationScope = undefined;

--- a/core/react/useEmaIdpLoginState.ts
+++ b/core/react/useEmaIdpLoginState.ts
@@ -40,8 +40,9 @@ export function useEmaIdpLoginState(
 
   const logout = useCallback(() => {
     if (!normalizedIssuer) return;
-    clearEmaIdpSession(storage, normalizedIssuer);
-    setLoginState("none");
+    void clearEmaIdpSession(storage, normalizedIssuer).then(() => {
+      setLoginState("none");
+    });
   }, [storage, normalizedIssuer]);
 
   return { loginState, refresh, logout };

--- a/core/react/useEmaIdpLoginState.ts
+++ b/core/react/useEmaIdpLoginState.ts
@@ -40,9 +40,17 @@ export function useEmaIdpLoginState(
 
   const logout = useCallback(() => {
     if (!normalizedIssuer) return;
-    void clearEmaIdpSession(storage, normalizedIssuer).then(() => {
-      setLoginState("none");
-    });
+    void clearEmaIdpSession(storage, normalizedIssuer)
+      .then(() => {
+        setLoginState("none");
+      })
+      .catch(() => {
+        // Clearing the persisted IdP session failed (e.g. the storage backend
+        // is unreachable). Swallow the rejection so it does not surface as an
+        // unhandled promise, and leave loginState unchanged so the UI keeps
+        // reflecting the still-present session rather than falsely showing
+        // signed-out.
+      });
   }, [storage, normalizedIssuer]);
 
   return { loginState, refresh, logout };

--- a/specification/v2_auth_ema.md
+++ b/specification/v2_auth_ema.md
@@ -111,12 +111,11 @@ Until **client profiles** (see below) land, install-level client config — star
 
 **Runtime auth state** (standard OAuth tokens, PKCE, **and** EMA runtime state: cached IdP ID Token / refresh token, leg-1 in-flight PKCE under `ema-idp:{issuer}`, and per-server resource tokens tagged `enterpriseManaged: true` when minted via EMA legs 2–3) uses the existing **`OAuthStorage`** interface (`core/auth/storage.ts`) — whatever adapter each client already passes to `InspectorClient`. ID-JAG is **not** cached — legs 2–3 re-mint on each connect or 401 refresh. EMA does **not** mandate a specific backing store; it extends the serialized auth state that adapter already persists.
 
-No EMA-specific migration of web OAuth persistence is required for the initial ship — sessionStorage-backed web sessions work for EMA today. **Follow-up:** shared file-backed OAuth via `RemoteOAuthStorage` → `/api/storage/oauth` so web matches CLI/TUI (see §Follow-up work).
+Web uses shared file-backed OAuth via `RemoteOAuthStorage` → `/api/storage/oauth` (same `oauth.json` as CLI/TUI). Existing **sessionStorage** OAuth blobs from before that wiring are not migrated automatically — users start fresh or re-authorize once.
 
 | Client | Config (`client.json`) | Runtime auth state (`OAuthStorage`) |
 | ------ | ---------------------- | ----------------------------------- |
-| **Web (today)** | `RemoteStorage` adapter → `/api/storage/client` | `BrowserOAuthStorage` → sessionStorage |
-| **Web (target)** | same | `RemoteOAuthStorage` → `/api/storage/oauth` → `~/.mcp-inspector/storage/oauth.json` |
+| **Web** | `RemoteStorage` adapter → `/api/storage/client` | `RemoteOAuthStorage` → `/api/storage/oauth` → `~/.mcp-inspector/storage/oauth.json` (via `getWebRemoteOAuthStorage()` in `clients/web/src/lib/remoteOAuthStorage.ts`) |
 | **CLI / TUI** | `NodeClientStorage` (file adapter) | `NodeOAuthStorage` → `oauth.json` |
 
 On-disk shape (initial):
@@ -299,7 +298,7 @@ Install-level IdP credentials are edited in **Client Settings**, separate from p
   2. Clears leg-1 in-flight state at `servers["ema-idp:{issuer}"]`
   3. Calls `OAuthStorage.clearEnterpriseManagedResourceServers()` — scans the shared OAuth blob and removes `servers[url]` entries where `enterpriseManaged === true` (set when EMA legs 2–3 saved tokens via `saveTokens(url, tokens, { enterpriseManaged: true })` in `emaFlow.ts` / `EmaTransportOAuthProvider`). Standard OAuth entries in the same blob are **not** cleared. Untagged legacy EMA tokens (saved before tagging landed) are not removed until the next EMA connect re-saves with the tag.
   The next connect to a cleared EMA server has no cached access token, so a **401** triggers leg 1 (IdP login) via `authenticate()`.
-- **Web OAuth store singleton:** web uses `getBrowserOAuthStorage()` (`core/auth/browser/storage.ts`) so Client Settings sign-out updates the same in-memory Zustand store as the active `InspectorClient` (not a separate `BrowserOAuthStorage` instance per consumer).
+- **Web OAuth store singleton:** web uses `getWebRemoteOAuthStorage()` (`clients/web/src/lib/remoteOAuthStorage.ts`) — memoized `RemoteOAuthStorage` backed by `/api/storage/oauth` — so Client Settings sign-out, EMA IdP session, connect, and per-server clear all mutate the same in-memory Zustand view as the active `InspectorClient`.
 
 **Future (not implemented):** explicit **Sign out** may additionally invoke the IdP's OIDC **end-session** / logout endpoint (RP-initiated logout) so the IdP SSO cookie is cleared — not just inspector-local IdP/resource token state. Today sign-out is **local-only** (clear `idpSessions`, tagged EMA resource entries, and leg-1 PKCE); the IdP may still treat the browser as signed in and skip the login prompt on the next authorize redirect until the IdP session expires or the user signs out at the IdP.
 
@@ -347,7 +346,7 @@ Leg 1 is **OIDC authorization-code login** against the enterprise IdP using cred
 
 | Client | Leg 1 mechanism (same stack as standard OAuth in that client) |
 | ------ | ------------------------------------------------------------- |
-| **Web** | Browser redirect via `navigation`; callback at `/oauth/callback`; `InspectorClient.completeOAuthFlow(code)`; `BrowserOAuthStorage` |
+| **Web** | Browser redirect via `navigation`; callback at `/oauth/callback`; `InspectorClient.completeOAuthFlow(code)`; `RemoteOAuthStorage` → shared `oauth.json` |
 | **TUI / CLI** | `OAuthCallbackServer` opens local callback; system browser for authorize URL; `completeOAuthFlow(code)`; `NodeOAuthStorage` |
 
 **Silent connect:** if a valid cached ID Token exists for the configured issuer, skip the interactive redirect and proceed to leg 2.
@@ -422,7 +421,8 @@ Inspector touchpoints to extend:
 - `core/mcp/oauthManager.ts` — branch on `enterpriseManaged`; EMA connect via `emaFlow`; `getOAuthState()`; `createOAuthProvider()` returns `EmaTransportOAuthProvider` for EMA servers (401 re-auth); standard OAuth unchanged
 - `core/mcp/inspectorClient.ts` — declare EMA extension in `initialize` capabilities when `enterpriseManaged`; `getOAuthState()`
 - `core/react/useEmaIdpLoginState.ts` — Client Settings IdP session status; calls `clearEmaIdpSession` on sign-out (no catalog wiring)
-- `core/auth/browser/storage.ts` — `getBrowserOAuthStorage()` singleton (web)
+- `clients/web/src/lib/remoteOAuthStorage.ts` — `getWebRemoteOAuthStorage()` singleton (web OAuth runtime store)
+- `core/auth/browser/storage.ts` — `BrowserOAuthStorage` / `getBrowserOAuthStorage()` (sessionStorage; reference provider only, not wired in v2 web app)
 - `clients/web` — **Client Settings** modal; **Connection Info** OAuth snapshot; friendly EMA connect toasts; load client config at startup; `ServerSettingsForm` OAuth section (HTTP/SSE only); web callback flow tagging for IdP vs resource OAuth
 - `clients/cli`, `clients/tui` — load `client.json` at startup; pass into `InspectorClient`; leg 1 via same `OAuthCallbackServer` + `NodeOAuthStorage` stack as TUI standard OAuth today
 
@@ -515,7 +515,7 @@ Design decisions for EMA are complete. Remaining work is the phased plan and che
 ### Later
 
 - [ ] **Remove Zustand from OAuth persistence** — direct read/write of OAuth blob; see §Follow-up work
-- [ ] **Web shared OAuth store** — `RemoteOAuthStorage` / `oauth.json` for web + CLI + TUI parity; see §Follow-up work
+- [x] **Web shared OAuth store** — `RemoteOAuthStorage` / `oauth.json` for web + CLI + TUI parity (#1548); see §Follow-up work
 - [ ] Client profile persistence (migrate from `client.json`; may extend or replace web Client Settings)
 - [ ] Optional: adopt `@modelcontextprotocol/client` v2 Layer-2 helpers for legs 2–3 (replace `wire.ts`) or full v2 transport for EMA
 - [ ] Optional: IdP **end-session** / RP-initiated logout on explicit **Sign out** (today sign-out clears inspector-local IdP session and tagged EMA resource tokens only; IdP browser SSO may remain active)
@@ -558,24 +558,26 @@ These items came out of EMA staging and apply beyond EMA. They are **not** requi
 Today `OAuthStorage` is backed by a **Zustand** `persist` store (`core/auth/store.ts`) with adapters for sessionStorage (`BrowserOAuthStorage`), file (`NodeOAuthStorage` via `file-storage.ts`), and HTTP (`RemoteOAuthStorage` via `remote-storage.ts`). The Zustand layer wraps a simple `{ servers, idpSessions }` blob and adds:
 
 - `{ state, version }` envelope on file/remote adapters (see [Servers file](v2_servers_file.md) — intentionally avoided for `mcp.json`)
-- A second in-memory copy and async persist semantics that complicate sign-out, callback rebuild, and multi-consumer sharing (`getBrowserOAuthStorage()` singleton exists partly to paper over this)
+- A second in-memory copy and async persist semantics that complicate sign-out, callback rebuild, and multi-consumer sharing (web uses `getWebRemoteOAuthStorage()`; legacy `getBrowserOAuthStorage()` existed partly to paper over this for sessionStorage)
 
 **Direction:** refactor `OAuthStorage` implementations to read/write the serialized shape **directly** (file I/O, `/api/storage/oauth`, or in-memory for tests) without Zustand. Keep the `OAuthStorage` interface stable for `InspectorClient` / `OAuthManager`.
 
 ### Shared file-backed OAuth state (web + CLI + TUI)
 
-Today:
+**Status (July 2026):** Web is wired through `RemoteOAuthStorage` (`environmentFactory.ts`, `App.tsx`, `getWebRemoteOAuthStorage()`). CLI/TUI continue to use `NodeOAuthStorage` on the same on-disk file when using the default local backend.
 
 | Client | OAuth runtime store |
 | ------ | ------------------- |
-| **Web** | `BrowserOAuthStorage` → **sessionStorage** (tab-local; lost on new tab / callback page load relies on same tab) |
+| **Web** | `RemoteOAuthStorage` → `/api/storage/oauth` → `~/.mcp-inspector/storage/oauth.json` |
 | **CLI / TUI** | `NodeOAuthStorage` → `~/.mcp-inspector/storage/oauth.json` |
 
-`RemoteOAuthStorage` already exists (`core/auth/remote/storage-remote.ts`) and talks to **`GET/POST/DELETE /api/storage/oauth`** on the local Hono backend — the same generic storage API that persists to disk under `~/.mcp-inspector/storage/`. Integration tests use it (`inspectorClient-oauth-remote-storage-e2e.test.ts`).
+`RemoteOAuthStorage` (`core/auth/remote/storage-remote.ts`) talks to **`GET/POST/DELETE /api/storage/oauth`** on the local Hono backend — the same generic storage API that persists to disk under `~/.mcp-inspector/storage/`. Integration tests use it (`inspectorClient-oauth-remote-storage-e2e.test.ts`).
 
-**Direction:** wire the **web app** through `RemoteOAuthStorage` (via `environmentFactory.ts` / `App.tsx`) instead of `BrowserOAuthStorage`, so web, CLI, and TUI share one **`oauth.json`** when using the default local backend. Benefits: IdP session and EMA resource tokens survive browser refresh; sign-out in Client Settings and connect use the same store without a sessionStorage singleton; EMA testing matches how CLI/TUI will behave in Phase 4.
+**Benefits:** IdP session and EMA resource tokens survive browser refresh; sign-out in Client Settings and connect use the same store; EMA testing matches CLI/TUI behavior.
 
-**Migration:** one-time import or “start fresh” for existing sessionStorage OAuth blobs; document that enabling shared storage is the default for local dev.
+**Migration:** no automatic import from old sessionStorage OAuth blobs; document that local dev uses shared `oauth.json` by default.
+
+**Optional follow-up:** `navigator.locks` for cross-tab single-flight on silent refresh (see [Mid-session auth](v2_auth_mid_session.md)).
 
 ---
 

--- a/specification/v2_auth_mid_session.md
+++ b/specification/v2_auth_mid_session.md
@@ -338,7 +338,7 @@ Snapshots **per app tab UI**, not message logs, tool results, or network bodies.
 
 ### Multiple browser tabs
 
-Each browser tab has its own `RemoteSession` and (today) `BrowserOAuthStorage` in `sessionStorage`. SSE `auth_challenge` is scoped to that session.
+Each browser tab has its own `RemoteSession`. OAuth runtime state is shared file-backed (`RemoteOAuthStorage` → `oauth.json`) across tabs on the same backend; SSE `auth_challenge` is scoped to that tab's session.
 
 When a tab is **hidden**, **interactive** OAuth must not steal focus:
 
@@ -413,7 +413,7 @@ Legacy **SSE** transport: **401 only** on mid-session `send()` (no 403 step-up).
 | ------- | --- | --- | --- |
 | Challenge detection | Inline send + SSE ambient | SDK transport + intercept | Same as TUI |
 | Auth execution | Browser `OAuthManager` | Node `OAuthManager` | Node `OAuthManager` |
-| OAuth storage | `BrowserOAuthStorage` (sessionStorage) | `NodeOAuthStorage` (file) | Same file as TUI |
+| OAuth storage | `RemoteOAuthStorage` → `oauth.json` (via `/api/storage/oauth`) | `NodeOAuthStorage` (file) | Same file as TUI |
 | Silent recovery | `auth-state` push + send retry | Reconnect / SDK retry (v2) | One-shot RPC retry |
 | Interactive recovery | Modal + full-page redirect + snapshot | Auth tab + callback | stderr **y/N** + callback |
 | Step-up confirm | `StepUpAuthModal` | Auth tab **A** / **C** | **y/N** |


### PR DESCRIPTION
Closes #1548

## Summary

Wire the v2 **web client** through shared file-backed OAuth storage instead of tab-local `sessionStorage`.

- Web OAuth runtime state now uses `RemoteOAuthStorage` → `GET/POST /api/storage/oauth` → `~/.mcp-inspector/storage/oauth.json` (same on-disk file as CLI/TUI when using the default local backend).
- New web-local accessor `getWebRemoteOAuthStorage()` (`clients/web/src/lib/remoteOAuthStorage.ts`) memoizes one in-memory `RemoteOAuthStorage` per `{ origin, authToken }` so connect, EMA IdP session, and per-server “clear stored OAuth” all mutate the same Zustand view.
- **`core/` unchanged** — no Zustand removal, no async storage interface churn (#1549 / #1592-style work stays out of scope).

### Why

| Before | After |
| ------ | ----- |
| `BrowserOAuthStorage` → `sessionStorage` (tab-local) | `RemoteOAuthStorage` → `oauth.json` (shared with CLI/TUI) |
| IdP session / tokens lost on refresh or cross-tab | Survive refresh; callback no longer depends on same-tab sessionStorage |
| Separate singleton (`getBrowserOAuthStorage`) | Web singleton (`getWebRemoteOAuthStorage`) over remote adapter |

### Call chain

```
App.tsx / environmentFactory.ts
  → getWebRemoteOAuthStorage(authToken)
  → RemoteOAuthStorage (core/auth/remote/storage-remote.ts)
  → /api/storage/oauth (Hono backend)
  → ~/.mcp-inspector/storage/oauth.json
```

`authToken` is forwarded on storage HTTP calls as `x-mcp-remote-auth` when the backend requires it (same as transport/fetch/logger).

---

## Changes

### New

| File | Purpose |
| ---- | ------- |
| `clients/web/src/lib/remoteOAuthStorage.ts` | Memoized `getRemoteOAuthStorage` / `getWebRemoteOAuthStorage` |
| `clients/web/src/lib/remoteOAuthStorage.test.ts` | Cache key, origin, window guard, cache reset |
| `clients/web/src/lib/environmentFactory.test.ts` | Wiring: shared storage, navigation, redirect provider, fetch wrapper |

### Modified (web)

| File | Change |
| ---- | ------ |
| `clients/web/src/lib/environmentFactory.ts` | `getWebRemoteOAuthStorage(authToken)` instead of `getBrowserOAuthStorage()`; doc comment |
| `clients/web/src/App.tsx` | `webOAuthStorage` useMemo; EMA + clear OAuth use shared store; callback comment |
| `clients/web/src/utils/clearServerOAuthState.ts` | Accept `oauthStorage: OAuthStorage`; active client narrowed to `Pick<InspectorClient, "clearOAuthTokens">` |
| `clients/web/vite.config.ts` | Add `src/lib/**` to coverage `include` |

### Tests / coverage

| File | Change |
| ---- | ------ |
| `clearServerOAuthState.test.ts` | Isolated `BrowserOAuthStorage` instances; typed client stub (no `as never`) |
| `storage-browser.test.ts` | `getBrowserOAuthStorage` singleton branch (coverage for core helper still used elsewhere) |

### Spec

| File | Change |
| ---- | ------ |
| `specification/v2_auth_ema.md` | Web on shared `oauth.json`; mark #1548 follow-up done |
| `specification/v2_auth_mid_session.md` | Client matrix + multi-tab OAuth storage note |

---

## Out of scope (follow-ups)

- **#1549** — Remove Zustand from OAuth persistence; plain JSON blob read/write.
- **`navigator.locks`** — Cross-tab single-flight on silent refresh (noted in spec).

---

## Review notes

- **Singleton cache** is intentional: each `RemoteOAuthStorage` instance owns a separate in-memory Zustand store; memoization matches the old `getBrowserOAuthStorage()` pattern.
- **`clearServerOAuthState` plumbs `oauthStorage`** from `App` so unit tests stay isolated without stubbing `window`/remote fetch; parameter types narrowed to what the helper actually calls.
- **`useMemo([], getAuthToken())`** matches existing `sessionStorageAdapter` assumption: API token is stable for the page lifetime (injected `__INSPECTOR_API_TOKEN__` on load).
