### PR TITLE
fix(server): preserve Windows path backslashes when parsing stdio args

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -436,7 +436,14 @@ const createTransport = async (
 
   if (transportType === "stdio") {
     const command = (query.command as string).trim();
-    const origArgs = shellParseArgs(query.args as string) as string[];
+    // shell-quote's default escape character `\` strips backslashes from Windows
+    // paths (C:\Users\app.jar -> C:Usersapp.jar), so on Windows parse with
+    // cmd.exe's escape character `^` instead.
+    const origArgs = shellParseArgs(
+      query.args as string,
+      undefined,
+      process.platform === "win32" ? { escape: "^" } : undefined,
+    ) as string[];
     const queryEnv = query.env ? JSON.parse(query.env as string) : {};
     const env = { ...defaultEnvironment, ...process.env, ...queryEnv };
 


### PR DESCRIPTION
## Summary

On Windows, launching a server whose arguments contain a path like
`C:\Users\name\app.jar` fails because the proxy strips the backslashes while
tokenizing the args string. shell-quote uses `\` as its escape character by
default, which is right for POSIX shells but wrong for Windows paths. This
change passes `{ escape: "^" }` (cmd.exe's escape character) to shell-quote on
win32 only. One call site in `server/src/index.ts`, no new files or
dependencies.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

`createTransport` in `server/src/index.ts` now calls `shellParseArgs` with a
parse option that sets the escape character to `^` when
`process.platform === "win32"`. On every other platform the options argument
is `undefined`, which shell-quote treats exactly like the old two-argument
call.

## Related Issues

Fixes #853

## Testing

- [x] Tested in UI mode
- [ ] Tested in CLI mode
- [x] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [ ] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

Reproduced on Windows 10 with the flow from the issue:
`node client/bin/start.js node C:\path\to\script.js`, then Connect in the UI.
Before the fix the server log shows
`STDIO transport: ... args=C:Userspathtoscript.js` and the spawn cannot find
the file. With the fix the same steps log the path intact and the script
actually runs.

Other inputs I checked on Windows: a quoted path with spaces
(`"C:\Program Files\My App\server.jar"`), a UNC path
(`\\server\share\tool.jar`), quoted values with spaces
(`--name="hello world"`), plain flag-style args, and a trailing backslash
(`--dir C:\Users\test\ --flag`), which previously also merged the two
following tokens into one argument. Non-Windows parsing is untouched.

One behavior note: on Windows a bare `^` is now consumed as an escape
character, same as in cmd.exe. Quoting it (`"foo^bar"`) keeps it literal.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None.
