### PR TITLE
feat(web): pin Logging/History/Network as a resizable column (#1616)

### DIFF
--- a/clients/web/src/App.css
+++ b/clients/web/src/App.css
@@ -422,3 +422,30 @@
   z-index: 200;
   box-shadow: var(--mantine-shadow-sm);
 }
+
+/*
+ * Draggable vertical divider between the primary screen area and the pinned
+ * monitoring column (#1616). The col-resize cursor, the hover/active accent,
+ * and the drag-time user-select suppression are all pseudo-selector / cursor /
+ * cross-element concerns that can't be expressed as Mantine props, so the whole
+ * unit lives here rather than split across the theme.
+ */
+.resize-handle {
+  flex: 0 0 auto;
+  width: 6px;
+  cursor: col-resize;
+  background-color: var(--inspector-border-default);
+  transition: background-color 120ms ease;
+  touch-action: none;
+}
+
+.resize-handle:hover,
+.resize-handle:focus-visible {
+  background-color: var(--mantine-primary-color-filled);
+}
+
+/* Suppress text selection anywhere on the page while a drag is in progress. */
+body.resizing-col {
+  user-select: none;
+  cursor: col-resize;
+}

--- a/clients/web/src/components/elements/EmbeddableScrollArea/EmbeddableScrollArea.stories.tsx
+++ b/clients/web/src/components/elements/EmbeddableScrollArea/EmbeddableScrollArea.stories.tsx
@@ -1,0 +1,43 @@
+import { createRef } from "react";
+import { Stack, Text } from "@mantine/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { EmbeddableScrollArea } from "./EmbeddableScrollArea";
+
+const meta: Meta<typeof EmbeddableScrollArea> = {
+  title: "Elements/EmbeddableScrollArea",
+  component: EmbeddableScrollArea,
+};
+
+export default meta;
+type Story = StoryObj<typeof EmbeddableScrollArea>;
+
+const rows = Array.from({ length: 40 }, (_, i) => (
+  <Text key={i}>Row {i + 1}</Text>
+));
+
+export const FullSize: Story = {
+  render: () => (
+    <EmbeddableScrollArea embedded={false} viewportRef={createRef()}>
+      <Stack gap="xs">{rows}</Stack>
+    </EmbeddableScrollArea>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText("Row 1")).toBeInTheDocument();
+  },
+};
+
+export const Embedded: Story = {
+  render: () => (
+    <Stack h={240} gap={0}>
+      <EmbeddableScrollArea embedded viewportRef={createRef()}>
+        <Stack gap="xs">{rows}</Stack>
+      </EmbeddableScrollArea>
+    </Stack>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText("Row 1")).toBeInTheDocument();
+  },
+};

--- a/clients/web/src/components/elements/EmbeddableScrollArea/EmbeddableScrollArea.test.tsx
+++ b/clients/web/src/components/elements/EmbeddableScrollArea/EmbeddableScrollArea.test.tsx
@@ -1,0 +1,34 @@
+import { createRef } from "react";
+import { describe, it, expect } from "vitest";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { EmbeddableScrollArea } from "./EmbeddableScrollArea";
+
+describe("EmbeddableScrollArea", () => {
+  it("renders its children full-size", () => {
+    renderWithMantine(
+      <EmbeddableScrollArea embedded={false} viewportRef={createRef()}>
+        <div>full-size content</div>
+      </EmbeddableScrollArea>,
+    );
+    expect(screen.getByText("full-size content")).toBeInTheDocument();
+  });
+
+  it("renders its children when embedded", () => {
+    renderWithMantine(
+      <EmbeddableScrollArea embedded={true} viewportRef={createRef()}>
+        <div>embedded content</div>
+      </EmbeddableScrollArea>,
+    );
+    expect(screen.getByText("embedded content")).toBeInTheDocument();
+  });
+
+  it("attaches the viewport ref to the scroll viewport", () => {
+    const ref = createRef<HTMLDivElement>();
+    renderWithMantine(
+      <EmbeddableScrollArea embedded={false} viewportRef={ref}>
+        <div>content</div>
+      </EmbeddableScrollArea>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+});

--- a/clients/web/src/components/elements/EmbeddableScrollArea/EmbeddableScrollArea.tsx
+++ b/clients/web/src/components/elements/EmbeddableScrollArea/EmbeddableScrollArea.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode, Ref } from "react";
+import { ScrollArea, Stack } from "@mantine/core";
+
+// Full-size, the monitor stream panels bound their scroll to the viewport
+// minus the header and the panel's own chrome.
+const FULLSIZE_MAH =
+  "calc(100vh - var(--app-shell-header-height, 0px) - 150px)";
+
+export interface EmbeddableScrollAreaProps {
+  /**
+   * True when rendered inside the pinned monitoring column (#1616): the scroll
+   * region fills its flex parent instead of using the viewport calc. A
+   * `flex:1 / mih:0` wrapper caps the inner `ScrollArea` at the space remaining
+   * below the column's controls (via `mah:100%`), so no viewport math is needed
+   * and the final rows never clip.
+   */
+  embedded: boolean;
+  viewportRef: Ref<HTMLDivElement>;
+  children: ReactNode;
+}
+
+/**
+ * The scroll region shared by the Logs / History / Network stream panels, which
+ * render both full-size (their own tab) and embedded (the monitoring column).
+ * Centralizes the one layout difference between those two hosts.
+ */
+export function EmbeddableScrollArea({
+  embedded,
+  viewportRef,
+  children,
+}: EmbeddableScrollAreaProps) {
+  if (embedded) {
+    return (
+      <Stack flex={1} mih={0} gap={0}>
+        <ScrollArea.Autosize
+          viewportRef={viewportRef}
+          mah="100%"
+          type="scroll"
+          offsetScrollbars
+        >
+          {children}
+        </ScrollArea.Autosize>
+      </Stack>
+    );
+  }
+  return (
+    <ScrollArea.Autosize
+      viewportRef={viewportRef}
+      mah={FULLSIZE_MAH}
+      type="scroll"
+      offsetScrollbars
+    >
+      {children}
+    </ScrollArea.Autosize>
+  );
+}

--- a/clients/web/src/components/elements/PinColumnButton/PinColumnButton.stories.tsx
+++ b/clients/web/src/components/elements/PinColumnButton/PinColumnButton.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, within } from "storybook/test";
+import { PinColumnButton } from "./PinColumnButton";
+
+const meta: Meta<typeof PinColumnButton> = {
+  title: "Elements/PinColumnButton",
+  component: PinColumnButton,
+  args: { onPin: fn() },
+};
+
+export default meta;
+type Story = StoryObj<typeof PinColumnButton>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(
+      canvas.getByRole("button", { name: "Pin as column" }),
+    ).toBeInTheDocument();
+  },
+};

--- a/clients/web/src/components/elements/PinColumnButton/PinColumnButton.test.tsx
+++ b/clients/web/src/components/elements/PinColumnButton/PinColumnButton.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { PinColumnButton } from "./PinColumnButton";
+
+describe("PinColumnButton", () => {
+  it("renders a labelled pin-as-column button", () => {
+    renderWithMantine(<PinColumnButton onPin={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: "Pin as column" }),
+    ).toBeInTheDocument();
+  });
+
+  it("invokes onPin when clicked", async () => {
+    const user = userEvent.setup();
+    const onPin = vi.fn();
+    renderWithMantine(<PinColumnButton onPin={onPin} />);
+    await user.click(screen.getByRole("button", { name: "Pin as column" }));
+    expect(onPin).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/components/elements/PinColumnButton/PinColumnButton.tsx
+++ b/clients/web/src/components/elements/PinColumnButton/PinColumnButton.tsx
@@ -1,0 +1,26 @@
+import { ActionIcon } from "@mantine/core";
+import { TbLayoutSidebarRightExpand } from "react-icons/tb";
+
+export interface PinColumnButtonProps {
+  /** Pin this screen into the monitoring column to the right. */
+  onPin: () => void;
+}
+
+/**
+ * Toolbar icon that pins the owning monitor screen (Logs / History / Network)
+ * into the resizable column on the right of the InspectorView (#1616). Distinct
+ * from `PinToggle` (which pins individual history entries) — this one opens a
+ * side column, so it uses a right-sidebar glyph and an "as column" label.
+ */
+export function PinColumnButton({ onPin }: PinColumnButtonProps) {
+  return (
+    <ActionIcon
+      variant="default"
+      size="lg"
+      aria-label="Pin as column"
+      onClick={onPin}
+    >
+      <TbLayoutSidebarRightExpand size={18} />
+    </ActionIcon>
+  );
+}

--- a/clients/web/src/components/elements/PinColumnButton/PinColumnButton.tsx
+++ b/clients/web/src/components/elements/PinColumnButton/PinColumnButton.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon } from "@mantine/core";
+import { Button } from "@mantine/core";
 import { TbLayoutSidebarRightExpand } from "react-icons/tb";
 
 export interface PinColumnButtonProps {
@@ -7,20 +7,21 @@ export interface PinColumnButtonProps {
 }
 
 /**
- * Toolbar icon that pins the owning monitor screen (Logs / History / Network)
+ * Toolbar button that pins the owning monitor screen (Logs / History / Network)
  * into the resizable column on the right of the InspectorView (#1616). Distinct
  * from `PinToggle` (which pins individual history entries) — this one opens a
- * side column, so it uses a right-sidebar glyph and an "as column" label.
+ * side column, so it uses a right-sidebar glyph and an "as column" label. Styled
+ * to match the panel's expand/collapse `ListToggle` (subtle icon button).
  */
 export function PinColumnButton({ onPin }: PinColumnButtonProps) {
   return (
-    <ActionIcon
-      variant="default"
-      size="lg"
+    <Button
+      size="sm"
+      variant="subtle"
       aria-label="Pin as column"
       onClick={onPin}
     >
-      <TbLayoutSidebarRightExpand size={18} />
-    </ActionIcon>
+      <TbLayoutSidebarRightExpand size={20} />
+    </Button>
   );
 }

--- a/clients/web/src/components/elements/ReplayButton/ReplayButton.stories.tsx
+++ b/clients/web/src/components/elements/ReplayButton/ReplayButton.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, within } from "storybook/test";
+import { ReplayButton } from "./ReplayButton";
+
+const meta: Meta<typeof ReplayButton> = {
+  title: "Elements/ReplayButton",
+  component: ReplayButton,
+  args: { onReplay: fn() },
+};
+
+export default meta;
+type Story = StoryObj<typeof ReplayButton>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole("button", { name: "Replay" })).toBeInTheDocument();
+  },
+};

--- a/clients/web/src/components/elements/ReplayButton/ReplayButton.test.tsx
+++ b/clients/web/src/components/elements/ReplayButton/ReplayButton.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { ReplayButton } from "./ReplayButton";
+
+describe("ReplayButton", () => {
+  it("renders a labelled replay button", () => {
+    renderWithMantine(<ReplayButton onReplay={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Replay" })).toBeInTheDocument();
+  });
+
+  it("invokes onReplay when clicked", async () => {
+    const user = userEvent.setup();
+    const onReplay = vi.fn();
+    renderWithMantine(<ReplayButton onReplay={onReplay} />);
+    await user.click(screen.getByRole("button", { name: "Replay" }));
+    expect(onReplay).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/components/elements/ReplayButton/ReplayButton.tsx
+++ b/clients/web/src/components/elements/ReplayButton/ReplayButton.tsx
@@ -1,0 +1,26 @@
+import { ActionIcon } from "@mantine/core";
+import { MdReplay } from "react-icons/md";
+
+export interface ReplayButtonProps {
+  /** Re-send the owning history request. */
+  onReplay: () => void;
+}
+
+/**
+ * Icon form of the "Replay" action, used in the compact (column) HistoryEntry
+ * layout where the text button is replaced by a replay icon sitting next to the
+ * pin toggle (#1616). Matches PinToggle's subtle gray icon-button styling.
+ */
+export function ReplayButton({ onReplay }: ReplayButtonProps) {
+  return (
+    <ActionIcon
+      variant="subtle"
+      color="gray"
+      size="md"
+      aria-label="Replay"
+      onClick={onReplay}
+    >
+      <MdReplay size={18} />
+    </ActionIcon>
+  );
+}

--- a/clients/web/src/components/elements/ResizeHandle/ResizeHandle.stories.tsx
+++ b/clients/web/src/components/elements/ResizeHandle/ResizeHandle.stories.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { Box, Group, Text } from "@mantine/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { ResizeHandle } from "./ResizeHandle";
+
+const meta: Meta<typeof ResizeHandle> = {
+  title: "Elements/ResizeHandle",
+  component: ResizeHandle,
+};
+
+export default meta;
+type Story = StoryObj<typeof ResizeHandle>;
+
+// A minimal split so the handle has a panel to resize in the docs view. The
+// panel sits to the right; dragging the handle left widens it.
+function ResizeDemo() {
+  const [width, setWidth] = useState(320);
+  const [dragWidth, setDragWidth] = useState<number | null>(null);
+  return (
+    <Group h={200} gap={0} wrap="nowrap">
+      <Box flex={1} bg="var(--inspector-surface-subtle)" p="md">
+        <Text>Primary</Text>
+      </Box>
+      <ResizeHandle
+        value={dragWidth ?? width}
+        min={200}
+        max={520}
+        onChange={setDragWidth}
+        onCommit={(next) => {
+          setWidth(next);
+          setDragWidth(null);
+        }}
+        aria-label="Resize demo panel"
+      />
+      <Box w={dragWidth ?? width} p="md" bg="var(--inspector-surface-card)">
+        <Text>Column ({dragWidth ?? width}px)</Text>
+      </Box>
+    </Group>
+  );
+}
+
+export const Default: Story = {
+  render: () => <ResizeDemo />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(
+      canvas.getByRole("separator", { name: "Resize demo panel" }),
+    ).toBeInTheDocument();
+  },
+};

--- a/clients/web/src/components/elements/ResizeHandle/ResizeHandle.test.tsx
+++ b/clients/web/src/components/elements/ResizeHandle/ResizeHandle.test.tsx
@@ -86,6 +86,28 @@ describe("ResizeHandle", () => {
     expect(document.body.classList.contains("resizing-col")).toBe(false);
   });
 
+  it("clears the drag body class if it unmounts mid-drag", () => {
+    const onChange = vi.fn();
+    const onCommit = vi.fn();
+    const { unmount } = renderWithMantine(
+      <ResizeHandle
+        value={400}
+        min={320}
+        max={720}
+        onChange={onChange}
+        onCommit={onCommit}
+      />,
+    );
+    fireEvent.pointerDown(screen.getByRole("separator"), {
+      clientX: 500,
+      pointerId: 1,
+    });
+    expect(document.body.classList.contains("resizing-col")).toBe(true);
+    // No pointerup/cancel — the handle is removed from the tree first.
+    unmount();
+    expect(document.body.classList.contains("resizing-col")).toBe(false);
+  });
+
   it("ignores pointer moves when no drag is active", () => {
     const { handle, onChange, onCommit } = setup();
     fireEvent.pointerMove(handle, { clientX: 460, pointerId: 1 });

--- a/clients/web/src/components/elements/ResizeHandle/ResizeHandle.test.tsx
+++ b/clients/web/src/components/elements/ResizeHandle/ResizeHandle.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  renderWithMantine,
+  screen,
+  fireEvent,
+} from "../../../test/renderWithMantine";
+import { ResizeHandle } from "./ResizeHandle";
+
+// The panel sits to the RIGHT of the handle, so moving the pointer LEFT
+// (decreasing clientX) widens it: next = startWidth + (startX - clientX).
+function setup(overrides: Partial<Parameters<typeof ResizeHandle>[0]> = {}) {
+  const onChange = vi.fn();
+  const onCommit = vi.fn();
+  renderWithMantine(
+    <ResizeHandle
+      value={400}
+      min={320}
+      max={720}
+      onChange={onChange}
+      onCommit={onCommit}
+      {...overrides}
+    />,
+  );
+  return { handle: screen.getByRole("separator"), onChange, onCommit };
+}
+
+describe("ResizeHandle", () => {
+  afterEach(() => {
+    document.body.classList.remove("resizing-col");
+  });
+
+  it("exposes the separator role with live aria values", () => {
+    const { handle } = setup();
+    expect(handle).toHaveAttribute("aria-orientation", "vertical");
+    expect(handle).toHaveAttribute("aria-valuenow", "400");
+    expect(handle).toHaveAttribute("aria-valuemin", "320");
+    expect(handle).toHaveAttribute("aria-valuemax", "720");
+    expect(handle).toHaveAccessibleName("Resize panel");
+  });
+
+  it("accepts a custom aria-label", () => {
+    setup({ "aria-label": "Resize monitoring column" });
+    expect(
+      screen.getByRole("separator", { name: "Resize monitoring column" }),
+    ).toBeInTheDocument();
+  });
+
+  it("reports the widened value while dragging left and commits on release", () => {
+    const { handle, onChange, onCommit } = setup();
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 460, pointerId: 1 });
+    // startWidth 400 + (500 - 460) = 440
+    expect(onChange).toHaveBeenLastCalledWith(440);
+    expect(onCommit).not.toHaveBeenCalled();
+    fireEvent.pointerUp(handle, { clientX: 460, pointerId: 1 });
+    expect(onCommit).toHaveBeenCalledWith(440);
+  });
+
+  it("clamps to max when dragged past the upper bound", () => {
+    const { handle, onChange } = setup();
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 0, pointerId: 1 });
+    expect(onChange).toHaveBeenLastCalledWith(720);
+  });
+
+  it("clamps to min when dragged past the lower bound", () => {
+    const { handle, onChange } = setup();
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 900, pointerId: 1 });
+    expect(onChange).toHaveBeenLastCalledWith(320);
+  });
+
+  it("toggles the drag body class across the gesture", () => {
+    const { handle } = setup();
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+    expect(document.body.classList.contains("resizing-col")).toBe(true);
+    fireEvent.pointerUp(handle, { clientX: 500, pointerId: 1 });
+    expect(document.body.classList.contains("resizing-col")).toBe(false);
+  });
+
+  it("ends the drag on pointer cancel", () => {
+    const { handle, onCommit } = setup();
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+    fireEvent.pointerCancel(handle, { clientX: 480, pointerId: 1 });
+    expect(onCommit).toHaveBeenCalledWith(420);
+    expect(document.body.classList.contains("resizing-col")).toBe(false);
+  });
+
+  it("ignores pointer moves when no drag is active", () => {
+    const { handle, onChange, onCommit } = setup();
+    fireEvent.pointerMove(handle, { clientX: 460, pointerId: 1 });
+    fireEvent.pointerUp(handle, { clientX: 460, pointerId: 1 });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("uses pointer capture when the platform supports it", () => {
+    const setCapture = vi.fn();
+    const releaseCapture = vi.fn();
+    const proto = HTMLElement.prototype as unknown as {
+      setPointerCapture?: (id: number) => void;
+      releasePointerCapture?: (id: number) => void;
+    };
+    proto.setPointerCapture = setCapture;
+    proto.releasePointerCapture = releaseCapture;
+    try {
+      const { handle } = setup();
+      fireEvent.pointerDown(handle, { clientX: 500, pointerId: 7 });
+      fireEvent.pointerUp(handle, { clientX: 500, pointerId: 7 });
+      expect(setCapture).toHaveBeenCalledWith(7);
+      expect(releaseCapture).toHaveBeenCalledWith(7);
+    } finally {
+      delete proto.setPointerCapture;
+      delete proto.releasePointerCapture;
+    }
+  });
+
+  it("widens by one step on ArrowLeft and commits", () => {
+    const { handle, onChange, onCommit } = setup({ step: 20 });
+    fireEvent.keyDown(handle, { key: "ArrowLeft" });
+    expect(onChange).toHaveBeenCalledWith(420);
+    expect(onCommit).toHaveBeenCalledWith(420);
+  });
+
+  it("narrows by one step on ArrowRight", () => {
+    const { handle, onChange } = setup();
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    // default step 16: 400 - 16 = 384
+    expect(onChange).toHaveBeenCalledWith(384);
+  });
+
+  it("clamps keyboard steps to the bounds", () => {
+    const { handle, onChange } = setup({ value: 712 });
+    fireEvent.keyDown(handle, { key: "ArrowLeft" });
+    expect(onChange).toHaveBeenCalledWith(720);
+  });
+
+  it("ignores non-arrow keys", () => {
+    const { handle, onChange, onCommit } = setup();
+    fireEvent.keyDown(handle, { key: "Enter" });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/components/elements/ResizeHandle/ResizeHandle.tsx
+++ b/clients/web/src/components/elements/ResizeHandle/ResizeHandle.tsx
@@ -1,0 +1,107 @@
+import { useRef, type KeyboardEvent, type PointerEvent } from "react";
+import { Box } from "@mantine/core";
+
+export interface ResizeHandleProps {
+  /** Current width (px) of the panel this handle resizes. */
+  value: number;
+  /** Lower / upper clamp bounds (px). */
+  min: number;
+  max: number;
+  /** Keyboard arrow step in px (default 16). */
+  step?: number;
+  /**
+   * Fired continuously while dragging and on each keyboard step, with the
+   * clamped next width. The parent renders from this for live feedback.
+   */
+  onChange: (next: number) => void;
+  /**
+   * Fired once when the gesture ends (pointer up / key up) with the final
+   * clamped width, so the parent can persist it in a single write.
+   */
+  onCommit: (next: number) => void;
+  "aria-label"?: string;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * A thin draggable vertical divider that resizes a panel sitting to its RIGHT
+ * (so dragging left widens the panel). Pointer-capture keeps the gesture alive
+ * even when the pointer crosses an iframe (the Apps screen renders one), which
+ * would otherwise swallow the move stream and make the drag stick. Exposes the
+ * ARIA `separator` role with live value so it's operable by keyboard too.
+ */
+export function ResizeHandle({
+  value,
+  min,
+  max,
+  step = 16,
+  onChange,
+  onCommit,
+  "aria-label": ariaLabel = "Resize panel",
+}: ResizeHandleProps) {
+  // Gesture origin, captured on pointer down. `null` while idle.
+  const drag = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  function handlePointerDown(e: PointerEvent<HTMLDivElement>) {
+    drag.current = { startX: e.clientX, startWidth: value };
+    // Optional chaining: happy-dom (unit tests) doesn't implement pointer
+    // capture, and it's a progressive enhancement, not required for correctness.
+    e.currentTarget.setPointerCapture?.(e.pointerId);
+    document.body.classList.add("resizing-col");
+  }
+
+  function handlePointerMove(e: PointerEvent<HTMLDivElement>) {
+    if (!drag.current) return;
+    const next = clamp(
+      drag.current.startWidth + (drag.current.startX - e.clientX),
+      min,
+      max,
+    );
+    onChange(next);
+  }
+
+  function endDrag(e: PointerEvent<HTMLDivElement>) {
+    if (!drag.current) return;
+    const next = clamp(
+      drag.current.startWidth + (drag.current.startX - e.clientX),
+      min,
+      max,
+    );
+    drag.current = null;
+    e.currentTarget.releasePointerCapture?.(e.pointerId);
+    document.body.classList.remove("resizing-col");
+    onCommit(next);
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    // Left widens (panel is on the right), Right narrows — mirrors the drag.
+    const delta =
+      e.key === "ArrowLeft" ? step : e.key === "ArrowRight" ? -step : 0;
+    if (delta === 0) return;
+    e.preventDefault();
+    const next = clamp(value + delta, min, max);
+    onChange(next);
+    onCommit(next);
+  }
+
+  return (
+    <Box
+      role="separator"
+      aria-orientation="vertical"
+      aria-valuenow={value}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-label={ariaLabel}
+      tabIndex={0}
+      className="resize-handle"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onKeyDown={handleKeyDown}
+    />
+  );
+}

--- a/clients/web/src/components/elements/ResizeHandle/ResizeHandle.tsx
+++ b/clients/web/src/components/elements/ResizeHandle/ResizeHandle.tsx
@@ -1,4 +1,9 @@
-import { useRef, type KeyboardEvent, type PointerEvent } from "react";
+import {
+  useEffect,
+  useRef,
+  type KeyboardEvent,
+  type PointerEvent,
+} from "react";
 import { Box } from "@mantine/core";
 
 export interface ResizeHandleProps {
@@ -44,6 +49,13 @@ export function ResizeHandle({
 }: ResizeHandleProps) {
   // Gesture origin, captured on pointer down. `null` while idle.
   const drag = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  // If the handle unmounts mid-drag — the window narrows past the split
+  // breakpoint or the server disconnects, either of which removes the handle
+  // from the tree before a pointerup/cancel fires — the drag body class would
+  // otherwise linger and leave `user-select: none` + `col-resize` applied
+  // page-wide. Clear it on unmount so the class is self-healing.
+  useEffect(() => () => document.body.classList.remove("resizing-col"), []);
 
   function handlePointerDown(e: PointerEvent<HTMLDivElement>) {
     drag.current = { startX: e.clientX, startWidth: value };

--- a/clients/web/src/components/groups/HistoryEntry/HistoryEntry.test.tsx
+++ b/clients/web/src/components/groups/HistoryEntry/HistoryEntry.test.tsx
@@ -208,6 +208,49 @@ describe("HistoryEntry", () => {
     expect(names.indexOf("Pin")).toBeLessThan(names.indexOf("Expand"));
   });
 
+  it("renders the compact two-line layout with Replay as an icon when embedded", () => {
+    renderWithMantine(
+      <HistoryEntry {...baseProps} entry={successEntry} embedded />,
+    );
+    // Line 1 essentials plus the method are still shown.
+    expect(screen.getByText("client → server")).toBeInTheDocument();
+    expect(screen.getByText("142ms")).toBeInTheDocument();
+    expect(screen.getByText("OK")).toBeInTheDocument();
+    expect(screen.getByText("tools/call")).toBeInTheDocument();
+    // Replay is an icon button (aria-label), not the text button.
+    expect(screen.getByRole("button", { name: "Replay" })).toBeInTheDocument();
+    expect(screen.queryByText("Replay")).toBeNull();
+  });
+
+  it("keeps action order Replay, Pin, Expand in the compact layout", () => {
+    renderWithMantine(
+      <HistoryEntry {...baseProps} entry={successEntry} embedded />,
+    );
+    const names = screen
+      .getAllByRole("button")
+      .map((b) => b.getAttribute("aria-label") ?? b.textContent);
+    expect(names.indexOf("Replay")).toBeLessThan(names.indexOf("Pin"));
+    expect(names.indexOf("Pin")).toBeLessThan(names.indexOf("Expand"));
+  });
+
+  it("does not render a Replay icon for a non-replayable method when embedded", () => {
+    // A server→client response isn't replayable.
+    const responseEntry: MessageEntry = {
+      id: "resp-1",
+      timestamp: new Date("2026-03-17T10:30:00Z"),
+      direction: "response",
+      origin: "server",
+      message: { jsonrpc: "2.0", id: 1, result: {} },
+    };
+    renderWithMantine(
+      <HistoryEntry {...baseProps} entry={responseEntry} embedded />,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Replay" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pin" })).toBeInTheDocument();
+  });
+
   it("invokes onTogglePin when Pin button is clicked", async () => {
     const user = userEvent.setup();
     const onTogglePin = vi.fn();

--- a/clients/web/src/components/groups/HistoryEntry/HistoryEntry.test.tsx
+++ b/clients/web/src/components/groups/HistoryEntry/HistoryEntry.test.tsx
@@ -212,7 +212,12 @@ describe("HistoryEntry", () => {
     renderWithMantine(
       <HistoryEntry {...baseProps} entry={successEntry} embedded />,
     );
-    // Line 1 essentials plus the method are still shown.
+    // Line 1 essentials plus the method are still shown. The timestamp is the
+    // compact time-only form (not the full ISO) to fit the narrow line.
+    expect(screen.getByText("10:30:00")).toBeInTheDocument();
+    expect(
+      screen.queryByText("2026-03-17T10:30:00.000Z"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("client → server")).toBeInTheDocument();
     expect(screen.getByText("142ms")).toBeInTheDocument();
     expect(screen.getByText("OK")).toBeInTheDocument();

--- a/clients/web/src/components/groups/HistoryEntry/HistoryEntry.tsx
+++ b/clients/web/src/components/groups/HistoryEntry/HistoryEntry.tsx
@@ -83,6 +83,12 @@ function formatTimestamp(date: Date): string {
   return date.toISOString();
 }
 
+// Time-only (HH:MM:SS, UTC) for the compact column header, where the full ISO
+// string would eat most of the narrow line-1 width (#1616).
+function formatTimestampCompact(date: Date): string {
+  return date.toISOString().slice(11, 19);
+}
+
 function extractTarget(entry: MessageEntry): string | undefined {
   const msg = entry.message;
   if (!("params" in msg) || !msg.params) return undefined;
@@ -161,7 +167,7 @@ export function HistoryEntry({
             <HeaderRow>
               <HeaderCluster>
                 <TimestampText>
-                  {formatTimestamp(entry.timestamp)}
+                  {formatTimestampCompact(entry.timestamp)}
                 </TimestampText>
                 {directionBadge}
               </HeaderCluster>

--- a/clients/web/src/components/groups/HistoryEntry/HistoryEntry.tsx
+++ b/clients/web/src/components/groups/HistoryEntry/HistoryEntry.tsx
@@ -14,6 +14,7 @@ import { ContentViewer } from "../../elements/ContentViewer/ContentViewer";
 import { MessageDirectionBadge } from "../../elements/MessageDirectionBadge/MessageDirectionBadge";
 import { ExpandToggle } from "../../elements/ExpandToggle/ExpandToggle";
 import { PinToggle } from "../../elements/PinToggle/PinToggle";
+import { ReplayButton } from "../../elements/ReplayButton/ReplayButton";
 import { extractMethod, isReplayableHistoryMethod } from "../historyUtils.js";
 
 export interface HistoryEntryProps {
@@ -22,6 +23,12 @@ export interface HistoryEntryProps {
   isListExpanded: boolean;
   onReplay: () => void;
   onTogglePin: () => void;
+  /**
+   * Compact two-line header for the narrow monitoring column (#1616): line 1 is
+   * time + direction + duration + status; line 2 is the method (and target) with
+   * the controls — Replay as an icon — on the right.
+   */
+  embedded?: boolean;
 }
 
 const EntryContainer = Card.withProps({
@@ -31,6 +38,19 @@ const EntryContainer = Card.withProps({
 
 const HeaderRow = Group.withProps({
   justify: "space-between",
+  wrap: "nowrap",
+});
+
+// Left / right clusters within a compact header line. The left cluster shrinks
+// (`miw: 0`) so a long target can truncate rather than push the row wider.
+const HeaderCluster = Group.withProps({
+  gap: "sm",
+  wrap: "nowrap",
+  miw: 0,
+});
+
+const ControlsCluster = Group.withProps({
+  gap: "xs",
   wrap: "nowrap",
 });
 
@@ -108,6 +128,7 @@ export function HistoryEntry({
   isListExpanded,
   onReplay,
   onTogglePin,
+  embedded = false,
 }: HistoryEntryProps) {
   const [isExpanded, setIsExpanded] = useState(isListExpanded);
   const method = extractMethod(entry);
@@ -119,44 +140,88 @@ export function HistoryEntry({
     setIsExpanded(isListExpanded);
   }, [isListExpanded]);
 
+  const directionBadge = entry.origin && (
+    <MessageDirectionBadge
+      direction={entry.origin === "client" ? "outgoing" : "incoming"}
+    />
+  );
+  const statusBadge = status !== "none" && (
+    <Badge color={statusColor(status)}>{statusLabel(status)}</Badge>
+  );
+  const durationText = entry.duration != null && (
+    <DurationText>{formatDuration(entry.duration)}</DurationText>
+  );
+
   return (
     <EntryContainer>
       <Stack gap="sm">
-        <HeaderRow>
-          <Group gap="sm">
-            <TimestampText>{formatTimestamp(entry.timestamp)}</TimestampText>
-            {entry.origin && (
-              <MessageDirectionBadge
-                direction={entry.origin === "client" ? "outgoing" : "incoming"}
-              />
-            )}
-            <Badge color="dark">{method}</Badge>
-            {target && <TargetText>{target}</TargetText>}
-          </Group>
-          <Group gap="sm">
-            {entry.duration != null && (
-              <DurationText>{formatDuration(entry.duration)}</DurationText>
-            )}
-            {status !== "none" && (
-              <Badge color={statusColor(status)}>{statusLabel(status)}</Badge>
-            )}
-          </Group>
-        </HeaderRow>
+        {embedded ? (
+          // Compact two-line header for the narrow column.
+          <Stack gap="xs">
+            <HeaderRow>
+              <HeaderCluster>
+                <TimestampText>
+                  {formatTimestamp(entry.timestamp)}
+                </TimestampText>
+                {directionBadge}
+              </HeaderCluster>
+              <ControlsCluster>
+                {durationText}
+                {statusBadge}
+              </ControlsCluster>
+            </HeaderRow>
+            <HeaderRow>
+              <HeaderCluster flex={1}>
+                <Badge color="dark">{method}</Badge>
+                {target && (
+                  <TargetText truncate="end" miw={0}>
+                    {target}
+                  </TargetText>
+                )}
+              </HeaderCluster>
+              <ControlsCluster>
+                {canReplay && <ReplayButton onReplay={onReplay} />}
+                <PinToggle pinned={isPinned} onToggle={onTogglePin} />
+                <ExpandToggle
+                  expanded={isExpanded}
+                  onToggle={() => setIsExpanded((v) => !v)}
+                />
+              </ControlsCluster>
+            </HeaderRow>
+          </Stack>
+        ) : (
+          <>
+            <HeaderRow>
+              <Group gap="sm">
+                <TimestampText>
+                  {formatTimestamp(entry.timestamp)}
+                </TimestampText>
+                {directionBadge}
+                <Badge color="dark">{method}</Badge>
+                {target && <TargetText>{target}</TargetText>}
+              </Group>
+              <Group gap="sm">
+                {durationText}
+                {statusBadge}
+              </Group>
+            </HeaderRow>
 
-        <Group gap="xs" justify="space-between">
-          <Group gap="xs">
-            {canReplay && (
-              <SubtleButton onClick={onReplay}>Replay</SubtleButton>
-            )}
-          </Group>
-          <Group gap="xs">
-            <PinToggle pinned={isPinned} onToggle={onTogglePin} />
-            <ExpandToggle
-              expanded={isExpanded}
-              onToggle={() => setIsExpanded((v) => !v)}
-            />
-          </Group>
-        </Group>
+            <Group gap="xs" justify="space-between">
+              <Group gap="xs">
+                {canReplay && (
+                  <SubtleButton onClick={onReplay}>Replay</SubtleButton>
+                )}
+              </Group>
+              <Group gap="xs">
+                <PinToggle pinned={isPinned} onToggle={onTogglePin} />
+                <ExpandToggle
+                  expanded={isExpanded}
+                  onToggle={() => setIsExpanded((v) => !v)}
+                />
+              </Group>
+            </Group>
+          </>
+        )}
 
         <Collapse in={isExpanded}>
           <Stack gap="sm">

--- a/clients/web/src/components/groups/HistoryEntry/HistoryEntry.tsx
+++ b/clients/web/src/components/groups/HistoryEntry/HistoryEntry.tsx
@@ -124,12 +124,12 @@ export function HistoryEntry({
       <Stack gap="sm">
         <HeaderRow>
           <Group gap="sm">
+            <TimestampText>{formatTimestamp(entry.timestamp)}</TimestampText>
             {entry.origin && (
               <MessageDirectionBadge
                 direction={entry.origin === "client" ? "outgoing" : "incoming"}
               />
             )}
-            <TimestampText>{formatTimestamp(entry.timestamp)}</TimestampText>
             <Badge color="dark">{method}</Badge>
             {target && <TargetText>{target}</TargetText>}
           </Group>

--- a/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.test.tsx
+++ b/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.test.tsx
@@ -98,11 +98,14 @@ describe("HistoryListPanel", () => {
     expect(screen.getByText("No request history")).toBeInTheDocument();
   });
 
-  it("renders the History title with count for unpinned entries", () => {
+  it("hides the History header when there are no pinned entries", () => {
     renderWithMantine(
       <HistoryListPanel {...baseProps} entries={sampleEntries} />,
     );
-    expect(screen.getByText("History (3)")).toBeInTheDocument();
+    // With no pinned section to distinguish it from, the header is dropped...
+    expect(screen.queryByText("History (3)")).toBeNull();
+    // ...but the entries themselves are still shown.
+    expect(screen.getByText("resources/read")).toBeInTheDocument();
   });
 
   it("renders the Pinned title with count when entries are pinned", () => {
@@ -135,12 +138,13 @@ describe("HistoryListPanel", () => {
     expect(header).toHaveAttribute("aria-expanded", "true");
   });
 
-  it("renders a lone section as a plain (non-collapsible) header with its entries shown", () => {
-    // Only the unpinned section → no accordion toggle, entries always visible.
+  it("renders a lone unpinned section headerless, with its entries shown", () => {
+    // Only the unpinned section → no header at all, no accordion toggle,
+    // entries always visible.
     renderWithMantine(
       <HistoryListPanel {...baseProps} entries={sampleEntries} />,
     );
-    expect(screen.getByText("History (3)")).toBeInTheDocument();
+    expect(screen.queryByText("History (3)")).toBeNull();
     expect(
       screen.queryByRole("button", { name: "History (3)" }),
     ).not.toBeInTheDocument();
@@ -246,8 +250,9 @@ describe("HistoryListPanel", () => {
         visibleDirections={{ client: true, server: false }}
       />,
     );
-    // The server-origin entry is filtered out, leaving one.
-    expect(screen.getByText("History (1)")).toBeInTheDocument();
+    // The server-origin entry is filtered out, leaving the client one.
+    expect(screen.getByText("tools/call")).toBeInTheDocument();
+    expect(screen.queryByText("resources/read")).toBeNull();
   });
 
   it("filters entries by searchText (case-insensitive)", () => {
@@ -258,7 +263,10 @@ describe("HistoryListPanel", () => {
         searchText="config.json"
       />,
     );
-    expect(screen.getByText("History (1)")).toBeInTheDocument();
+    // Only the resources/read entry references config.json.
+    expect(screen.getByText("resources/read")).toBeInTheDocument();
+    expect(screen.queryByText("tools/call")).toBeNull();
+    expect(screen.queryByText("tools/list")).toBeNull();
   });
 
   it("filters entries by methodFilter", () => {
@@ -269,7 +277,9 @@ describe("HistoryListPanel", () => {
         methodFilter="tools/list"
       />,
     );
-    expect(screen.getByText("History (1)")).toBeInTheDocument();
+    expect(screen.getByText("tools/list")).toBeInTheDocument();
+    expect(screen.queryByText("tools/call")).toBeNull();
+    expect(screen.queryByText("resources/read")).toBeNull();
   });
 
   it("invokes onExport when Export is clicked", async () => {

--- a/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
+++ b/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
@@ -245,9 +245,6 @@ export function HistoryListPanel({
       <Group justify="space-between" mb="sm">
         <Title order={4}>Requests</Title>
         <Group gap="xs">
-          {hasResults && (
-            <ListToggle compact={compact} onToggle={onToggleCompact} />
-          )}
           <SortToggle
             value={sortDirection}
             onChange={onSortChange}
@@ -263,6 +260,9 @@ export function HistoryListPanel({
           <Button variant="default" onClick={onExport} disabled={!hasResults}>
             Export
           </Button>
+          {hasResults && (
+            <ListToggle compact={compact} onToggle={onToggleCompact} />
+          )}
           {onPin ? <PinColumnButton onPin={onPin} /> : null}
         </Group>
       </Group>

--- a/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
+++ b/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
@@ -245,7 +245,6 @@ export function HistoryListPanel({
       <Group justify="space-between" mb="sm">
         <Title order={4}>Requests</Title>
         <Group gap="xs">
-          {onPin ? <PinColumnButton onPin={onPin} /> : null}
           {hasResults && (
             <ListToggle compact={compact} onToggle={onToggleCompact} />
           )}
@@ -264,6 +263,7 @@ export function HistoryListPanel({
           <Button variant="default" onClick={onExport} disabled={!hasResults}>
             Export
           </Button>
+          {onPin ? <PinColumnButton onPin={onPin} /> : null}
         </Group>
       </Group>
 

--- a/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
+++ b/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
@@ -318,6 +318,7 @@ export function HistoryListPanel({
                     entry={entry}
                     isPinned={true}
                     isListExpanded={!compact}
+                    embedded={embedded}
                     onReplay={() => onReplay(entry.id)}
                     onTogglePin={() => onTogglePin(entry.id)}
                   />
@@ -349,6 +350,7 @@ export function HistoryListPanel({
                     entry={entry}
                     isPinned={false}
                     isListExpanded={!compact}
+                    embedded={embedded}
                     onReplay={() => onReplay(entry.id)}
                     onTogglePin={() => onTogglePin(entry.id)}
                   />

--- a/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
+++ b/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
@@ -215,15 +215,26 @@ export function HistoryListPanel({
   const [pinnedOpen, setPinnedOpen] = useState(true);
   const [historyOpen, setHistoryOpen] = useState(true);
   const filteredEntries = useMemo(() => {
-    // `.filter()` returns a fresh array, so sorting in-place is safe.
+    // Embedded column: show the full stream (no filter sidebar to explain a
+    // mirrored filter). See LogStreamPanel (#1616). `.filter()` returns a fresh
+    // array, so sorting in-place is safe.
     const sorted = entries
-      .filter((e) =>
-        matchesFilters(e, searchText, visibleDirections, methodFilter),
+      .filter(
+        (e) =>
+          embedded ||
+          matchesFilters(e, searchText, visibleDirections, methodFilter),
       )
       .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
     if (sortDirection === "newest-first") sorted.reverse();
     return sorted;
-  }, [entries, searchText, visibleDirections, methodFilter, sortDirection]);
+  }, [
+    entries,
+    searchText,
+    visibleDirections,
+    methodFilter,
+    sortDirection,
+    embedded,
+  ]);
 
   const pinnedEntries = useMemo(
     () => filteredEntries.filter((e) => pinnedIds.has(e.id)),

--- a/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
+++ b/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
@@ -128,10 +128,14 @@ function SectionActions({
 // is a `listItem` toggle — with an optional actions slot on the right — over a
 // `Collapse` of the entries. When it's the only section, the accordion makes no
 // sense: the header is a plain title and the entries always show (so a stale
-// collapsed state from when both sections were present can't hide them).
+// collapsed state from when both sections were present can't hide them) —
+// unless `hideHeaderWhenAlone`, in which case the lone section drops its title
+// entirely (the "History" label is redundant when there's nothing to
+// distinguish it from).
 function CollapsibleSection({
   title,
   collapsible,
+  hideHeaderWhenAlone = false,
   open,
   onToggle,
   actions,
@@ -139,6 +143,7 @@ function CollapsibleSection({
 }: {
   title: string;
   collapsible: boolean;
+  hideHeaderWhenAlone?: boolean;
   open: boolean;
   onToggle: () => void;
   actions?: ReactNode;
@@ -147,7 +152,7 @@ function CollapsibleSection({
   if (!collapsible) {
     return (
       <Stack gap="md">
-        <Title order={5}>{title}</Title>
+        {hideHeaderWhenAlone ? null : <Title order={5}>{title}</Title>}
         <Stack gap="md">{children}</Stack>
       </Stack>
     );
@@ -173,13 +178,18 @@ function matchesFilters(
   entry: MessageEntry,
   searchText: string,
   visibleDirections: Record<MessageOrigin, boolean>,
-  methodFilter?: MessageMethod,
+  methodFilter: MessageMethod | undefined,
+  // The embedded column exposes only the search box (no direction/method
+  // controls), so it applies the text filter but skips those (#1616).
+  ignoreDirectionAndMethod: boolean,
 ): boolean {
-  // Hide a direction when its toggle is off. Entries with no recorded origin
-  // (legacy / pre-origin logs) are never filtered out by direction.
-  if (entry.origin && !visibleDirections[entry.origin]) return false;
   const method = extractMethod(entry);
-  if (methodFilter && method !== methodFilter) return false;
+  if (!ignoreDirectionAndMethod) {
+    // Hide a direction when its toggle is off. Entries with no recorded origin
+    // (legacy / pre-origin logs) are never filtered out by direction.
+    if (entry.origin && !visibleDirections[entry.origin]) return false;
+    if (methodFilter && method !== methodFilter) return false;
+  }
   if (searchText) {
     const term = searchText.toLowerCase();
     const responseText = entry.response ? JSON.stringify(entry.response) : "";
@@ -215,14 +225,18 @@ export function HistoryListPanel({
   const [pinnedOpen, setPinnedOpen] = useState(true);
   const [historyOpen, setHistoryOpen] = useState(true);
   const filteredEntries = useMemo(() => {
-    // Embedded column: show the full stream (no filter sidebar to explain a
-    // mirrored filter). See LogStreamPanel (#1616). `.filter()` returns a fresh
-    // array, so sorting in-place is safe.
+    // Embedded column filters by text only (its direction/method controls live
+    // in the full-size sidebar). See LogStreamPanel (#1616). `.filter()` returns
+    // a fresh array, so sorting in-place is safe.
     const sorted = entries
-      .filter(
-        (e) =>
-          embedded ||
-          matchesFilters(e, searchText, visibleDirections, methodFilter),
+      .filter((e) =>
+        matchesFilters(
+          e,
+          searchText,
+          visibleDirections,
+          methodFilter,
+          embedded,
+        ),
       )
       .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
     if (sortDirection === "newest-first") sorted.reverse();
@@ -315,6 +329,9 @@ export function HistoryListPanel({
               <CollapsibleSection
                 title={formatHistoryTitle(unpinnedEntries.length)}
                 collapsible={bothSections}
+                // With no pinned section to distinguish it from, the lone
+                // "History (N)" header is redundant — drop it.
+                hideHeaderWhenAlone
                 open={historyOpen}
                 onToggle={() => setHistoryOpen((v) => !v)}
                 actions={

--- a/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
+++ b/clients/web/src/components/groups/HistoryListPanel/HistoryListPanel.tsx
@@ -4,7 +4,6 @@ import {
   Collapse,
   Group,
   Paper,
-  ScrollArea,
   Stack,
   Text,
   Title,
@@ -21,6 +20,8 @@ import {
   SortToggle,
   type SortDirection,
 } from "../../elements/SortToggle/SortToggle";
+import { PinColumnButton } from "../../elements/PinColumnButton/PinColumnButton";
+import { EmbeddableScrollArea } from "../../elements/EmbeddableScrollArea/EmbeddableScrollArea";
 import { extractMethod } from "../historyUtils.js";
 import { useScrollMemory } from "../../../hooks/useScrollMemory";
 
@@ -43,6 +44,10 @@ export interface HistoryListPanelProps {
   onSortChange: (next: SortDirection) => void;
   compact: boolean;
   onToggleCompact: () => void;
+  /** See LogStreamPanel: shows a "pin as column" button when set (#1616). */
+  onPin?: () => void;
+  /** See LogStreamPanel: fills the flex parent instead of the viewport calc. */
+  embedded?: boolean;
 }
 
 const PanelContainer = Paper.withProps({
@@ -201,6 +206,8 @@ export function HistoryListPanel({
   onSortChange,
   compact,
   onToggleCompact,
+  onPin,
+  embedded = false,
 }: HistoryListPanelProps) {
   const viewportRef = useScrollMemory("history-list");
   // Per-section expand/collapse, like the LogControls level toggles. Both start
@@ -238,6 +245,7 @@ export function HistoryListPanel({
       <Group justify="space-between" mb="sm">
         <Title order={4}>Requests</Title>
         <Group gap="xs">
+          {onPin ? <PinColumnButton onPin={onPin} /> : null}
           {hasResults && (
             <ListToggle compact={compact} onToggle={onToggleCompact} />
           )}
@@ -262,12 +270,7 @@ export function HistoryListPanel({
       {!hasResults ? (
         <EmptyState>No request history</EmptyState>
       ) : (
-        <ScrollArea.Autosize
-          viewportRef={viewportRef}
-          mah="calc(100vh - var(--app-shell-header-height, 0px) - 150px)"
-          type="scroll"
-          offsetScrollbars
-        >
+        <EmbeddableScrollArea embedded={embedded} viewportRef={viewportRef}>
           <Stack gap="md">
             {pinnedEntries.length > 0 && (
               <CollapsibleSection
@@ -325,7 +328,7 @@ export function HistoryListPanel({
               </CollapsibleSection>
             )}
           </Stack>
-        </ScrollArea.Autosize>
+        </EmbeddableScrollArea>
       )}
     </PanelContainer>
   );

--- a/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
+++ b/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
@@ -56,8 +56,11 @@ function matchesFilters(
   entry: LogEntryData,
   filterText: string,
   visibleLevels: Record<LoggingLevel, boolean>,
+  // The embedded column exposes only the search box (no level toggles), so it
+  // applies the text filter but skips the level filter (#1616).
+  ignoreLevels: boolean,
 ): boolean {
-  if (!visibleLevels[entry.params.level]) return false;
+  if (!ignoreLevels && !visibleLevels[entry.params.level]) return false;
   if (filterText) {
     const term = filterText.toLowerCase();
     const searchable =
@@ -80,12 +83,11 @@ export function LogStreamPanel({
 }: LogStreamPanelProps) {
   const viewportRef = useScrollMemory("logs-stream");
   const filteredEntries = useMemo(() => {
-    // The embedded column has no filter sidebar, so it shows the full stream
-    // rather than mirroring the full-size screen's live filter with no visible
-    // control to explain it (#1616). `.filter()` returns a fresh array, so
-    // sorting in-place is safe.
+    // The embedded column has only the search box (its level toggles live in the
+    // full-size sidebar), so it filters by text but ignores the level filter
+    // (#1616). `.filter()` returns a fresh array, so sorting in-place is safe.
     const sorted = entries
-      .filter((e) => embedded || matchesFilters(e, filterText, visibleLevels))
+      .filter((e) => matchesFilters(e, filterText, visibleLevels, embedded))
       .sort((a, b) => a.receivedAt.getTime() - b.receivedAt.getTime());
     if (sortDirection === "newest-first") sorted.reverse();
     return sorted;

--- a/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
+++ b/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
@@ -93,7 +93,6 @@ export function LogStreamPanel({
       <Group justify="space-between" mb="sm">
         <Title order={4}>Log Stream</Title>
         <Group>
-          {onPin ? <PinColumnButton onPin={onPin} /> : null}
           <SortToggle
             value={sortDirection}
             onChange={onSortChange}
@@ -113,6 +112,7 @@ export function LogStreamPanel({
           >
             Export
           </Button>
+          {onPin ? <PinColumnButton onPin={onPin} /> : null}
         </Group>
       </Group>
       {filteredEntries.length > 0 ? (

--- a/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
+++ b/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
@@ -80,13 +80,16 @@ export function LogStreamPanel({
 }: LogStreamPanelProps) {
   const viewportRef = useScrollMemory("logs-stream");
   const filteredEntries = useMemo(() => {
-    // `.filter()` returns a fresh array, so sorting in-place is safe.
+    // The embedded column has no filter sidebar, so it shows the full stream
+    // rather than mirroring the full-size screen's live filter with no visible
+    // control to explain it (#1616). `.filter()` returns a fresh array, so
+    // sorting in-place is safe.
     const sorted = entries
-      .filter((e) => matchesFilters(e, filterText, visibleLevels))
+      .filter((e) => embedded || matchesFilters(e, filterText, visibleLevels))
       .sort((a, b) => a.receivedAt.getTime() - b.receivedAt.getTime());
     if (sortDirection === "newest-first") sorted.reverse();
     return sorted;
-  }, [entries, filterText, visibleLevels, sortDirection]);
+  }, [entries, filterText, visibleLevels, sortDirection, embedded]);
 
   return (
     <PanelContainer>

--- a/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
+++ b/clients/web/src/components/groups/LogStreamPanel/LogStreamPanel.tsx
@@ -1,13 +1,5 @@
 import { useMemo } from "react";
-import {
-  Button,
-  Group,
-  Paper,
-  ScrollArea,
-  Stack,
-  Text,
-  Title,
-} from "@mantine/core";
+import { Button, Group, Paper, Stack, Text, Title } from "@mantine/core";
 import type { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
 import { LogEntry } from "../../elements/LogEntry/LogEntry";
 import type { LogEntryData } from "../../elements/LogEntry/LogEntry";
@@ -15,6 +7,8 @@ import {
   SortToggle,
   type SortDirection,
 } from "../../elements/SortToggle/SortToggle";
+import { PinColumnButton } from "../../elements/PinColumnButton/PinColumnButton";
+import { EmbeddableScrollArea } from "../../elements/EmbeddableScrollArea/EmbeddableScrollArea";
 import { useScrollMemory } from "../../../hooks/useScrollMemory";
 
 export interface LogStreamPanelProps {
@@ -25,6 +19,18 @@ export interface LogStreamPanelProps {
   onExport: () => void;
   sortDirection: SortDirection;
   onSortChange: (next: SortDirection) => void;
+  /**
+   * When set, renders a "pin as column" button in the toolbar that opens this
+   * screen in the monitoring column (#1616). Omitted when the panel is already
+   * embedded in that column (or when pinning isn't available).
+   */
+  onPin?: () => void;
+  /**
+   * True when this panel is rendered inside the monitoring column. Switches the
+   * scroll region from the viewport-height calc to filling its flex parent, so
+   * it fits below the column's controls row without viewport math.
+   */
+  embedded?: boolean;
 }
 
 const PanelContainer = Paper.withProps({
@@ -69,6 +75,8 @@ export function LogStreamPanel({
   onExport,
   sortDirection,
   onSortChange,
+  onPin,
+  embedded = false,
 }: LogStreamPanelProps) {
   const viewportRef = useScrollMemory("logs-stream");
   const filteredEntries = useMemo(() => {
@@ -85,6 +93,7 @@ export function LogStreamPanel({
       <Group justify="space-between" mb="sm">
         <Title order={4}>Log Stream</Title>
         <Group>
+          {onPin ? <PinColumnButton onPin={onPin} /> : null}
           <SortToggle
             value={sortDirection}
             onChange={onSortChange}
@@ -107,18 +116,13 @@ export function LogStreamPanel({
         </Group>
       </Group>
       {filteredEntries.length > 0 ? (
-        <ScrollArea.Autosize
-          viewportRef={viewportRef}
-          mah="calc(100vh - var(--app-shell-header-height, 0px) - 150px)"
-          type="scroll"
-          offsetScrollbars
-        >
+        <EmbeddableScrollArea embedded={embedded} viewportRef={viewportRef}>
           <Stack gap="xs">
             {filteredEntries.map((entry, index) => (
               <LogEntry key={index} entry={entry} />
             ))}
           </Stack>
-        </ScrollArea.Autosize>
+        </EmbeddableScrollArea>
       ) : (
         <EmptyCenter>
           <Text c="dimmed">No log entries</Text>

--- a/clients/web/src/components/groups/MonitoringControls/MonitoringControls.stories.tsx
+++ b/clients/web/src/components/groups/MonitoringControls/MonitoringControls.stories.tsx
@@ -9,6 +9,8 @@ const meta: Meta<typeof MonitoringControls> = {
     tabs: ["Logs", "History", "Network"],
     value: "Logs",
     onChange: fn(),
+    searchValue: "",
+    onSearchChange: fn(),
     onClose: fn(),
   },
 };

--- a/clients/web/src/components/groups/MonitoringControls/MonitoringControls.stories.tsx
+++ b/clients/web/src/components/groups/MonitoringControls/MonitoringControls.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, within } from "storybook/test";
+import { MonitoringControls } from "./MonitoringControls";
+
+const meta: Meta<typeof MonitoringControls> = {
+  title: "Groups/MonitoringControls",
+  component: MonitoringControls,
+  args: {
+    tabs: ["Logs", "History", "Network"],
+    value: "Logs",
+    onChange: fn(),
+    onClose: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MonitoringControls>;
+
+export const AllTabs: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole("radio", { name: "Logs" })).toBeChecked();
+    expect(
+      canvas.getByRole("button", { name: "Close monitoring column" }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const StdioServer: Story = {
+  args: { tabs: ["Logs", "History"], value: "History" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.queryByRole("radio", { name: "Network" })).toBeNull();
+  },
+};

--- a/clients/web/src/components/groups/MonitoringControls/MonitoringControls.test.tsx
+++ b/clients/web/src/components/groups/MonitoringControls/MonitoringControls.test.tsx
@@ -33,6 +33,20 @@ describe("MonitoringControls", () => {
     expect(screen.queryByRole("radio", { name: "Network" })).toBeNull();
   });
 
+  it("gives the tab switcher an accessible name", () => {
+    const { container } = renderWithMantine(
+      <MonitoringControls
+        tabs={TABS}
+        value="Logs"
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(
+      container.querySelector('[aria-label="Monitoring screen"]'),
+    ).not.toBeNull();
+  });
+
   it("marks the active tab as selected", () => {
     renderWithMantine(
       <MonitoringControls

--- a/clients/web/src/components/groups/MonitoringControls/MonitoringControls.test.tsx
+++ b/clients/web/src/components/groups/MonitoringControls/MonitoringControls.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { MonitoringControls } from "./MonitoringControls";
+
+const TABS = ["Logs", "History", "Network"];
+
+describe("MonitoringControls", () => {
+  it("renders a radio option for each available tab", () => {
+    renderWithMantine(
+      <MonitoringControls
+        tabs={TABS}
+        value="Logs"
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    for (const tab of TABS) {
+      expect(screen.getByRole("radio", { name: tab })).toBeInTheDocument();
+    }
+  });
+
+  it("renders only the tabs it is given", () => {
+    renderWithMantine(
+      <MonitoringControls
+        tabs={["Logs", "History"]}
+        value="Logs"
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByRole("radio")).toHaveLength(2);
+    expect(screen.queryByRole("radio", { name: "Network" })).toBeNull();
+  });
+
+  it("marks the active tab as selected", () => {
+    renderWithMantine(
+      <MonitoringControls
+        tabs={TABS}
+        value="History"
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("radio", { name: "History" })).toBeChecked();
+  });
+
+  it("calls onChange when a different tab is chosen", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderWithMantine(
+      <MonitoringControls
+        tabs={TABS}
+        value="Logs"
+        onChange={onChange}
+        onClose={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("radio", { name: "Network" }));
+    expect(onChange).toHaveBeenCalledWith("Network");
+  });
+
+  it("calls onClose when the close button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderWithMantine(
+      <MonitoringControls
+        tabs={TABS}
+        value="Logs"
+        onChange={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Close monitoring column" }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/components/groups/MonitoringControls/MonitoringControls.test.tsx
+++ b/clients/web/src/components/groups/MonitoringControls/MonitoringControls.test.tsx
@@ -1,34 +1,37 @@
 import { describe, it, expect, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { renderWithMantine, screen } from "../../../test/renderWithMantine";
-import { MonitoringControls } from "./MonitoringControls";
+import {
+  MonitoringControls,
+  type MonitoringControlsProps,
+} from "./MonitoringControls";
 
 const TABS = ["Logs", "History", "Network"];
 
+function renderControls(overrides: Partial<MonitoringControlsProps> = {}) {
+  const props: MonitoringControlsProps = {
+    tabs: TABS,
+    value: "Logs",
+    onChange: vi.fn(),
+    searchValue: "",
+    onSearchChange: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+  renderWithMantine(<MonitoringControls {...props} />);
+  return props;
+}
+
 describe("MonitoringControls", () => {
   it("renders a radio option for each available tab", () => {
-    renderWithMantine(
-      <MonitoringControls
-        tabs={TABS}
-        value="Logs"
-        onChange={vi.fn()}
-        onClose={vi.fn()}
-      />,
-    );
+    renderControls();
     for (const tab of TABS) {
       expect(screen.getByRole("radio", { name: tab })).toBeInTheDocument();
     }
   });
 
   it("renders only the tabs it is given", () => {
-    renderWithMantine(
-      <MonitoringControls
-        tabs={["Logs", "History"]}
-        value="Logs"
-        onChange={vi.fn()}
-        onClose={vi.fn()}
-      />,
-    );
+    renderControls({ tabs: ["Logs", "History"] });
     expect(screen.getAllByRole("radio")).toHaveLength(2);
     expect(screen.queryByRole("radio", { name: "Network" })).toBeNull();
   });
@@ -39,6 +42,8 @@ describe("MonitoringControls", () => {
         tabs={TABS}
         value="Logs"
         onChange={vi.fn()}
+        searchValue=""
+        onSearchChange={vi.fn()}
         onClose={vi.fn()}
       />,
     );
@@ -48,43 +53,48 @@ describe("MonitoringControls", () => {
   });
 
   it("marks the active tab as selected", () => {
-    renderWithMantine(
-      <MonitoringControls
-        tabs={TABS}
-        value="History"
-        onChange={vi.fn()}
-        onClose={vi.fn()}
-      />,
-    );
+    renderControls({ value: "History" });
     expect(screen.getByRole("radio", { name: "History" })).toBeChecked();
   });
 
   it("calls onChange when a different tab is chosen", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    renderWithMantine(
-      <MonitoringControls
-        tabs={TABS}
-        value="Logs"
-        onChange={onChange}
-        onClose={vi.fn()}
-      />,
-    );
+    renderControls({ onChange });
     await user.click(screen.getByRole("radio", { name: "Network" }));
     expect(onChange).toHaveBeenCalledWith("Network");
+  });
+
+  it("renders the search box with the current value", () => {
+    renderControls({ searchValue: "auth" });
+    expect(screen.getByRole("textbox", { name: "Search" })).toHaveValue("auth");
+  });
+
+  it("calls onSearchChange as the user types", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    renderControls({ onSearchChange });
+    await user.type(screen.getByRole("textbox", { name: "Search" }), "x");
+    expect(onSearchChange).toHaveBeenCalledWith("x");
+  });
+
+  it("clears the search via the clear button", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    renderControls({ searchValue: "term", onSearchChange });
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+    expect(onSearchChange).toHaveBeenCalledWith("");
+  });
+
+  it("shows no clear button when the search is empty", () => {
+    renderControls({ searchValue: "" });
+    expect(screen.queryByRole("button", { name: "Clear" })).toBeNull();
   });
 
   it("calls onClose when the close button is clicked", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderWithMantine(
-      <MonitoringControls
-        tabs={TABS}
-        value="Logs"
-        onChange={vi.fn()}
-        onClose={onClose}
-      />,
-    );
+    renderControls({ onClose });
     await user.click(
       screen.getByRole("button", { name: "Close monitoring column" }),
     );

--- a/clients/web/src/components/groups/MonitoringControls/MonitoringControls.tsx
+++ b/clients/web/src/components/groups/MonitoringControls/MonitoringControls.tsx
@@ -39,6 +39,7 @@ export function MonitoringControls({
         value={value}
         onChange={onChange}
         data={tabs}
+        aria-label="Monitoring screen"
       />
       <CloseButton aria-label="Close monitoring column" onClick={onClose} />
     </ControlsBar>

--- a/clients/web/src/components/groups/MonitoringControls/MonitoringControls.tsx
+++ b/clients/web/src/components/groups/MonitoringControls/MonitoringControls.tsx
@@ -1,4 +1,6 @@
-import { CloseButton, Group, SegmentedControl } from "@mantine/core";
+import { ActionIcon, Group, SegmentedControl, TextInput } from "@mantine/core";
+import { TbLayoutSidebarRightCollapse } from "react-icons/tb";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
 
 export interface MonitoringControlsProps {
   /** The monitor screens currently available to pin (e.g. Logs/History/Network). */
@@ -6,30 +8,46 @@ export interface MonitoringControlsProps {
   /** The active monitor tab shown in the column below. */
   value: string;
   onChange: (tab: string) => void;
+  /** Search text for the active screen (shares the screen's own filter state). */
+  searchValue: string;
+  onSearchChange: (next: string) => void;
   /** Close the monitoring column, returning its screens to the header menu. */
   onClose: () => void;
 }
 
-// The controls row that sits at the top of the pinned monitoring column: a
-// segmented tab switcher on the left, a close button on the right that unpins
-// the whole column.
+// The controls row at the top of the pinned monitoring column: a segmented tab
+// switcher on the left, a search box filling the middle, and a close button on
+// the right that unpins the whole column.
 const ControlsBar = Group.withProps({
-  justify: "space-between",
   wrap: "nowrap",
   gap: "sm",
   p: "sm",
 });
 
+// Search box, styled to match the `*Controls` search fields; `flex:1`/`miw:0`
+// so it fills the space between the tabs and the close button.
+const SearchInput = TextInput.withProps({
+  placeholder: "Search...",
+  size: "sm",
+  flex: 1,
+  miw: 0,
+  "aria-label": "Search",
+});
+
 /**
- * Tab row + close control for the pinned monitoring column (#1616). Renders only
- * the currently-available monitor tabs (the caller filters by capability), so it
- * never shows an empty switcher. Selecting a tab swaps the screen below; the
- * close button unpins the column so its screens rejoin the header tab menu.
+ * Tab row + search + close control for the pinned monitoring column (#1616).
+ * Renders only the currently-available monitor tabs (the caller filters by
+ * capability), so it never shows an empty switcher. Selecting a tab swaps the
+ * screen below; the search box filters the shown screen (wired by the caller to
+ * that screen's own filter state); the close button unpins the column so its
+ * screens rejoin the header tab menu.
  */
 export function MonitoringControls({
   tabs,
   value,
   onChange,
+  searchValue,
+  onSearchChange,
   onClose,
 }: MonitoringControlsProps) {
   return (
@@ -41,7 +59,25 @@ export function MonitoringControls({
         data={tabs}
         aria-label="Monitoring screen"
       />
-      <CloseButton aria-label="Close monitoring column" onClick={onClose} />
+      <SearchInput
+        value={searchValue}
+        onChange={(e) => onSearchChange(e.currentTarget.value)}
+        rightSectionPointerEvents="auto"
+        rightSection={
+          searchValue ? (
+            <ClearButton onClick={() => onSearchChange("")} />
+          ) : null
+        }
+      />
+      <ActionIcon
+        variant="subtle"
+        color="gray"
+        size="lg"
+        aria-label="Close monitoring column"
+        onClick={onClose}
+      >
+        <TbLayoutSidebarRightCollapse size={20} />
+      </ActionIcon>
     </ControlsBar>
   );
 }

--- a/clients/web/src/components/groups/MonitoringControls/MonitoringControls.tsx
+++ b/clients/web/src/components/groups/MonitoringControls/MonitoringControls.tsx
@@ -1,0 +1,46 @@
+import { CloseButton, Group, SegmentedControl } from "@mantine/core";
+
+export interface MonitoringControlsProps {
+  /** The monitor screens currently available to pin (e.g. Logs/History/Network). */
+  tabs: string[];
+  /** The active monitor tab shown in the column below. */
+  value: string;
+  onChange: (tab: string) => void;
+  /** Close the monitoring column, returning its screens to the header menu. */
+  onClose: () => void;
+}
+
+// The controls row that sits at the top of the pinned monitoring column: a
+// segmented tab switcher on the left, a close button on the right that unpins
+// the whole column.
+const ControlsBar = Group.withProps({
+  justify: "space-between",
+  wrap: "nowrap",
+  gap: "sm",
+  p: "sm",
+});
+
+/**
+ * Tab row + close control for the pinned monitoring column (#1616). Renders only
+ * the currently-available monitor tabs (the caller filters by capability), so it
+ * never shows an empty switcher. Selecting a tab swaps the screen below; the
+ * close button unpins the column so its screens rejoin the header tab menu.
+ */
+export function MonitoringControls({
+  tabs,
+  value,
+  onChange,
+  onClose,
+}: MonitoringControlsProps) {
+  return (
+    <ControlsBar>
+      <SegmentedControl
+        size="sm"
+        value={value}
+        onChange={onChange}
+        data={tabs}
+      />
+      <CloseButton aria-label="Close monitoring column" onClick={onClose} />
+    </ControlsBar>
+  );
+}

--- a/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.stories.tsx
+++ b/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.stories.tsx
@@ -1,0 +1,59 @@
+import { Box, Text } from "@mantine/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, within } from "storybook/test";
+import { MonitoringScreen } from "./MonitoringScreen";
+
+const demoScreens = {
+  Logs: (
+    <Box p="md">
+      <Text>Log stream</Text>
+    </Box>
+  ),
+  History: (
+    <Box p="md">
+      <Text>Request history</Text>
+    </Box>
+  ),
+  Network: (
+    <Box p="md">
+      <Text>Network requests</Text>
+    </Box>
+  ),
+};
+
+const meta: Meta<typeof MonitoringScreen> = {
+  title: "Groups/MonitoringScreen",
+  component: MonitoringScreen,
+  decorators: [
+    (Story) => (
+      <Box h={320}>
+        <Story />
+      </Box>
+    ),
+  ],
+  args: {
+    tabs: ["Logs", "History", "Network"],
+    value: "Logs",
+    onChange: fn(),
+    onClose: fn(),
+    screens: demoScreens,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MonitoringScreen>;
+
+export const Logs: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText("Log stream")).toBeInTheDocument();
+  },
+};
+
+export const History: Story = {
+  args: { value: "History" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText("Request history")).toBeInTheDocument();
+  },
+};

--- a/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.stories.tsx
+++ b/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.stories.tsx
@@ -35,6 +35,8 @@ const meta: Meta<typeof MonitoringScreen> = {
     tabs: ["Logs", "History", "Network"],
     value: "Logs",
     onChange: fn(),
+    searchValue: "",
+    onSearchChange: fn(),
     onClose: fn(),
     screens: demoScreens,
   },

--- a/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.test.tsx
+++ b/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { MonitoringScreen } from "./MonitoringScreen";
+
+const TABS = ["Logs", "History", "Network"];
+
+function screens() {
+  return {
+    Logs: <div>logs-body</div>,
+    History: <div>history-body</div>,
+    Network: <div>network-body</div>,
+  };
+}
+
+describe("MonitoringScreen", () => {
+  it("renders the screen for the active tab", () => {
+    renderWithMantine(
+      <MonitoringScreen
+        tabs={TABS}
+        value="History"
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        screens={screens()}
+      />,
+    );
+    expect(screen.getByText("history-body")).toBeInTheDocument();
+    expect(screen.queryByText("logs-body")).toBeNull();
+    expect(screen.queryByText("network-body")).toBeNull();
+  });
+
+  it("renders the controls tab row", () => {
+    renderWithMantine(
+      <MonitoringScreen
+        tabs={TABS}
+        value="Logs"
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        screens={screens()}
+      />,
+    );
+    expect(screen.getByRole("radio", { name: "Logs" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Close monitoring column" }),
+    ).toBeInTheDocument();
+  });
+
+  it("forwards tab changes and close from the controls", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    renderWithMantine(
+      <MonitoringScreen
+        tabs={TABS}
+        value="Logs"
+        onChange={onChange}
+        onClose={onClose}
+        screens={screens()}
+      />,
+    );
+    await user.click(screen.getByRole("radio", { name: "Network" }));
+    expect(onChange).toHaveBeenCalledWith("Network");
+    await user.click(
+      screen.getByRole("button", { name: "Close monitoring column" }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing in the slot when the active tab has no screen", () => {
+    renderWithMantine(
+      <MonitoringScreen
+        tabs={TABS}
+        value="Network"
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        screens={{ Logs: <div>logs-body</div> }}
+      />,
+    );
+    expect(screen.queryByText("logs-body")).toBeNull();
+  });
+});

--- a/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.test.tsx
+++ b/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { renderWithMantine, screen } from "../../../test/renderWithMantine";
-import { MonitoringScreen } from "./MonitoringScreen";
+import {
+  MonitoringScreen,
+  type MonitoringScreenProps,
+} from "./MonitoringScreen";
 
 const TABS = ["Logs", "History", "Network"];
 
@@ -13,32 +16,31 @@ function screens() {
   };
 }
 
+function renderScreen(overrides: Partial<MonitoringScreenProps> = {}) {
+  const props: MonitoringScreenProps = {
+    tabs: TABS,
+    value: "Logs",
+    onChange: vi.fn(),
+    searchValue: "",
+    onSearchChange: vi.fn(),
+    onClose: vi.fn(),
+    screens: screens(),
+    ...overrides,
+  };
+  renderWithMantine(<MonitoringScreen {...props} />);
+  return props;
+}
+
 describe("MonitoringScreen", () => {
   it("renders the screen for the active tab", () => {
-    renderWithMantine(
-      <MonitoringScreen
-        tabs={TABS}
-        value="History"
-        onChange={vi.fn()}
-        onClose={vi.fn()}
-        screens={screens()}
-      />,
-    );
+    renderScreen({ value: "History" });
     expect(screen.getByText("history-body")).toBeInTheDocument();
     expect(screen.queryByText("logs-body")).toBeNull();
     expect(screen.queryByText("network-body")).toBeNull();
   });
 
   it("renders the controls tab row", () => {
-    renderWithMantine(
-      <MonitoringScreen
-        tabs={TABS}
-        value="Logs"
-        onChange={vi.fn()}
-        onClose={vi.fn()}
-        screens={screens()}
-      />,
-    );
+    renderScreen();
     expect(screen.getByRole("radio", { name: "Logs" })).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Close monitoring column" }),
@@ -49,15 +51,7 @@ describe("MonitoringScreen", () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     const onClose = vi.fn();
-    renderWithMantine(
-      <MonitoringScreen
-        tabs={TABS}
-        value="Logs"
-        onChange={onChange}
-        onClose={onClose}
-        screens={screens()}
-      />,
-    );
+    renderScreen({ onChange, onClose });
     await user.click(screen.getByRole("radio", { name: "Network" }));
     expect(onChange).toHaveBeenCalledWith("Network");
     await user.click(
@@ -66,16 +60,18 @@ describe("MonitoringScreen", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards the search value and changes from the controls", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    renderScreen({ searchValue: "hi", onSearchChange });
+    const box = screen.getByRole("textbox", { name: "Search" });
+    expect(box).toHaveValue("hi");
+    await user.type(box, "!");
+    expect(onSearchChange).toHaveBeenCalledWith("hi!");
+  });
+
   it("renders nothing in the slot when the active tab has no screen", () => {
-    renderWithMantine(
-      <MonitoringScreen
-        tabs={TABS}
-        value="Network"
-        onChange={vi.fn()}
-        onClose={vi.fn()}
-        screens={{ Logs: <div>logs-body</div> }}
-      />,
-    );
+    renderScreen({ value: "Network", screens: { Logs: <div>logs-body</div> } });
     expect(screen.queryByText("logs-body")).toBeNull();
   });
 });

--- a/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.tsx
+++ b/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+import { Divider, Stack } from "@mantine/core";
+import { MonitoringControls } from "../MonitoringControls/MonitoringControls";
+
+export interface MonitoringScreenProps {
+  /** Available monitor tabs (Logs/History/Network, filtered by capability). */
+  tabs: string[];
+  /** Active monitor tab; keys into `screens` to pick what renders below. */
+  value: string;
+  onChange: (tab: string) => void;
+  onClose: () => void;
+  /**
+   * The embedded screen node for each tab, keyed by tab label. The caller builds
+   * these (with `embedded` set) so this component stays a pure layout shell.
+   */
+  screens: Record<string, ReactNode>;
+}
+
+// Fills the pinned column: a fixed controls row on top and the selected screen
+// filling the remaining height below (mih:0 lets the inner ScrollArea bound).
+const ColumnLayout = Stack.withProps({
+  h: "100%",
+  gap: 0,
+});
+
+const ScreenSlot = Stack.withProps({
+  flex: 1,
+  mih: 0,
+  gap: 0,
+});
+
+/**
+ * The pinned monitoring column's content (#1616): a `MonitoringControls` tab row
+ * over the currently-selected monitor screen. Layout-only — it renders whichever
+ * embedded screen node the caller supplies for the active tab.
+ */
+export function MonitoringScreen({
+  tabs,
+  value,
+  onChange,
+  onClose,
+  screens,
+}: MonitoringScreenProps) {
+  return (
+    <ColumnLayout>
+      <MonitoringControls
+        tabs={tabs}
+        value={value}
+        onChange={onChange}
+        onClose={onClose}
+      />
+      <Divider />
+      <ScreenSlot>{screens[value]}</ScreenSlot>
+    </ColumnLayout>
+  );
+}

--- a/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.tsx
+++ b/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.tsx
@@ -8,6 +8,9 @@ export interface MonitoringScreenProps {
   /** Active monitor tab; keys into `screens` to pick what renders below. */
   value: string;
   onChange: (tab: string) => void;
+  /** Search text for the active screen; wired by the caller to its filter state. */
+  searchValue: string;
+  onSearchChange: (next: string) => void;
   onClose: () => void;
   /**
    * The embedded screen node for each tab, keyed by tab label. The caller builds
@@ -38,6 +41,8 @@ export function MonitoringScreen({
   tabs,
   value,
   onChange,
+  searchValue,
+  onSearchChange,
   onClose,
   screens,
 }: MonitoringScreenProps) {
@@ -47,6 +52,8 @@ export function MonitoringScreen({
         tabs={tabs}
         value={value}
         onChange={onChange}
+        searchValue={searchValue}
+        onSearchChange={onSearchChange}
         onClose={onClose}
       />
       <Divider />

--- a/clients/web/src/components/groups/NetworkEntry/NetworkEntry.test.tsx
+++ b/clients/web/src/components/groups/NetworkEntry/NetworkEntry.test.tsx
@@ -31,6 +31,20 @@ describe("NetworkEntry", () => {
     expect(screen.getByText("transport")).toBeInTheDocument();
   });
 
+  it("renders the compact two-line layout (line 1 meta, line 2 URL) when embedded", () => {
+    renderWithMantine(
+      <NetworkEntry entry={baseEntry} isListExpanded={false} embedded />,
+    );
+    // Line 1: method, category, duration, status.
+    expect(screen.getByText("POST")).toBeInTheDocument();
+    expect(screen.getByText("transport")).toBeInTheDocument();
+    expect(screen.getByText("45ms")).toBeInTheDocument();
+    expect(screen.getByText("200 OK")).toBeInTheDocument();
+    // Line 2: the URL (in its scroll area) and the expand toggle.
+    expect(screen.getByText("https://example.com/mcp")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand" })).toBeInTheDocument();
+  });
+
   it("shows body / header detail when expanded", async () => {
     const user = userEvent.setup();
     renderWithMantine(

--- a/clients/web/src/components/groups/NetworkEntry/NetworkEntry.test.tsx
+++ b/clients/web/src/components/groups/NetworkEntry/NetworkEntry.test.tsx
@@ -35,7 +35,11 @@ describe("NetworkEntry", () => {
     renderWithMantine(
       <NetworkEntry entry={baseEntry} isListExpanded={false} embedded />,
     );
-    // Line 1: method, category, duration, status.
+    // Line 1: compact time-only timestamp, method, category, duration, status.
+    expect(screen.getByText("10:00:00")).toBeInTheDocument();
+    expect(
+      screen.queryByText("2026-03-17T10:00:00.000Z"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("POST")).toBeInTheDocument();
     expect(screen.getByText("transport")).toBeInTheDocument();
     expect(screen.getByText("45ms")).toBeInTheDocument();

--- a/clients/web/src/components/groups/NetworkEntry/NetworkEntry.tsx
+++ b/clients/web/src/components/groups/NetworkEntry/NetworkEntry.tsx
@@ -6,6 +6,7 @@ import {
   Collapse,
   Divider,
   Group,
+  ScrollArea,
   Stack,
   Table,
   Text,
@@ -19,6 +20,12 @@ import { maskSecretsInBody } from "../../../utils/maskSecrets";
 export interface NetworkEntryProps {
   entry: FetchRequestEntry;
   isListExpanded: boolean;
+  /**
+   * Compact two-line header for the narrow monitoring column (#1616): line 1 is
+   * time + method + category + duration + status; line 2 is the URL in a
+   * horizontal scroll area with the expand toggle on the right.
+   */
+  embedded?: boolean;
 }
 
 const EntryContainer = Card.withProps({
@@ -41,6 +48,26 @@ const UrlText = Text.withProps({
   size: "sm",
   fw: 500,
   truncate: "end",
+});
+
+// Compact-header URL: never wraps, so a long URL scrolls horizontally inside its
+// ScrollArea instead of wrapping to many lines.
+const UrlScroll = Text.withProps({
+  size: "sm",
+  fw: 500,
+  variant: "nowrap",
+});
+
+// Left / right clusters for a compact header line (mirrors HistoryEntry).
+const HeaderCluster = Group.withProps({
+  gap: "sm",
+  wrap: "nowrap",
+  miw: 0,
+});
+
+const ControlsCluster = Group.withProps({
+  gap: "sm",
+  wrap: "nowrap",
 });
 
 const DurationText = Text.withProps({
@@ -197,7 +224,11 @@ function BodyPreview({
   );
 }
 
-export function NetworkEntry({ entry, isListExpanded }: NetworkEntryProps) {
+export function NetworkEntry({
+  entry,
+  isListExpanded,
+  embedded = false,
+}: NetworkEntryProps) {
   const [isExpanded, setIsExpanded] = useState(isListExpanded);
 
   // The list-level Expand/Collapse toggle is authoritative: each time the
@@ -210,33 +241,70 @@ export function NetworkEntry({ entry, isListExpanded }: NetworkEntryProps) {
     setIsExpanded(isListExpanded);
   }, [isListExpanded]);
 
+  const metaBadges = (
+    <>
+      {entry.duration != null && (
+        <DurationText>{formatDuration(entry.duration)}</DurationText>
+      )}
+      {isLongLivedStream(entry) && <Badge color="orange">SSE</Badge>}
+      <Badge color={statusColor(entry)}>{statusLabel(entry)}</Badge>
+    </>
+  );
+  const expandToggle = (
+    <ExpandToggle
+      expanded={isExpanded}
+      onToggle={() => setIsExpanded((v) => !v)}
+    />
+  );
+
   return (
     <EntryContainer>
       <Stack gap="sm">
-        <HeaderRow>
-          <Group gap="sm" wrap="nowrap" miw={0} flex={1}>
-            <TimestampText>{formatTimestamp(entry.timestamp)}</TimestampText>
-            <Badge color="dark">{entry.method}</Badge>
-            <Badge color={categoryColor(entry.category)} variant="light">
-              {entry.category}
-            </Badge>
-            <UrlText>{entry.url}</UrlText>
-          </Group>
-          <Group gap="sm" wrap="nowrap">
-            {entry.duration != null && (
-              <DurationText>{formatDuration(entry.duration)}</DurationText>
-            )}
-            {isLongLivedStream(entry) && <Badge color="orange">SSE</Badge>}
-            <Badge color={statusColor(entry)}>{statusLabel(entry)}</Badge>
-          </Group>
-        </HeaderRow>
+        {embedded ? (
+          // Compact two-line header for the narrow column.
+          <Stack gap="xs">
+            <HeaderRow>
+              <HeaderCluster>
+                <TimestampText>
+                  {formatTimestamp(entry.timestamp)}
+                </TimestampText>
+                <Badge color="dark">{entry.method}</Badge>
+                <Badge color={categoryColor(entry.category)} variant="light">
+                  {entry.category}
+                </Badge>
+              </HeaderCluster>
+              <ControlsCluster>{metaBadges}</ControlsCluster>
+            </HeaderRow>
+            <Group gap="xs" wrap="nowrap" justify="space-between">
+              <ScrollArea type="hover" scrollbarSize={6} flex={1} miw={0}>
+                <UrlScroll>{entry.url}</UrlScroll>
+              </ScrollArea>
+              {expandToggle}
+            </Group>
+          </Stack>
+        ) : (
+          <>
+            <HeaderRow>
+              <Group gap="sm" wrap="nowrap" miw={0} flex={1}>
+                <TimestampText>
+                  {formatTimestamp(entry.timestamp)}
+                </TimestampText>
+                <Badge color="dark">{entry.method}</Badge>
+                <Badge color={categoryColor(entry.category)} variant="light">
+                  {entry.category}
+                </Badge>
+                <UrlText>{entry.url}</UrlText>
+              </Group>
+              <Group gap="sm" wrap="nowrap">
+                {metaBadges}
+              </Group>
+            </HeaderRow>
 
-        <Group gap="xs" justify="flex-end">
-          <ExpandToggle
-            expanded={isExpanded}
-            onToggle={() => setIsExpanded((v) => !v)}
-          />
-        </Group>
+            <Group gap="xs" justify="flex-end">
+              {expandToggle}
+            </Group>
+          </>
+        )}
 
         <Collapse in={isExpanded}>
           <Stack gap="sm">

--- a/clients/web/src/components/groups/NetworkEntry/NetworkEntry.tsx
+++ b/clients/web/src/components/groups/NetworkEntry/NetworkEntry.tsx
@@ -89,6 +89,12 @@ function formatTimestamp(date: Date): string {
   return date.toISOString();
 }
 
+// Time-only (HH:MM:SS, UTC) for the compact column header, where the full ISO
+// string would eat most of the narrow line-1 width (#1616).
+function formatTimestampCompact(date: Date): string {
+  return date.toISOString().slice(11, 19);
+}
+
 function statusColor(entry: FetchRequestEntry): string {
   if (entry.error) return "red";
   const status = entry.responseStatus;
@@ -266,7 +272,7 @@ export function NetworkEntry({
             <HeaderRow>
               <HeaderCluster>
                 <TimestampText>
-                  {formatTimestamp(entry.timestamp)}
+                  {formatTimestampCompact(entry.timestamp)}
                 </TimestampText>
                 <Badge color="dark">{entry.method}</Badge>
                 <Badge color={categoryColor(entry.category)} variant="light">

--- a/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
+++ b/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
@@ -114,9 +114,6 @@ export function NetworkStreamPanel({
       <Group justify="space-between" mb="sm">
         <Title order={4}>{formatTitle(filteredEntries.length)}</Title>
         <Group gap="xs">
-          {hasResults && (
-            <ListToggle compact={compact} onToggle={onToggleCompact} />
-          )}
           <SortToggle
             value={sortDirection}
             onChange={onSortChange}
@@ -128,6 +125,9 @@ export function NetworkStreamPanel({
           <Button variant="default" onClick={onExport} disabled={!hasEntries}>
             Export
           </Button>
+          {hasResults && (
+            <ListToggle compact={compact} onToggle={onToggleCompact} />
+          )}
           {onPin ? <PinColumnButton onPin={onPin} /> : null}
         </Group>
       </Group>

--- a/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
+++ b/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
@@ -147,6 +147,7 @@ export function NetworkStreamPanel({
                 key={entry.id}
                 entry={entry}
                 isListExpanded={!compact}
+                embedded={embedded}
               />
             ))}
           </Stack>

--- a/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
+++ b/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
@@ -58,8 +58,11 @@ function matchesFilters(
   entry: FetchRequestEntry,
   filterText: string,
   visibleCategories: Record<FetchRequestCategory, boolean>,
+  // The embedded column exposes only the search box (no category toggles), so it
+  // applies the text filter but skips the category filter (#1616).
+  ignoreCategories: boolean,
 ): boolean {
-  if (!visibleCategories[entry.category]) return false;
+  if (!ignoreCategories && !visibleCategories[entry.category]) return false;
   if (filterText) {
     const term = filterText.toLowerCase();
     const status =
@@ -98,13 +101,11 @@ export function NetworkStreamPanel({
 }: NetworkStreamPanelProps) {
   const viewportRef = useScrollMemory("network-stream");
   const filteredEntries = useMemo(() => {
-    // Embedded column: show the full stream (no filter sidebar to explain a
-    // mirrored filter). See LogStreamPanel (#1616). `.filter()` returns a fresh
-    // array, so sorting in-place is safe.
+    // Embedded column filters by text only (its category toggles live in the
+    // full-size sidebar). See LogStreamPanel (#1616). `.filter()` returns a
+    // fresh array, so sorting in-place is safe.
     const sorted = entries
-      .filter(
-        (e) => embedded || matchesFilters(e, filterText, visibleCategories),
-      )
+      .filter((e) => matchesFilters(e, filterText, visibleCategories, embedded))
       .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
     if (sortDirection === "newest-first") sorted.reverse();
     return sorted;

--- a/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
+++ b/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
@@ -98,13 +98,17 @@ export function NetworkStreamPanel({
 }: NetworkStreamPanelProps) {
   const viewportRef = useScrollMemory("network-stream");
   const filteredEntries = useMemo(() => {
-    // `.filter()` returns a fresh array, so sorting in-place is safe.
+    // Embedded column: show the full stream (no filter sidebar to explain a
+    // mirrored filter). See LogStreamPanel (#1616). `.filter()` returns a fresh
+    // array, so sorting in-place is safe.
     const sorted = entries
-      .filter((e) => matchesFilters(e, filterText, visibleCategories))
+      .filter(
+        (e) => embedded || matchesFilters(e, filterText, visibleCategories),
+      )
       .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
     if (sortDirection === "newest-first") sorted.reverse();
     return sorted;
-  }, [entries, filterText, visibleCategories, sortDirection]);
+  }, [entries, filterText, visibleCategories, sortDirection, embedded]);
 
   const hasEntries = entries.length > 0;
   const hasResults = filteredEntries.length > 0;

--- a/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
+++ b/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
@@ -1,13 +1,5 @@
 import { useMemo } from "react";
-import {
-  Button,
-  Group,
-  Paper,
-  ScrollArea,
-  Stack,
-  Text,
-  Title,
-} from "@mantine/core";
+import { Button, Group, Paper, Stack, Text, Title } from "@mantine/core";
 import type {
   FetchRequestCategory,
   FetchRequestEntry,
@@ -18,6 +10,8 @@ import {
   SortToggle,
   type SortDirection,
 } from "../../elements/SortToggle/SortToggle";
+import { PinColumnButton } from "../../elements/PinColumnButton/PinColumnButton";
+import { EmbeddableScrollArea } from "../../elements/EmbeddableScrollArea/EmbeddableScrollArea";
 import { useScrollMemory } from "../../../hooks/useScrollMemory";
 
 export interface NetworkStreamPanelProps {
@@ -30,6 +24,10 @@ export interface NetworkStreamPanelProps {
   onSortChange: (next: SortDirection) => void;
   compact: boolean;
   onToggleCompact: () => void;
+  /** See LogStreamPanel: shows a "pin as column" button when set (#1616). */
+  onPin?: () => void;
+  /** See LogStreamPanel: fills the flex parent instead of the viewport calc. */
+  embedded?: boolean;
 }
 
 const PanelContainer = Paper.withProps({
@@ -95,6 +93,8 @@ export function NetworkStreamPanel({
   onSortChange,
   compact,
   onToggleCompact,
+  onPin,
+  embedded = false,
 }: NetworkStreamPanelProps) {
   const viewportRef = useScrollMemory("network-stream");
   const filteredEntries = useMemo(() => {
@@ -114,6 +114,7 @@ export function NetworkStreamPanel({
       <Group justify="space-between" mb="sm">
         <Title order={4}>{formatTitle(filteredEntries.length)}</Title>
         <Group gap="xs">
+          {onPin ? <PinColumnButton onPin={onPin} /> : null}
           {hasResults && (
             <ListToggle compact={compact} onToggle={onToggleCompact} />
           )}
@@ -134,12 +135,7 @@ export function NetworkStreamPanel({
       {!hasResults ? (
         <EmptyState>No network requests</EmptyState>
       ) : (
-        <ScrollArea.Autosize
-          viewportRef={viewportRef}
-          mah="calc(100vh - var(--app-shell-header-height, 0px) - 150px)"
-          type="scroll"
-          offsetScrollbars
-        >
+        <EmbeddableScrollArea embedded={embedded} viewportRef={viewportRef}>
           <Stack gap="md">
             {filteredEntries.map((entry) => (
               <NetworkEntry
@@ -149,7 +145,7 @@ export function NetworkStreamPanel({
               />
             ))}
           </Stack>
-        </ScrollArea.Autosize>
+        </EmbeddableScrollArea>
       )}
     </PanelContainer>
   );

--- a/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
+++ b/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
@@ -114,7 +114,6 @@ export function NetworkStreamPanel({
       <Group justify="space-between" mb="sm">
         <Title order={4}>{formatTitle(filteredEntries.length)}</Title>
         <Group gap="xs">
-          {onPin ? <PinColumnButton onPin={onPin} /> : null}
           {hasResults && (
             <ListToggle compact={compact} onToggle={onToggleCompact} />
           )}
@@ -129,6 +128,7 @@ export function NetworkStreamPanel({
           <Button variant="default" onClick={onExport} disabled={!hasEntries}>
             Export
           </Button>
+          {onPin ? <PinColumnButton onPin={onPin} /> : null}
         </Group>
       </Group>
 

--- a/clients/web/src/components/screens/HistoryScreen/HistoryScreen.test.tsx
+++ b/clients/web/src/components/screens/HistoryScreen/HistoryScreen.test.tsx
@@ -126,4 +126,17 @@ describe("HistoryScreen", () => {
     // The sidebar (HistoryControls, with its Search box) is not rendered.
     expect(screen.queryByPlaceholderText("Search...")).toBeNull();
   });
+
+  it("shows the full stream when embedded, ignoring the live filter", () => {
+    // A search that matches nothing would empty the full-size screen...
+    renderWithMantine(
+      <HistoryScreen
+        {...baseProps}
+        ui={{ ...EMPTY_HISTORY_UI, search: "zzz-no-match" }}
+        embedded
+      />,
+    );
+    // ...but the embedded column shows the full stream (not the empty state).
+    expect(screen.queryByText("No request history")).toBeNull();
+  });
 });

--- a/clients/web/src/components/screens/HistoryScreen/HistoryScreen.test.tsx
+++ b/clients/web/src/components/screens/HistoryScreen/HistoryScreen.test.tsx
@@ -111,4 +111,19 @@ describe("HistoryScreen", () => {
       expect.objectContaining({ methodFilter: undefined }),
     );
   });
+
+  it("renders a pin-as-column button when onPin is provided and invokes it", async () => {
+    const user = userEvent.setup();
+    const onPin = vi.fn();
+    renderWithMantine(<HistoryScreen {...baseProps} onPin={onPin} />);
+    await user.click(screen.getByRole("button", { name: "Pin as column" }));
+    expect(onPin).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops the filter sidebar when embedded, keeping the request list", () => {
+    renderWithMantine(<HistoryScreen {...baseProps} embedded />);
+    expect(screen.getByText("Requests")).toBeInTheDocument();
+    // The sidebar (HistoryControls, with its Search box) is not rendered.
+    expect(screen.queryByPlaceholderText("Search...")).toBeNull();
+  });
 });

--- a/clients/web/src/components/screens/HistoryScreen/HistoryScreen.test.tsx
+++ b/clients/web/src/components/screens/HistoryScreen/HistoryScreen.test.tsx
@@ -127,8 +127,25 @@ describe("HistoryScreen", () => {
     expect(screen.queryByPlaceholderText("Search...")).toBeNull();
   });
 
-  it("shows the full stream when embedded, ignoring the live filter", () => {
-    // A search that matches nothing would empty the full-size screen...
+  it("applies the search text but ignores the method filter when embedded", () => {
+    renderWithMantine(
+      <HistoryScreen
+        {...baseProps}
+        ui={{
+          ...EMPTY_HISTORY_UI,
+          // Method filter would exclude the tools/list entries on the full-size
+          // screen...
+          methodFilter: "resources/list",
+          // ...but the column search matches them.
+          search: "tools",
+        }}
+        embedded
+      />,
+    );
+    expect(screen.queryByText("No request history")).toBeNull();
+  });
+
+  it("hides entries not matching the column search when embedded", () => {
     renderWithMantine(
       <HistoryScreen
         {...baseProps}
@@ -136,7 +153,6 @@ describe("HistoryScreen", () => {
         embedded
       />,
     );
-    // ...but the embedded column shows the full stream (not the empty state).
-    expect(screen.queryByText("No request history")).toBeNull();
+    expect(screen.getByText("No request history")).toBeInTheDocument();
   });
 });

--- a/clients/web/src/components/screens/HistoryScreen/HistoryScreen.tsx
+++ b/clients/web/src/components/screens/HistoryScreen/HistoryScreen.tsx
@@ -25,6 +25,10 @@ export interface HistoryScreenProps {
   onSortChange: (next: SortDirection) => void;
   compact: boolean;
   onToggleCompact: () => void;
+  /** See LoggingScreen: shows a "pin as column" button when set (#1616). */
+  onPin?: () => void;
+  /** See LoggingScreen: fills the parent height and drops the filter sidebar. */
+  embedded?: boolean;
 }
 
 // Search text, method filter, and per-direction visibility — controlled by the
@@ -69,6 +73,8 @@ export function HistoryScreen({
   onSortChange,
   compact,
   onToggleCompact,
+  onPin,
+  embedded = false,
 }: HistoryScreenProps) {
   const { search, methodFilter, visibleDirections } = ui;
 
@@ -101,23 +107,25 @@ export function HistoryScreen({
   }, [ui, visibleDirections, onUiChange]);
 
   return (
-    <ScreenLayout>
-      <Sidebar>
-        <SidebarCard>
-          <HistoryControls
-            searchText={search}
-            methodFilter={methodFilter}
-            availableMethods={availableMethods}
-            visibleDirections={visibleDirections}
-            onSearchChange={(value) => onUiChange({ ...ui, search: value })}
-            onMethodFilterChange={(value) =>
-              onUiChange({ ...ui, methodFilter: value })
-            }
-            onToggleDirection={handleToggleDirection}
-            onToggleAllDirections={handleToggleAllDirections}
-          />
-        </SidebarCard>
-      </Sidebar>
+    <ScreenLayout h={embedded ? "100%" : undefined}>
+      {embedded ? null : (
+        <Sidebar>
+          <SidebarCard>
+            <HistoryControls
+              searchText={search}
+              methodFilter={methodFilter}
+              availableMethods={availableMethods}
+              visibleDirections={visibleDirections}
+              onSearchChange={(value) => onUiChange({ ...ui, search: value })}
+              onMethodFilterChange={(value) =>
+                onUiChange({ ...ui, methodFilter: value })
+              }
+              onToggleDirection={handleToggleDirection}
+              onToggleAllDirections={handleToggleAllDirections}
+            />
+          </SidebarCard>
+        </Sidebar>
+      )}
       <HistoryListPanel
         entries={entries}
         pinnedIds={pinnedIds}
@@ -134,6 +142,8 @@ export function HistoryScreen({
         onSortChange={onSortChange}
         compact={compact}
         onToggleCompact={onToggleCompact}
+        onPin={onPin}
+        embedded={embedded}
       />
     </ScreenLayout>
   );

--- a/clients/web/src/components/screens/LoggingScreen/LoggingScreen.test.tsx
+++ b/clients/web/src/components/screens/LoggingScreen/LoggingScreen.test.tsx
@@ -147,14 +147,38 @@ describe("LoggingScreen", () => {
     expect(screen.queryByRole("button", { name: "Set" })).toBeNull();
   });
 
-  it("shows the full stream when embedded, ignoring the live filter", () => {
+  it("applies the search text but ignores the level filter when embedded", () => {
     const entries = [
       {
         receivedAt: new Date(),
         params: { level: "info" as const, data: "hello" },
       },
     ];
-    // A filter that would hide the entry on the full-size screen...
+    renderWithMantine(
+      <LoggingScreen
+        {...baseProps}
+        entries={entries}
+        ui={{
+          ...EMPTY_LOGS_UI,
+          // The level filter would hide this entry on the full-size screen...
+          visibleLevels: { ...EMPTY_LOGS_UI.visibleLevels, info: false },
+          // ...but the column search matches it.
+          filterText: "hello",
+        }}
+        embedded
+      />,
+    );
+    // Search matches + level filter is ignored → the entry shows.
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("hides entries not matching the column search when embedded", () => {
+    const entries = [
+      {
+        receivedAt: new Date(),
+        params: { level: "info" as const, data: "hello" },
+      },
+    ];
     renderWithMantine(
       <LoggingScreen
         {...baseProps}
@@ -163,7 +187,6 @@ describe("LoggingScreen", () => {
         embedded
       />,
     );
-    // ...is ignored in the embedded, sidebar-less column.
-    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.queryByText("hello")).toBeNull();
   });
 });

--- a/clients/web/src/components/screens/LoggingScreen/LoggingScreen.test.tsx
+++ b/clients/web/src/components/screens/LoggingScreen/LoggingScreen.test.tsx
@@ -131,4 +131,19 @@ describe("LoggingScreen", () => {
     await user.click(screen.getByRole("button", { name: "Set" }));
     expect(onSetLevel).toHaveBeenCalledWith("info");
   });
+
+  it("renders a pin-as-column button when onPin is provided and invokes it", async () => {
+    const user = userEvent.setup();
+    const onPin = vi.fn();
+    renderWithMantine(<LoggingScreen {...baseProps} onPin={onPin} />);
+    await user.click(screen.getByRole("button", { name: "Pin as column" }));
+    expect(onPin).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops the filter sidebar when embedded, keeping the stream", () => {
+    renderWithMantine(<LoggingScreen {...baseProps} embedded />);
+    expect(screen.getByText("Log Stream")).toBeInTheDocument();
+    // The sidebar (LogControls, with its Set button) is not rendered.
+    expect(screen.queryByRole("button", { name: "Set" })).toBeNull();
+  });
 });

--- a/clients/web/src/components/screens/LoggingScreen/LoggingScreen.test.tsx
+++ b/clients/web/src/components/screens/LoggingScreen/LoggingScreen.test.tsx
@@ -146,4 +146,24 @@ describe("LoggingScreen", () => {
     // The sidebar (LogControls, with its Set button) is not rendered.
     expect(screen.queryByRole("button", { name: "Set" })).toBeNull();
   });
+
+  it("shows the full stream when embedded, ignoring the live filter", () => {
+    const entries = [
+      {
+        receivedAt: new Date(),
+        params: { level: "info" as const, data: "hello" },
+      },
+    ];
+    // A filter that would hide the entry on the full-size screen...
+    renderWithMantine(
+      <LoggingScreen
+        {...baseProps}
+        entries={entries}
+        ui={{ ...EMPTY_LOGS_UI, filterText: "zzz-no-match" }}
+        embedded
+      />,
+    );
+    // ...is ignored in the embedded, sidebar-less column.
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
 });

--- a/clients/web/src/components/screens/LoggingScreen/LoggingScreen.tsx
+++ b/clients/web/src/components/screens/LoggingScreen/LoggingScreen.tsx
@@ -16,6 +16,17 @@ export interface LoggingScreenProps {
   onExport: () => void;
   sortDirection: SortDirection;
   onSortChange: (next: SortDirection) => void;
+  /**
+   * When set, the stream panel shows a "pin as column" button (#1616). Omitted
+   * when already embedded, or when pinning isn't currently available.
+   */
+  onPin?: () => void;
+  /**
+   * True when rendered inside the monitoring column: the screen fills its
+   * parent's height (instead of the viewport calc) and drops the filter
+   * sidebar so the narrow column is stream-only.
+   */
+  embedded?: boolean;
 }
 
 // Filter text + visible-level set — controlled by the parent (App) as one
@@ -52,6 +63,8 @@ export function LoggingScreen({
   onExport,
   sortDirection,
   onSortChange,
+  onPin,
+  embedded = false,
 }: LoggingScreenProps) {
   const { filterText, visibleLevels } = ui;
 
@@ -71,20 +84,24 @@ export function LoggingScreen({
   }
 
   return (
-    <ScreenLayout>
-      <Sidebar>
-        <SidebarCard>
-          <LogControls
-            currentLevel={currentLevel}
-            filterText={filterText}
-            visibleLevels={visibleLevels}
-            onSetLevel={onSetLevel}
-            onFilterChange={(value) => onUiChange({ ...ui, filterText: value })}
-            onToggleLevel={handleToggleLevel}
-            onToggleAllLevels={handleToggleAllLevels}
-          />
-        </SidebarCard>
-      </Sidebar>
+    <ScreenLayout h={embedded ? "100%" : undefined}>
+      {embedded ? null : (
+        <Sidebar>
+          <SidebarCard>
+            <LogControls
+              currentLevel={currentLevel}
+              filterText={filterText}
+              visibleLevels={visibleLevels}
+              onSetLevel={onSetLevel}
+              onFilterChange={(value) =>
+                onUiChange({ ...ui, filterText: value })
+              }
+              onToggleLevel={handleToggleLevel}
+              onToggleAllLevels={handleToggleAllLevels}
+            />
+          </SidebarCard>
+        </Sidebar>
+      )}
       <LogStreamPanel
         entries={entries}
         filterText={filterText}
@@ -93,6 +110,8 @@ export function LoggingScreen({
         onExport={onExport}
         sortDirection={sortDirection}
         onSortChange={onSortChange}
+        onPin={onPin}
+        embedded={embedded}
       />
     </ScreenLayout>
   );

--- a/clients/web/src/components/screens/NetworkScreen/NetworkScreen.test.tsx
+++ b/clients/web/src/components/screens/NetworkScreen/NetworkScreen.test.tsx
@@ -163,4 +163,20 @@ describe("NetworkScreen", () => {
     expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Export" })).toBeDisabled();
   });
+
+  it("renders a pin-as-column button when onPin is provided and invokes it", async () => {
+    const user = userEvent.setup();
+    const onPin = vi.fn();
+    renderWithMantine(<NetworkScreen {...baseProps} onPin={onPin} />);
+    await user.click(screen.getByRole("button", { name: "Pin as column" }));
+    expect(onPin).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops the filter sidebar when embedded, keeping the request list", () => {
+    renderWithMantine(<NetworkScreen {...baseProps} embedded />);
+    // The sidebar (NetworkControls, with its Search box) is not rendered.
+    expect(screen.queryByPlaceholderText("Search...")).toBeNull();
+    // The stream toolbar (Export) is still present.
+    expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument();
+  });
 });

--- a/clients/web/src/components/screens/NetworkScreen/NetworkScreen.test.tsx
+++ b/clients/web/src/components/screens/NetworkScreen/NetworkScreen.test.tsx
@@ -179,4 +179,17 @@ describe("NetworkScreen", () => {
     // The stream toolbar (Export) is still present.
     expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument();
   });
+
+  it("shows the full stream when embedded, ignoring the live filter", () => {
+    // A filter that matches nothing would empty the full-size screen...
+    renderWithMantine(
+      <NetworkScreen
+        {...baseProps}
+        ui={{ ...EMPTY_NETWORK_UI, filterText: "zzz-no-match" }}
+        embedded
+      />,
+    );
+    // ...but the embedded column shows the full stream (not the empty state).
+    expect(screen.queryByText("No network requests")).toBeNull();
+  });
 });

--- a/clients/web/src/components/screens/NetworkScreen/NetworkScreen.test.tsx
+++ b/clients/web/src/components/screens/NetworkScreen/NetworkScreen.test.tsx
@@ -180,8 +180,25 @@ describe("NetworkScreen", () => {
     expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument();
   });
 
-  it("shows the full stream when embedded, ignoring the live filter", () => {
-    // A filter that matches nothing would empty the full-size screen...
+  it("applies the search text but ignores the category filter when embedded", () => {
+    renderWithMantine(
+      <NetworkScreen
+        {...baseProps}
+        ui={{
+          ...EMPTY_NETWORK_UI,
+          // Category filter would hide the transport entry on the full-size
+          // screen...
+          visibleCategories: { auth: true, transport: false },
+          // ...but the column search matches it.
+          filterText: "example.com",
+        }}
+        embedded
+      />,
+    );
+    expect(screen.queryByText("No network requests")).toBeNull();
+  });
+
+  it("hides entries not matching the column search when embedded", () => {
     renderWithMantine(
       <NetworkScreen
         {...baseProps}
@@ -189,7 +206,6 @@ describe("NetworkScreen", () => {
         embedded
       />,
     );
-    // ...but the embedded column shows the full stream (not the empty state).
-    expect(screen.queryByText("No network requests")).toBeNull();
+    expect(screen.getByText("No network requests")).toBeInTheDocument();
   });
 });

--- a/clients/web/src/components/screens/NetworkScreen/NetworkScreen.tsx
+++ b/clients/web/src/components/screens/NetworkScreen/NetworkScreen.tsx
@@ -21,6 +21,10 @@ export interface NetworkScreenProps {
   onSortChange: (next: SortDirection) => void;
   compact: boolean;
   onToggleCompact: () => void;
+  /** See LoggingScreen: shows a "pin as column" button when set (#1616). */
+  onPin?: () => void;
+  /** See LoggingScreen: fills the parent height and drops the filter sidebar. */
+  embedded?: boolean;
 }
 
 // Filter text + visible-category set — controlled by the parent (App) as one
@@ -57,6 +61,8 @@ export function NetworkScreen({
   onSortChange,
   compact,
   onToggleCompact,
+  onPin,
+  embedded = false,
 }: NetworkScreenProps) {
   const { filterText, visibleCategories } = ui;
 
@@ -81,18 +87,22 @@ export function NetworkScreen({
   }
 
   return (
-    <ScreenLayout>
-      <Sidebar>
-        <SidebarCard>
-          <NetworkControls
-            filterText={filterText}
-            visibleCategories={visibleCategories}
-            onFilterChange={(value) => onUiChange({ ...ui, filterText: value })}
-            onToggleCategory={handleToggleCategory}
-            onToggleAllCategories={handleToggleAllCategories}
-          />
-        </SidebarCard>
-      </Sidebar>
+    <ScreenLayout h={embedded ? "100%" : undefined}>
+      {embedded ? null : (
+        <Sidebar>
+          <SidebarCard>
+            <NetworkControls
+              filterText={filterText}
+              visibleCategories={visibleCategories}
+              onFilterChange={(value) =>
+                onUiChange({ ...ui, filterText: value })
+              }
+              onToggleCategory={handleToggleCategory}
+              onToggleAllCategories={handleToggleAllCategories}
+            />
+          </SidebarCard>
+        </Sidebar>
+      )}
       <NetworkStreamPanel
         entries={entries}
         filterText={filterText}
@@ -103,6 +113,8 @@ export function NetworkScreen({
         onSortChange={onSortChange}
         compact={compact}
         onToggleCompact={onToggleCompact}
+        onPin={onPin}
+        embedded={embedded}
       />
     </ScreenLayout>
   );

--- a/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import type {
   InitializeResult,
@@ -15,8 +15,25 @@ import {
   renderWithMantine,
   screen,
   waitFor,
+  within,
+  fireEvent,
 } from "../../../test/renderWithMantine";
 import { InspectorView, type InspectorViewProps } from "./InspectorView";
+
+// The monitoring column (#1616) is gated on a 1040px viewport media query.
+// happy-dom's viewport is 1024px, so that query is really false; make just that
+// gate controllable per test. ViewHeader's own 992/768 queries stay "wide" (as
+// they are in the real 1024px happy-dom viewport), so header rendering — and
+// every existing test below — is unaffected.
+const monitorWide = vi.hoisted(() => ({ value: false }));
+vi.mock("@mantine/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mantine/hooks")>();
+  return {
+    ...actual,
+    useMediaQuery: (query: string): boolean =>
+      query === "(min-width: 1040px)" ? monitorWide.value : true,
+  };
+});
 import type { BridgeFactory } from "../../elements/AppRenderer/AppRenderer";
 import {
   EMPTY_TOOLS_UI,
@@ -1272,6 +1289,271 @@ describe("InspectorView", () => {
       ).toBeInTheDocument();
       // ...but the indicator is not, since promptsListChanged is false.
       expect(screen.queryByText("List updated")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("pinned monitoring column (#1616)", () => {
+    const httpServer: ServerEntry = {
+      id: "beta",
+      name: "Beta",
+      config: { type: "streamable-http", url: "http://localhost:3000/mcp" },
+      connection: { status: "connected" },
+    };
+    const httpInit = initWithCapabilities(allCapabilities);
+
+    beforeEach(() => {
+      // Default narrow so a test only pins when it opts in.
+      monitorWide.value = false;
+    });
+
+    function connectedHttp(overrides: Partial<InspectorViewProps> = {}) {
+      return makeProps({
+        servers: [httpServer],
+        activeServer: "beta",
+        connectionStatus: "connected",
+        initializeResult: httpInit,
+        ...overrides,
+      });
+    }
+
+    async function gotoTab(tab: string) {
+      const user = userEvent.setup();
+      const tabSelect = await screen.findByDisplayValue("Servers");
+      await user.click(tabSelect);
+      await user.click(await screen.findByText(tab));
+      return user;
+    }
+
+    it("shows the Pin as column button on a monitor screen only when wide", async () => {
+      monitorWide.value = false;
+      const { unmount } = renderWithMantine(
+        <StatefulInspectorViewHost {...connectedHttp()} />,
+      );
+      await gotoTab("Logs");
+      expect(
+        screen.queryByRole("button", { name: "Pin as column" }),
+      ).not.toBeInTheDocument();
+      unmount();
+
+      monitorWide.value = true;
+      renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);
+      await gotoTab("Logs");
+      expect(
+        await screen.findByRole("button", { name: "Pin as column" }),
+      ).toBeInTheDocument();
+    });
+
+    it("pins the monitor group into the column and removes it from the header", async () => {
+      monitorWide.value = true;
+      renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);
+      const user = await gotoTab("Logs");
+      await user.click(
+        await screen.findByRole("button", { name: "Pin as column" }),
+      );
+
+      // Column is open (its close control is present).
+      expect(
+        await screen.findByRole("button", { name: "Close monitoring column" }),
+      ).toBeInTheDocument();
+
+      // The monitor group is gone from the header tab bar...
+      const header = screen.getByRole("banner");
+      expect(within(header).queryByRole("radio", { name: "Logs" })).toBeNull();
+      expect(
+        within(header).queryByRole("radio", { name: "History" }),
+      ).toBeNull();
+      expect(
+        within(header).queryByRole("radio", { name: "Network" }),
+      ).toBeNull();
+      // ...and a non-monitor tab still sits in the header.
+      expect(
+        within(header).getByRole("radio", { name: "Tools" }),
+      ).toBeInTheDocument();
+
+      // The column hosts the monitor tabs, defaulting to the pinned one.
+      expect(screen.getByRole("radio", { name: "Logs" })).toBeChecked();
+      expect(
+        screen.getByRole("radio", { name: "Network" }),
+      ).toBeInTheDocument();
+    });
+
+    it("returns the monitor group to the header when the column is closed", async () => {
+      monitorWide.value = true;
+      renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);
+      const user = await gotoTab("Logs");
+      await user.click(
+        await screen.findByRole("button", { name: "Pin as column" }),
+      );
+      await user.click(
+        await screen.findByRole("button", { name: "Close monitoring column" }),
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Close monitoring column" }),
+      ).toBeNull();
+      const header = screen.getByRole("banner");
+      expect(
+        within(header).getByRole("radio", { name: "Logs" }),
+      ).toBeInTheDocument();
+    });
+
+    it("persists the pin preference and reopens the column when wide", () => {
+      // Stored preference from a prior wide session.
+      window.localStorage.setItem("inspector.monitor.pinned", "true");
+
+      // Narrow: the column stays closed and the group is in the header.
+      monitorWide.value = false;
+      const { unmount } = renderWithMantine(
+        <StatefulInspectorViewHost {...connectedHttp()} />,
+      );
+      expect(
+        screen.queryByRole("button", { name: "Close monitoring column" }),
+      ).toBeNull();
+      expect(
+        within(screen.getByRole("banner")).getByRole("radio", { name: "Logs" }),
+      ).toBeInTheDocument();
+      unmount();
+
+      // Wide: the preserved preference reopens the column without re-pinning.
+      monitorWide.value = true;
+      renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);
+      expect(
+        screen.getByRole("button", { name: "Close monitoring column" }),
+      ).toBeInTheDocument();
+    });
+
+    it("keeps the column closed when the stored preference is explicitly false", () => {
+      window.localStorage.setItem("inspector.monitor.pinned", "false");
+      monitorWide.value = true;
+      renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);
+      expect(
+        screen.queryByRole("button", { name: "Close monitoring column" }),
+      ).toBeNull();
+    });
+
+    it("hides the column on disconnect but keeps the pin preference", () => {
+      window.localStorage.setItem("inspector.monitor.pinned", "true");
+      monitorWide.value = true;
+      const { rerender } = renderWithMantine(
+        <StatefulInspectorViewHost {...connectedHttp()} />,
+      );
+      expect(
+        screen.getByRole("button", { name: "Close monitoring column" }),
+      ).toBeInTheDocument();
+
+      rerender(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [httpServer],
+            activeServer: undefined,
+            connectionStatus: "disconnected",
+          })}
+        />,
+      );
+      expect(
+        screen.queryByRole("button", { name: "Close monitoring column" }),
+      ).toBeNull();
+      // Preference is untouched — only the column's close button clears it.
+      expect(window.localStorage.getItem("inspector.monitor.pinned")).toBe(
+        "true",
+      );
+    });
+
+    it("drops Network from the column tabs for a stdio server", () => {
+      window.localStorage.setItem("inspector.monitor.pinned", "true");
+      monitorWide.value = true;
+      renderWithMantine(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [sampleServer],
+            activeServer: "alpha",
+            connectionStatus: "connected",
+            initializeResult: initWithCapabilities(allCapabilities),
+          })}
+        />,
+      );
+      // Column open, but Network is unavailable over stdio.
+      expect(
+        screen.getByRole("button", { name: "Close monitoring column" }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Logs" })).toBeInTheDocument();
+      expect(screen.queryByRole("radio", { name: "Network" })).toBeNull();
+    });
+
+    it("falls back to an available tab when the stored monitor tab is unavailable", () => {
+      // Stored tab is Network, but a stdio + logging-only server can't offer it.
+      window.localStorage.setItem("inspector.monitor.pinned", "true");
+      window.localStorage.setItem("inspector.monitor.tab", "Network");
+      monitorWide.value = true;
+      renderWithMantine(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [sampleServer],
+            activeServer: "alpha",
+            connectionStatus: "connected",
+            initializeResult: initWithCapabilities({ logging: {} }),
+          })}
+        />,
+      );
+      // Column active tab clamps to the first available monitor tab (Logs).
+      expect(screen.getByRole("radio", { name: "Logs" })).toBeChecked();
+      expect(screen.queryByRole("radio", { name: "Network" })).toBeNull();
+    });
+
+    it("clamps the primary tab to Servers when the header has no other tab", () => {
+      // stdio + logging only ⇒ availableTabs = [Servers, Logs, History]; pinning
+      // moves both monitor tabs out, leaving [Servers] as the only header tab.
+      window.localStorage.setItem("inspector.monitor.pinned", "true");
+      monitorWide.value = true;
+      renderWithMantine(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [sampleServer],
+            activeServer: "alpha",
+            connectionStatus: "connected",
+            initializeResult: initWithCapabilities({ logging: {} }),
+          })}
+        />,
+      );
+      const header = screen.getByRole("banner");
+      expect(
+        within(header)
+          .getAllByRole("radio")
+          .map((r) => r.getAttribute("value")),
+      ).toEqual(["Servers"]);
+      expect(
+        screen.getByRole("button", { name: "Close monitoring column" }),
+      ).toBeInTheDocument();
+    });
+
+    it("persists the selected column tab", async () => {
+      window.localStorage.setItem("inspector.monitor.pinned", "true");
+      monitorWide.value = true;
+      const user = userEvent.setup();
+      renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);
+      await user.click(await screen.findByRole("radio", { name: "History" }));
+      await waitFor(() =>
+        expect(window.localStorage.getItem("inspector.monitor.tab")).toBe(
+          "History",
+        ),
+      );
+    });
+
+    it("resizes and persists the column width from the keyboard", async () => {
+      window.localStorage.setItem("inspector.monitor.pinned", "true");
+      window.localStorage.setItem("inspector.monitor.width", "420");
+      monitorWide.value = true;
+      renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);
+      const handle = await screen.findByRole("separator", {
+        name: "Resize monitoring column",
+      });
+      // ArrowLeft widens by the 16px step (panel is on the right).
+      fireEvent.keyDown(handle, { key: "ArrowLeft" });
+      await waitFor(() =>
+        expect(window.localStorage.getItem("inspector.monitor.width")).toBe(
+          "436",
+        ),
+      );
     });
   });
 });

--- a/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
@@ -1388,13 +1388,36 @@ describe("InspectorView", () => {
         await screen.findByRole("button", { name: "Close monitoring column" }),
       );
 
-      expect(
-        screen.queryByRole("button", { name: "Close monitoring column" }),
-      ).toBeNull();
+      // The column plays its slide-out animation before unmounting.
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("button", { name: "Close monitoring column" }),
+        ).toBeNull(),
+      );
       const header = screen.getByRole("banner");
       expect(
         within(header).getByRole("radio", { name: "Logs" }),
       ).toBeInTheDocument();
+    });
+
+    it("carries the column's selection to the primary view on close", async () => {
+      monitorWide.value = true;
+      renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);
+      const user = await gotoTab("Logs");
+      await user.click(
+        await screen.findByRole("button", { name: "Pin as column" }),
+      );
+      // Switch the column to History, then close it.
+      await user.click(await screen.findByRole("radio", { name: "History" }));
+      await user.click(
+        await screen.findByRole("button", { name: "Close monitoring column" }),
+      );
+
+      // The primary header now has History selected (not the pre-pin Logs).
+      const header = screen.getByRole("banner");
+      expect(
+        within(header).getByRole("radio", { name: "History" }),
+      ).toBeChecked();
     });
 
     it("persists the pin preference and reopens the column when wide", () => {
@@ -1431,7 +1454,7 @@ describe("InspectorView", () => {
       ).toBeNull();
     });
 
-    it("hides the column on disconnect but keeps the pin preference", () => {
+    it("hides the column on disconnect but keeps the pin preference", async () => {
       window.localStorage.setItem("inspector.monitor.pinned", "true");
       monitorWide.value = true;
       const { rerender } = renderWithMantine(
@@ -1450,9 +1473,12 @@ describe("InspectorView", () => {
           })}
         />,
       );
-      expect(
-        screen.queryByRole("button", { name: "Close monitoring column" }),
-      ).toBeNull();
+      // The column plays its slide-out animation before unmounting.
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("button", { name: "Close monitoring column" }),
+        ).toBeNull(),
+      );
       // Preference is untouched — only the column's close button clears it.
       expect(window.localStorage.getItem("inspector.monitor.pinned")).toBe(
         "true",
@@ -1536,6 +1562,46 @@ describe("InspectorView", () => {
         expect(window.localStorage.getItem("inspector.monitor.tab")).toBe(
           "History",
         ),
+      );
+    });
+
+    it("keeps the column search across tabs and filters each screen", async () => {
+      window.localStorage.setItem("inspector.monitor.pinned", "true");
+      monitorWide.value = true;
+      const user = userEvent.setup();
+      renderWithMantine(
+        <StatefulInspectorViewHost
+          {...connectedHttp({
+            logs: [
+              {
+                receivedAt: new Date(),
+                params: { level: "info", data: "loghello" },
+              },
+            ],
+            history: [
+              {
+                id: "h1",
+                timestamp: new Date(),
+                direction: "request",
+                message: { jsonrpc: "2.0", id: 1, method: "tools/list" },
+              },
+            ],
+          })}
+        />,
+      );
+      // Column defaults to Logs; the log entry shows.
+      expect(await screen.findByText("loghello")).toBeInTheDocument();
+
+      // A search matching nothing filters the Logs stream...
+      const searchBox = screen.getByRole("textbox", { name: "Search" });
+      await user.type(searchBox, "zzz");
+      expect(screen.queryByText("loghello")).toBeNull();
+
+      // ...and the same term carries over to History (still filtered → empty).
+      await user.click(screen.getByRole("radio", { name: "History" }));
+      expect(screen.getByText("No request history")).toBeInTheDocument();
+      expect(screen.getByRole("textbox", { name: "Search" })).toHaveValue(
+        "zzz",
       );
     });
 

--- a/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
@@ -1400,24 +1400,38 @@ describe("InspectorView", () => {
       ).toBeInTheDocument();
     });
 
-    it("carries the column's selection to the primary view on close", async () => {
+    it("keeps the current header screen (not the column's) when closed", async () => {
       monitorWide.value = true;
       renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);
       const user = await gotoTab("Logs");
       await user.click(
         await screen.findByRole("button", { name: "Pin as column" }),
       );
+      // Pinning moved the primary to the first non-Servers header tab (Tools).
+      const header = screen.getByRole("banner");
+      expect(
+        within(header).getByRole("radio", { name: "Tools" }),
+      ).toBeChecked();
+
       // Switch the column to History, then close it.
       await user.click(await screen.findByRole("radio", { name: "History" }));
       await user.click(
         await screen.findByRole("button", { name: "Close monitoring column" }),
       );
 
-      // The primary header now has History selected (not the pre-pin Logs).
-      const header = screen.getByRole("banner");
+      // The primary stays on the header's current screen (Tools), not the
+      // column's History, and the monitor group returns to the header.
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("button", { name: "Close monitoring column" }),
+        ).toBeNull(),
+      );
+      expect(
+        within(header).getByRole("radio", { name: "Tools" }),
+      ).toBeChecked();
       expect(
         within(header).getByRole("radio", { name: "History" }),
-      ).toBeChecked();
+      ).toBeInTheDocument();
     });
 
     it("persists the pin preference and reopens the column when wide", () => {

--- a/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
@@ -1343,6 +1343,39 @@ describe("InspectorView", () => {
       ).toBeInTheDocument();
     });
 
+    it("opens the monitoring column when a connection is established", async () => {
+      monitorWide.value = true;
+      const { rerender } = renderWithMantine(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [httpServer],
+            activeServer: undefined,
+            connectionStatus: "disconnected",
+          })}
+        />,
+      );
+      // Disconnected: the column is closed.
+      expect(
+        screen.queryByRole("button", { name: "Close monitoring column" }),
+      ).toBeNull();
+
+      // Connecting opens it (the disconnected → connected transition).
+      rerender(<StatefulInspectorViewHost {...connectedHttp()} />);
+      expect(
+        await screen.findByRole("button", { name: "Close monitoring column" }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not auto-open on a mount that starts already connected", () => {
+      // No disconnected → connected transition, and no stored preference, so the
+      // column stays closed (a user who closed it isn't fought on remount).
+      monitorWide.value = true;
+      renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);
+      expect(
+        screen.queryByRole("button", { name: "Close monitoring column" }),
+      ).toBeNull();
+    });
+
     it("pins the monitor group into the column and removes it from the header", async () => {
       monitorWide.value = true;
       renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -1,6 +1,6 @@
-import { useMemo, type ReactNode, type Ref } from "react";
-import { AppShell, Box, Stack, Transition } from "@mantine/core";
-import { useLocalStorage } from "@mantine/hooks";
+import { useMemo, useState, type ReactNode, type Ref } from "react";
+import { AppShell, Box, Flex, Stack, Transition } from "@mantine/core";
+import { useLocalStorage, useMediaQuery } from "@mantine/hooks";
 import type {
   InitializeResult,
   LoggingLevel,
@@ -64,6 +64,8 @@ import {
   type NetworkUiState,
 } from "../../screens/NetworkScreen/NetworkScreen";
 import type { SortDirection } from "../../elements/SortToggle/SortToggle";
+import { MonitoringScreen } from "../../groups/MonitoringScreen/MonitoringScreen";
+import { ResizeHandle } from "../../elements/ResizeHandle/ResizeHandle";
 import { getServerType } from "@inspector/core/mcp/config.js";
 import { INSPECTOR_SERVERS_TAB } from "../../../utils/inspectorTabs";
 
@@ -127,6 +129,8 @@ function useListCompact(
 }
 
 const SERVERS_TAB = INSPECTOR_SERVERS_TAB;
+const LOGS_TAB = "Logs";
+const HISTORY_TAB = "History";
 const NETWORK_TAB = "Network";
 
 const ALL_TABS: string[] = [
@@ -136,10 +140,71 @@ const ALL_TABS: string[] = [
   "Prompts",
   "Resources",
   "Tasks",
-  "Logs",
-  "History",
+  LOGS_TAB,
+  HISTORY_TAB,
   NETWORK_TAB,
 ];
+
+// The screens that can be pinned into the monitoring column (#1616). Pinning is
+// a group action: opening the column removes all *available* monitor tabs from
+// the header and hosts them in the column instead.
+type MonitorTab = "Logs" | "History" | "Network";
+const MONITOR_TABS: string[] = [LOGS_TAB, HISTORY_TAB, NETWORK_TAB];
+
+function isMonitorTab(tab: string): tab is MonitorTab {
+  return tab === LOGS_TAB || tab === HISTORY_TAB || tab === NETWORK_TAB;
+}
+
+// The viewport width below which the split collapses to a single column: matches
+// the point where ServerListScreen drops to one card, so the primary area always
+// has room for at least one full-width card beside the column.
+const MONITOR_WIDE_QUERY = "(min-width: 1040px)";
+
+// Monitoring column width bounds (px). MIN keeps the stream readable; MAX stops
+// the column from crowding out the primary area.
+const MONITOR_WIDTH_MIN = 320;
+const MONITOR_WIDTH_MAX = 720;
+const MONITOR_WIDTH_DEFAULT = 420;
+const MONITOR_WIDTH_STEP = 16;
+
+function clampMonitorWidth(value: number): number {
+  return Math.min(MONITOR_WIDTH_MAX, Math.max(MONITOR_WIDTH_MIN, value));
+}
+
+// localStorage adapters for the monitoring-column preferences, matching the
+// human-readable / clamp-on-read shape of the sort + compact adapters above.
+const MONITOR_PINNED_DEFAULT = false;
+
+function deserializeMonitorPinned(raw: string | undefined): boolean {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  return MONITOR_PINNED_DEFAULT;
+}
+
+function serializeMonitorPinned(value: boolean): string {
+  return value ? "true" : "false";
+}
+
+const MONITOR_TAB_DEFAULT: MonitorTab = LOGS_TAB;
+
+function deserializeMonitorTab(raw: string | undefined): MonitorTab {
+  return raw !== undefined && isMonitorTab(raw) ? raw : MONITOR_TAB_DEFAULT;
+}
+
+function serializeMonitorTab(value: MonitorTab): string {
+  return value;
+}
+
+function deserializeMonitorWidth(raw: string | undefined): number {
+  const parsed = raw !== undefined ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed)
+    ? clampMonitorWidth(parsed)
+    : MONITOR_WIDTH_DEFAULT;
+}
+
+function serializeMonitorWidth(value: number): string {
+  return String(value);
+}
 
 const SCREEN_ENTER_MS = 350;
 const SCREEN_EXIT_MS = 250;
@@ -154,6 +219,29 @@ const ScreenStageContainer = Stack.withProps({
   gap: 0,
   flex: 1,
   mih: "100%",
+  // Let the pane shrink below its content's intrinsic width when the monitoring
+  // column opens — without this the Servers grid / SegmentedControl refuse to
+  // shrink and squeeze the column (or force a page scrollbar). (#1616)
+  miw: 0,
+});
+
+// Row wrapper turning AppShell.Main into a [primary | handle | column] split.
+// `h/w: 100%` inherit the header-offset height AppShell.Main provides, matching
+// the screens' own `calc(100dvh - header)`. (#1616)
+const SplitRow = Flex.withProps({
+  direction: "row",
+  gap: 0,
+  h: "100%",
+  w: "100%",
+});
+
+// The pinned monitoring column. Fixed-basis (its width is driven live via the
+// `w` style prop at the call site); `miw: 0` so its inner ScrollArea can bound.
+const MonitoringColumn = Stack.withProps({
+  flex: "0 0 auto",
+  h: "100%",
+  gap: 0,
+  miw: 0,
 });
 
 // Wraps each screen in a Mantine Transition. With Transition's default
@@ -489,6 +577,42 @@ export function InspectorView({
     false,
   );
 
+  // Monitoring-column state (#1616): whether Logs/History/Network are pinned to
+  // the right column, which one is active there, and the column width. All
+  // persisted (view-layout preferences), same shape as the sort/compact hooks.
+  const [monitorPinned, setMonitorPinned] = useLocalStorage<boolean>({
+    key: "inspector.monitor.pinned",
+    defaultValue: MONITOR_PINNED_DEFAULT,
+    deserialize: deserializeMonitorPinned,
+    serialize: serializeMonitorPinned,
+    getInitialValueInEffect: false,
+  });
+  const [monitorTab, setMonitorTab] = useLocalStorage<MonitorTab>({
+    key: "inspector.monitor.tab",
+    defaultValue: MONITOR_TAB_DEFAULT,
+    deserialize: deserializeMonitorTab,
+    serialize: serializeMonitorTab,
+    getInitialValueInEffect: false,
+  });
+  const [monitorWidth, setMonitorWidth] = useLocalStorage<number>({
+    key: "inspector.monitor.width",
+    defaultValue: MONITOR_WIDTH_DEFAULT,
+    deserialize: deserializeMonitorWidth,
+    serialize: serializeMonitorWidth,
+    getInitialValueInEffect: false,
+  });
+  // Transient width during a drag; committed to `monitorWidth` on release so
+  // localStorage takes a single write per drag rather than one per pointer move.
+  const [dragWidth, setDragWidth] = useState<number | null>(null);
+  const columnWidth = dragWidth ?? monitorWidth;
+
+  // The split only exists with enough horizontal room. `true` initial value so
+  // the first synchronous paint assumes wide (the common desktop case) rather
+  // than flashing the collapsed layout.
+  const isWide = useMediaQuery(MONITOR_WIDE_QUERY, true, {
+    getInitialValueInEffect: false,
+  });
+
   const appTools = useMemo<Tool[]>(() => {
     return tools.filter((tool) => {
       try {
@@ -558,15 +682,72 @@ export function InspectorView({
     appTools,
   ]);
 
-  // Clamp the rendered tab to whatever's currently available. If the user
-  // had "Tools" selected and the connection drops, `availableTabs` becomes
+  // Monitoring column, derived (#1616). The monitor group is pinned into the
+  // right column only when: the user asked for it, the viewport is wide enough,
+  // a server is connected, and at least one monitor tab is actually available
+  // (capability/stdio aware). Narrowing, disconnecting, or losing the last
+  // monitor capability flips `effectivePinned` false and closes the column —
+  // WITHOUT clearing `monitorPinned`, so it re-opens when the condition returns.
+  // Only the column's close button writes `monitorPinned = false`.
+  const connected = connectionStatus === "connected";
+  const monitorAvailable = useMemo<string[]>(
+    () => availableTabs.filter((t) => MONITOR_TABS.includes(t)),
+    [availableTabs],
+  );
+  const effectivePinned =
+    monitorPinned && !!isWide && connected && monitorAvailable.length > 0;
+
+  // The header loses the monitor group while the column is open (its screens
+  // live in the column instead); otherwise it shows every available tab.
+  const headerTabs = useMemo<string[]>(
+    () =>
+      effectivePinned
+        ? availableTabs.filter((t) => !MONITOR_TABS.includes(t))
+        : availableTabs,
+    [effectivePinned, availableTabs],
+  );
+
+  // Clamp the rendered primary tab to whatever the header currently shows. If
+  // the user had "Tools" selected and the connection drops, `headerTabs` becomes
   // `[Servers]` and the view renders Servers without us having to imperatively
-  // reset the state (and trip the `set-state-in-effect` lint). When the
-  // connection comes back, the previous selection pops in again because
-  // the parent's `activeTab` is preserved.
-  const activeTab = availableTabs.includes(activeTabProp)
+  // reset the state (and trip the `set-state-in-effect` lint). When pinning
+  // moves a monitor tab out of the header, the primary falls back to the first
+  // non-Servers tab; the lifted `activeTabProp` is left intact so closing the
+  // column restores the user's prior selection.
+  const firstNonServersTab =
+    headerTabs.find((t) => t !== SERVERS_TAB) ?? SERVERS_TAB;
+  const activeTab = headerTabs.includes(activeTabProp)
     ? activeTabProp
-    : SERVERS_TAB;
+    : effectivePinned
+      ? firstNonServersTab
+      : SERVERS_TAB;
+
+  // The monitor tab shown in the column, clamped to what's available (e.g. a
+  // switch to a stdio server drops Network). `?? LOGS_TAB` is a types-only
+  // fallback: the column only renders while `monitorAvailable.length > 0`.
+  const effectiveMonitorTab: MonitorTab =
+    monitorAvailable.includes(monitorTab) && isMonitorTab(monitorTab)
+      ? monitorTab
+      : (monitorAvailable.find(isMonitorTab) ?? LOGS_TAB);
+
+  // Pinning is a group action: remember which tab was clicked and open the
+  // column. Gated by `canPin` so the pin affordance only appears when a click
+  // would actually take effect (wide + connected).
+  const canPin = !!isWide && connected;
+  function pinMonitor(tab: MonitorTab) {
+    setMonitorTab(tab);
+    setMonitorPinned(true);
+  }
+  function handleMonitorTabChange(tab: string) {
+    // The SegmentedControl's data only holds valid monitor tabs, so the guard's
+    // false arm is unreachable through the UI.
+    /* v8 ignore next */
+    if (isMonitorTab(tab)) setMonitorTab(tab);
+  }
+  function commitMonitorWidth(next: number) {
+    setMonitorWidth(next);
+    setDragWidth(null);
+  }
 
   // Merge the parent's `serversInput` (static config) with the runtime
   // connection state owned by the parent — only the active server reflects
@@ -616,6 +797,56 @@ export function InspectorView({
     ? undefined
     : activeServer;
 
+  // Shared props for each monitor screen, spread into both its primary
+  // (header-tab) instance and its embedded (column) instance so the two can't
+  // drift. The primary adds `onPin`; the embedded adds `embedded`. (#1616)
+  const loggingScreenProps = {
+    entries: logs,
+    currentLevel: currentLogLevel,
+    ui: logsUi,
+    onUiChange: onLogsUiChange,
+    onSetLevel: onSetLogLevel,
+    onClear: onClearLogs,
+    onExport: onExportLogs,
+    sortDirection: logsSort,
+    onSortChange: setLogsSort,
+  };
+  const historyScreenProps = {
+    entries: history,
+    pinnedIds: pinnedHistoryIds ?? new Set<string>(),
+    ui: historyUi,
+    onUiChange: onHistoryUiChange,
+    onClearAll: onClearHistory,
+    onExport: onExportHistory,
+    onClearSection: onClearHistorySection,
+    onExportSection: onExportHistorySection,
+    onReplay: onReplayHistory,
+    onTogglePin: onTogglePinHistory,
+    sortDirection: historySort,
+    onSortChange: setHistorySort,
+    compact: historyCompact,
+    onToggleCompact: () => setHistoryCompact((c) => !c),
+  };
+  const networkScreenProps = {
+    entries: network,
+    ui: networkUi,
+    onUiChange: onNetworkUiChange,
+    onClear: onClearNetwork,
+    onExport: onExportNetwork,
+    sortDirection: networkSort,
+    onSortChange: setNetworkSort,
+    compact: networkCompact,
+    onToggleCompact: () => setNetworkCompact((c) => !c),
+  };
+
+  // Embedded instances for the pinned column, keyed by tab. MonitoringScreen
+  // renders only the active one; the rest are unmounted element values.
+  const monitorScreens: Record<string, ReactNode> = {
+    [LOGS_TAB]: <LoggingScreen {...loggingScreenProps} embedded />,
+    [HISTORY_TAB]: <HistoryScreen {...historyScreenProps} embedded />,
+    [NETWORK_TAB]: <NetworkScreen {...networkScreenProps} embedded />,
+  };
+
   return (
     // padding={0}: each screen fills `calc(100dvh - header)` and supplies its
     // own `xl` padding, so Main must contribute only the fixed-header offset.
@@ -632,7 +863,7 @@ export function InspectorView({
             status={connectionStatus}
             latencyMs={latencyMs}
             activeTab={activeTab}
-            availableTabs={availableTabs}
+            availableTabs={headerTabs}
             onTabChange={onActiveTabChange}
             onDisconnect={onDisconnect}
             onToggleTheme={onToggleTheme}
@@ -647,150 +878,148 @@ export function InspectorView({
         )}
       </AppShell.Header>
       <AppShell.Main>
-        <ScreenStageContainer>
-          <ScreenStage active={activeTab === SERVERS_TAB}>
-            <ServerListScreen
-              servers={servers}
-              writable={serverListWritable}
-              activeServer={dimCardsAgainst}
-              onAddManually={onServerAdd}
-              onImportConfig={onServerImportConfig}
-              onImportServerJson={onServerImportJson}
-              onExport={onServerExport}
-              onToggleConnection={onToggleConnection}
-              onConnectionInfo={onConnectionInfo}
-              onSettings={onServerSettings}
-              onEdit={onServerEdit}
-              onClone={onServerClone}
-              onRemove={onServerRemove}
-              onReorder={onServerReorder}
-              highlightedServerIds={highlightedServerIds}
-              onClearHighlight={onClearHighlight}
-              compact={serversCompact}
-              onToggleCompact={() => setServersCompact((c) => !c)}
-            />
-          </ScreenStage>
-          <ScreenStage active={activeTab === "Tools"}>
-            <ToolsScreen
-              tools={tools}
-              callState={toolCallState}
-              ui={toolsUi}
-              listChanged={toolsListChanged}
-              serverSupportsTaskToolCalls={serverSupportsTaskToolCalls}
-              onUiChange={onToolsUiChange}
-              onRefreshList={onRefreshTools}
-              onCallTool={onCallTool}
-              onCancelCall={onCancelToolCall}
-              onClearResult={onClearToolResult}
-              onReadResource={onReadResourceContents}
-            />
-          </ScreenStage>
-          <ScreenStage active={activeTab === "Apps"}>
-            <AppsScreen
-              tools={appTools}
-              listChanged={toolsListChanged}
-              sandboxPath={sandboxPath}
-              bridgeFactory={bridgeFactory}
-              rendererRef={appRendererRef}
-              ui={appsUi}
-              onUiChange={onAppsUiChange}
-              onRefreshList={onRefreshApps}
-              onSelectApp={onSelectApp}
-              onOpenApp={onOpenApp}
-              onCloseApp={onCloseApp}
-              onError={onAppError}
-            />
-          </ScreenStage>
-          <ScreenStage active={activeTab === "Prompts"}>
-            <PromptsScreen
-              prompts={prompts}
-              getPromptState={getPromptState}
-              ui={promptsUi}
-              listChanged={promptsListChanged}
-              completionsSupported={completionsSupported}
-              onUiChange={onPromptsUiChange}
-              onRefreshList={onRefreshPrompts}
-              onGetPrompt={onGetPrompt}
-              onCopyMessages={onCopyPromptMessages}
-              onCompleteArgument={onCompleteArgument}
-            />
-          </ScreenStage>
-          <ScreenStage active={activeTab === "Resources"}>
-            <ResourcesScreen
-              resources={resources}
-              templates={resourceTemplates}
-              subscriptions={subscriptions}
-              readState={readResourceState}
-              ui={resourcesUi}
-              listChanged={resourcesListChanged}
-              completionsSupported={completionsSupported}
-              subscriptionsSupported={subscriptionsSupported}
-              onUiChange={onResourcesUiChange}
-              onRefreshList={onRefreshResources}
-              onReadResource={onReadResource}
-              onSubscribeResource={onSubscribeResource}
-              onUnsubscribeResource={onUnsubscribeResource}
-              onCompleteArgument={onCompleteArgument}
-              compact={resourcesCompact}
-              onCompactChange={setResourcesCompact}
-            />
-          </ScreenStage>
-          <ScreenStage active={activeTab === "Tasks"}>
-            <TasksScreen
-              tasks={tasks}
-              progressByTaskId={progressByTaskId}
-              ui={tasksUi}
-              onUiChange={onTasksUiChange}
-              onRefresh={onRefreshTasks}
-              onClearCompleted={onClearCompletedTasks}
-              onCancel={onCancelTask}
-            />
-          </ScreenStage>
-          <ScreenStage active={activeTab === "Logs"}>
-            <LoggingScreen
-              entries={logs}
-              currentLevel={currentLogLevel}
-              ui={logsUi}
-              onUiChange={onLogsUiChange}
-              onSetLevel={onSetLogLevel}
-              onClear={onClearLogs}
-              onExport={onExportLogs}
-              sortDirection={logsSort}
-              onSortChange={setLogsSort}
-            />
-          </ScreenStage>
-          <ScreenStage active={activeTab === "History"}>
-            <HistoryScreen
-              entries={history}
-              pinnedIds={pinnedHistoryIds ?? new Set()}
-              ui={historyUi}
-              onUiChange={onHistoryUiChange}
-              onClearAll={onClearHistory}
-              onExport={onExportHistory}
-              onClearSection={onClearHistorySection}
-              onExportSection={onExportHistorySection}
-              onReplay={onReplayHistory}
-              onTogglePin={onTogglePinHistory}
-              sortDirection={historySort}
-              onSortChange={setHistorySort}
-              compact={historyCompact}
-              onToggleCompact={() => setHistoryCompact((c) => !c)}
-            />
-          </ScreenStage>
-          <ScreenStage active={activeTab === "Network"}>
-            <NetworkScreen
-              entries={network}
-              ui={networkUi}
-              onUiChange={onNetworkUiChange}
-              onClear={onClearNetwork}
-              onExport={onExportNetwork}
-              sortDirection={networkSort}
-              onSortChange={setNetworkSort}
-              compact={networkCompact}
-              onToggleCompact={() => setNetworkCompact((c) => !c)}
-            />
-          </ScreenStage>
-        </ScreenStageContainer>
+        <SplitRow>
+          <ScreenStageContainer>
+            <ScreenStage active={activeTab === SERVERS_TAB}>
+              <ServerListScreen
+                servers={servers}
+                writable={serverListWritable}
+                activeServer={dimCardsAgainst}
+                onAddManually={onServerAdd}
+                onImportConfig={onServerImportConfig}
+                onImportServerJson={onServerImportJson}
+                onExport={onServerExport}
+                onToggleConnection={onToggleConnection}
+                onConnectionInfo={onConnectionInfo}
+                onSettings={onServerSettings}
+                onEdit={onServerEdit}
+                onClone={onServerClone}
+                onRemove={onServerRemove}
+                onReorder={onServerReorder}
+                highlightedServerIds={highlightedServerIds}
+                onClearHighlight={onClearHighlight}
+                compact={serversCompact}
+                onToggleCompact={() => setServersCompact((c) => !c)}
+              />
+            </ScreenStage>
+            <ScreenStage active={activeTab === "Tools"}>
+              <ToolsScreen
+                tools={tools}
+                callState={toolCallState}
+                ui={toolsUi}
+                listChanged={toolsListChanged}
+                serverSupportsTaskToolCalls={serverSupportsTaskToolCalls}
+                onUiChange={onToolsUiChange}
+                onRefreshList={onRefreshTools}
+                onCallTool={onCallTool}
+                onCancelCall={onCancelToolCall}
+                onClearResult={onClearToolResult}
+                onReadResource={onReadResourceContents}
+              />
+            </ScreenStage>
+            <ScreenStage active={activeTab === "Apps"}>
+              <AppsScreen
+                tools={appTools}
+                listChanged={toolsListChanged}
+                sandboxPath={sandboxPath}
+                bridgeFactory={bridgeFactory}
+                rendererRef={appRendererRef}
+                ui={appsUi}
+                onUiChange={onAppsUiChange}
+                onRefreshList={onRefreshApps}
+                onSelectApp={onSelectApp}
+                onOpenApp={onOpenApp}
+                onCloseApp={onCloseApp}
+                onError={onAppError}
+              />
+            </ScreenStage>
+            <ScreenStage active={activeTab === "Prompts"}>
+              <PromptsScreen
+                prompts={prompts}
+                getPromptState={getPromptState}
+                ui={promptsUi}
+                listChanged={promptsListChanged}
+                completionsSupported={completionsSupported}
+                onUiChange={onPromptsUiChange}
+                onRefreshList={onRefreshPrompts}
+                onGetPrompt={onGetPrompt}
+                onCopyMessages={onCopyPromptMessages}
+                onCompleteArgument={onCompleteArgument}
+              />
+            </ScreenStage>
+            <ScreenStage active={activeTab === "Resources"}>
+              <ResourcesScreen
+                resources={resources}
+                templates={resourceTemplates}
+                subscriptions={subscriptions}
+                readState={readResourceState}
+                ui={resourcesUi}
+                listChanged={resourcesListChanged}
+                completionsSupported={completionsSupported}
+                subscriptionsSupported={subscriptionsSupported}
+                onUiChange={onResourcesUiChange}
+                onRefreshList={onRefreshResources}
+                onReadResource={onReadResource}
+                onSubscribeResource={onSubscribeResource}
+                onUnsubscribeResource={onUnsubscribeResource}
+                onCompleteArgument={onCompleteArgument}
+                compact={resourcesCompact}
+                onCompactChange={setResourcesCompact}
+              />
+            </ScreenStage>
+            <ScreenStage active={activeTab === "Tasks"}>
+              <TasksScreen
+                tasks={tasks}
+                progressByTaskId={progressByTaskId}
+                ui={tasksUi}
+                onUiChange={onTasksUiChange}
+                onRefresh={onRefreshTasks}
+                onClearCompleted={onClearCompletedTasks}
+                onCancel={onCancelTask}
+              />
+            </ScreenStage>
+            <ScreenStage active={activeTab === LOGS_TAB}>
+              <LoggingScreen
+                {...loggingScreenProps}
+                onPin={canPin ? () => pinMonitor(LOGS_TAB) : undefined}
+              />
+            </ScreenStage>
+            <ScreenStage active={activeTab === HISTORY_TAB}>
+              <HistoryScreen
+                {...historyScreenProps}
+                onPin={canPin ? () => pinMonitor(HISTORY_TAB) : undefined}
+              />
+            </ScreenStage>
+            <ScreenStage active={activeTab === NETWORK_TAB}>
+              <NetworkScreen
+                {...networkScreenProps}
+                onPin={canPin ? () => pinMonitor(NETWORK_TAB) : undefined}
+              />
+            </ScreenStage>
+          </ScreenStageContainer>
+          {effectivePinned ? (
+            <>
+              <ResizeHandle
+                value={columnWidth}
+                min={MONITOR_WIDTH_MIN}
+                max={MONITOR_WIDTH_MAX}
+                step={MONITOR_WIDTH_STEP}
+                onChange={setDragWidth}
+                onCommit={commitMonitorWidth}
+                aria-label="Resize monitoring column"
+              />
+              <MonitoringColumn w={columnWidth}>
+                <MonitoringScreen
+                  tabs={monitorAvailable}
+                  value={effectiveMonitorTab}
+                  onChange={handleMonitorTabChange}
+                  onClose={() => setMonitorPinned(false)}
+                  screens={monitorScreens}
+                />
+              </MonitoringColumn>
+            </>
+          ) : null}
+        </SplitRow>
       </AppShell.Main>
     </AppShell>
   );

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -1,5 +1,13 @@
 import { useMemo, useState, type ReactNode, type Ref } from "react";
-import { AppShell, Box, Flex, Stack, Transition } from "@mantine/core";
+import {
+  AppShell,
+  Box,
+  Flex,
+  Group,
+  Stack,
+  Transition,
+  type MantineTransition,
+} from "@mantine/core";
 import { useLocalStorage, useMediaQuery } from "@mantine/hooks";
 import type {
   InitializeResult,
@@ -242,6 +250,27 @@ const MonitoringColumn = Stack.withProps({
   h: "100%",
   gap: 0,
   miw: 0,
+});
+
+// Column open/close animation (#1616): the handle + column slide in from the
+// right edge and fade as they mount, reversing on close, so pinning reads as the
+// screen moving into a side column rather than snapping in. `AppShell.Main`'s
+// `overflow: hidden` clips the off-screen portion during the slide.
+const COLUMN_ANIM_MS = 300;
+const slideInFromRight: MantineTransition = {
+  in: { opacity: 1, transform: "translateX(0)" },
+  out: { opacity: 0, transform: "translateX(100%)" },
+  common: { transformOrigin: "right center" },
+  transitionProperty: "transform, opacity",
+};
+
+// Flex-row wrapper holding the resize handle + column so the whole unit animates
+// as one (the Transition interpolation is applied to it via `style`).
+const MonitorColumnGroup = Group.withProps({
+  wrap: "nowrap",
+  gap: 0,
+  h: "100%",
+  flex: "0 0 auto",
 });
 
 // Wraps each screen in a Mantine Transition. With Transition's default
@@ -744,10 +773,24 @@ export function InspectorView({
     /* v8 ignore next */
     if (isMonitorTab(tab)) setMonitorTab(tab);
   }
+  // Closing the column carries its selection back to the primary area: the
+  // screen the user was watching in the column becomes the active header tab,
+  // rather than snapping back to whatever was selected before they pinned.
+  function closeMonitorColumn() {
+    onActiveTabChange(effectiveMonitorTab);
+    setMonitorPinned(false);
+  }
   function commitMonitorWidth(next: number) {
     setMonitorWidth(next);
     setDragWidth(null);
   }
+
+  // A single search shared across the column's tabs (kept as you move between
+  // Logs/History/Network so it filters each one), distinct from the full-size
+  // screens' own searches. The embedded panels apply only this text; their other
+  // filters (levels / categories / directions / method) have no control in the
+  // column and are bypassed there.
+  const [monitorSearch, setMonitorSearch] = useState("");
 
   // Merge the parent's `serversInput` (static config) with the runtime
   // connection state owned by the parent — only the active server reflects
@@ -840,11 +883,31 @@ export function InspectorView({
   };
 
   // Embedded instances for the pinned column, keyed by tab. MonitoringScreen
-  // renders only the active one; the rest are unmounted element values.
+  // renders only the active one; the rest are unmounted element values. Each
+  // screen's search field is overridden with the shared column search so it
+  // filters whichever tab is showing, and carries over as tabs change.
   const monitorScreens: Record<string, ReactNode> = {
-    [LOGS_TAB]: <LoggingScreen {...loggingScreenProps} embedded />,
-    [HISTORY_TAB]: <HistoryScreen {...historyScreenProps} embedded />,
-    [NETWORK_TAB]: <NetworkScreen {...networkScreenProps} embedded />,
+    [LOGS_TAB]: (
+      <LoggingScreen
+        {...loggingScreenProps}
+        ui={{ ...logsUi, filterText: monitorSearch }}
+        embedded
+      />
+    ),
+    [HISTORY_TAB]: (
+      <HistoryScreen
+        {...historyScreenProps}
+        ui={{ ...historyUi, search: monitorSearch }}
+        embedded
+      />
+    ),
+    [NETWORK_TAB]: (
+      <NetworkScreen
+        {...networkScreenProps}
+        ui={{ ...networkUi, filterText: monitorSearch }}
+        embedded
+      />
+    ),
   };
 
   return (
@@ -997,28 +1060,40 @@ export function InspectorView({
               />
             </ScreenStage>
           </ScreenStageContainer>
-          {effectivePinned ? (
-            <>
-              <ResizeHandle
-                value={columnWidth}
-                min={MONITOR_WIDTH_MIN}
-                max={MONITOR_WIDTH_MAX}
-                step={MONITOR_WIDTH_STEP}
-                onChange={setDragWidth}
-                onCommit={commitMonitorWidth}
-                aria-label="Resize monitoring column"
-              />
-              <MonitoringColumn w={columnWidth}>
-                <MonitoringScreen
-                  tabs={monitorAvailable}
-                  value={effectiveMonitorTab}
-                  onChange={handleMonitorTabChange}
-                  onClose={() => setMonitorPinned(false)}
-                  screens={monitorScreens}
+          <Transition
+            mounted={effectivePinned}
+            transition={slideInFromRight}
+            duration={COLUMN_ANIM_MS}
+            exitDuration={COLUMN_ANIM_MS}
+            timingFunction="ease"
+          >
+            {(styles) => (
+              // `style={styles}` is Mantine's runtime Transition interpolation,
+              // not static styling — same pattern as ScreenStage above.
+              <MonitorColumnGroup style={styles}>
+                <ResizeHandle
+                  value={columnWidth}
+                  min={MONITOR_WIDTH_MIN}
+                  max={MONITOR_WIDTH_MAX}
+                  step={MONITOR_WIDTH_STEP}
+                  onChange={setDragWidth}
+                  onCommit={commitMonitorWidth}
+                  aria-label="Resize monitoring column"
                 />
-              </MonitoringColumn>
-            </>
-          ) : null}
+                <MonitoringColumn w={columnWidth}>
+                  <MonitoringScreen
+                    tabs={monitorAvailable}
+                    value={effectiveMonitorTab}
+                    onChange={handleMonitorTabChange}
+                    searchValue={monitorSearch}
+                    onSearchChange={setMonitorSearch}
+                    onClose={closeMonitorColumn}
+                    screens={monitorScreens}
+                  />
+                </MonitoringColumn>
+              </MonitorColumnGroup>
+            )}
+          </Transition>
         </SplitRow>
       </AppShell.Main>
     </AppShell>

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -253,11 +253,13 @@ const MonitoringColumn = Stack.withProps({
 });
 
 // Column open/close animation (#1616): the handle + column slide in from the
-// right edge and fade as they mount, reversing on close, so pinning reads as the
-// screen moving into a side column rather than snapping in. `AppShell.Main`'s
-// `overflow: hidden` clips the off-screen portion during the slide.
+// right edge and fade as they mount, reversing on close, so pinning reads as a
+// side column sliding open rather than snapping in. The primary screen keeps its
+// standard `ScreenStage` transition. Mantine plays `out → in` on enter and
+// `in → out` on exit. `AppShell.Main`'s `overflow: hidden` clips the off-screen
+// portion during the slide.
 const COLUMN_ANIM_MS = 300;
-const slideInFromRight: MantineTransition = {
+const columnSlide: MantineTransition = {
   in: { opacity: 1, transform: "translateX(0)" },
   out: { opacity: 0, transform: "translateX(100%)" },
   common: { transformOrigin: "right center" },
@@ -265,9 +267,12 @@ const slideInFromRight: MantineTransition = {
 };
 
 // Flex-row wrapper holding the resize handle + column so the whole unit animates
-// as one (the Transition interpolation is applied to it via `style`).
+// as one (the Transition interpolation is applied to it via `style`). `align:
+// stretch` overrides Group's default `center` so the full-height resize handle
+// (which has no intrinsic height) fills the column instead of collapsing.
 const MonitorColumnGroup = Group.withProps({
   wrap: "nowrap",
+  align: "stretch",
   gap: 0,
   h: "100%",
   flex: "0 0 auto",
@@ -773,11 +778,12 @@ export function InspectorView({
     /* v8 ignore next */
     if (isMonitorTab(tab)) setMonitorTab(tab);
   }
-  // Closing the column carries its selection back to the primary area: the
-  // screen the user was watching in the column becomes the active header tab,
-  // rather than snapping back to whatever was selected before they pinned.
+  // Closing the column leaves the primary area on whatever screen is currently
+  // selected in the header — it does not swap in the column's screen. We commit
+  // the current `activeTab` to the lifted state first so unpinning can't resurrect
+  // the (now stale) monitor tab that was selected before pinning.
   function closeMonitorColumn() {
-    onActiveTabChange(effectiveMonitorTab);
+    onActiveTabChange(activeTab);
     setMonitorPinned(false);
   }
   function commitMonitorWidth(next: number) {
@@ -1062,7 +1068,7 @@ export function InspectorView({
           </ScreenStageContainer>
           <Transition
             mounted={effectivePinned}
-            transition={slideInFromRight}
+            transition={columnSlide}
             duration={COLUMN_ANIM_MS}
             exitDuration={COLUMN_ANIM_MS}
             timingFunction="ease"

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -1,4 +1,11 @@
-import { useMemo, useState, type ReactNode, type Ref } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type Ref,
+} from "react";
 import {
   AppShell,
   Box,
@@ -646,6 +653,23 @@ export function InspectorView({
   const isWide = useMediaQuery(MONITOR_WIDE_QUERY, true, {
     getInitialValueInEffect: false,
   });
+
+  // Open the monitoring column when a connection is established (#1616). Gated on
+  // the disconnected → connected *transition* (via the ref) rather than the
+  // "connected" state itself, so it fires on an actual connect — not on every
+  // render while connected, and not on a mount that starts already-connected
+  // (which would fight a user who closed it). The column still only *appears*
+  // when wide + a monitor tab is available (`effectivePinned`); this just sets
+  // the preference. Closing it stays closed until the next connect, since this
+  // effect only re-runs when `connectionStatus` changes.
+  const wasConnectedRef = useRef(connectionStatus === "connected");
+  useEffect(() => {
+    const isConnected = connectionStatus === "connected";
+    if (isConnected && !wasConnectedRef.current) {
+      setMonitorPinned(true);
+    }
+    wasConnectedRef.current = isConnected;
+  }, [connectionStatus, setMonitorPinned]);
 
   const appTools = useMemo<Tool[]>(() => {
     return tools.filter((tool) => {

--- a/clients/web/src/theme/Text.ts
+++ b/clients/web/src/theme/Text.ts
@@ -16,6 +16,16 @@ export const ThemeText = Text.extend({
         },
       };
     }
+    // Single-line text that never wraps — used inside a horizontal ScrollArea so
+    // a long value (e.g. a network URL in the compact column) scrolls instead of
+    // wrapping to many lines (#1616).
+    if (props.variant === "nowrap") {
+      return {
+        root: {
+          whiteSpace: "nowrap",
+        },
+      };
+    }
     return { root: {} };
   },
 });


### PR DESCRIPTION
Closes #1616

## Summary

Adds the ability to **pin** the Logging, History, and Network screens into a resizable, animated second column on the right of the `InspectorView`, so a primary screen and a monitor screen are visible at once (e.g. watch **Logs** while calling a **Tool**). Includes a column-local search and compact entry layouts tuned for the narrow column.

## What ships

### Pinning & the column
- **Pin button** — a "pin as column" icon on the Logs/History/Network panel toolbars (rightmost, styled like the expand/collapse toggle). Shown only when the viewport is wide enough and a server is connected.
- **Group pinning** — pinning any one of the three opens the column with all *available* monitor tabs and removes that group from the header tab bar; the primary switches to the first non-Servers header tab. Closing returns the group to the header.
- **`MonitoringControls`** — the column's top row: a segmented tab switcher, a **search box**, and a **close** button that uses the "collapse sidebar" icon (mirror of the pin's "expand sidebar" icon).
- **Close behavior** — closing leaves the primary on whatever screen is currently selected in the header (it does not swap in the column's screen).

### Search
- A single **column search** kept across the column's tabs (Logs/History/Network) — it filters whichever screen is showing and carries over as you switch tabs. The embedded panels apply this search text but bypass the sidebar-only filters (levels/categories/directions/method), which have no control in the column.

### Layout, resize & animation
- **Resizable divider** — draggable (pointer + keyboard) between the primary area and the column; width clamped to `[320, 720]px` and persisted. Pointer capture so a drag over the Apps iframe doesn't stick; a cleanup guard prevents a stuck drag class if the handle unmounts mid-drag.
- **Open/close animation** — the handle + column slide in from the right and fade (reversing on close) via a Mantine `Transition`. The primary screen keeps its standard transition.
- **Responsive collapse** — below ~1040px (the `ServerListScreen` single-card breakpoint) the split collapses to one column and the pin buttons hide.
- **Disconnect** — the column hides on disconnect. Both collapse cases preserve the pin preference, so the column reopens when the condition returns (wide + connected).

### Embedded (compact) entry layouts
- The pinned column is **stream-only** (no 340px filter sidebar); the panel toolbar (sort/clear/export) stays. Screens/panels gained an `embedded` mode via a shared `EmbeddableScrollArea` element.
- **Compact two-line entries** for the narrow column (the single-line headers wrapped badly):
  - `HistoryEntry`: line 1 = time + client/server badge + elapsed + status; line 2 = method (+ truncated target) on the left, controls on the right with **Replay as an icon** (new `ReplayButton`) next to Pin/Expand.
  - `NetworkEntry`: line 1 = time + HTTP method + category + elapsed + status; line 2 = the URL in a horizontal scroll area (new Text `nowrap` variant) with the expand toggle on the right.
- `HistoryEntry` header now leads with the timestamp (direction badge moved to its right) to match `NetworkEntry`.
- `HistoryListPanel` drops the redundant "History (N)" header when there are no pinned requests.

## Design notes
- New state (`pinned` / `tab` / `width`) is **view-local** and persisted via the existing `useLocalStorage` pattern in `InspectorView`, so **no new props thread through `App.tsx`** and **`ViewHeader` is unchanged** — it just receives a filtered tab list. Only the column's close button clears the pin preference; narrowing and disconnecting are derived.
- The column search is a single `InspectorView`-local state; the embedded screens' search field is overridden with it.

## New components / theme
- `elements/ResizeHandle`, `elements/PinColumnButton`, `elements/ReplayButton`, `elements/EmbeddableScrollArea`
- `groups/MonitoringControls`, `groups/MonitoringScreen`
- `Text` theme `nowrap` variant; `App.css` resize-handle styles
## Screencap


https://github.com/user-attachments/assets/39b36cec-1651-4187-88f6-576e85f3ceac


## Testing
- `npm run validate` passes — **2810 unit tests**, lint, build, format. New coverage for every new component and the InspectorView behaviors (pin/close, narrow collapse, disconnect, stdio dropping Network, stored-tab fallback, header-tab clamping, tab/width persistence, shared search across tabs, mid-drag cleanup) and the compact entry layouts.
- ⚠️ **Not yet eyeballed in a live browser** (no connected browser in the working session). The CSS-level items worth a visual pass before merge: the nested fixed-height fill of the embedded column, the resize drag, the column slide animation, and the compact entry two-line layouts at narrow widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
