### PR TITLE
Preserve OAuth resource path during scope discovery

### DIFF
--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -24,7 +24,10 @@ import {
   ElicitResult,
   ElicitRequest,
 } from "@modelcontextprotocol/sdk/types.js";
-import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
+import {
+  auth,
+  discoverOAuthProtectedResourceMetadata,
+} from "@modelcontextprotocol/sdk/client/auth.js";
 import { discoverScopes } from "../../auth";
 import { CustomHeaders } from "../../types/customHeaders";
 
@@ -129,6 +132,9 @@ jest.mock("@modelcontextprotocol/sdk/client/auth.js", () => {
   return {
     UnauthorizedError,
     auth: jest.fn().mockResolvedValue("AUTHORIZED"),
+    discoverOAuthProtectedResourceMetadata: jest
+      .fn()
+      .mockResolvedValue(undefined),
   };
 });
 
@@ -154,6 +160,10 @@ jest.mock("../../auth", () => ({
 }));
 
 const mockAuth = auth as jest.MockedFunction<typeof auth>;
+const mockDiscoverOAuthProtectedResourceMetadata =
+  discoverOAuthProtectedResourceMetadata as jest.MockedFunction<
+    typeof discoverOAuthProtectedResourceMetadata
+  >;
 const mockDiscoverScopes = discoverScopes as jest.MockedFunction<
   typeof discoverScopes
 >;
@@ -1601,6 +1611,44 @@ describe("useConnection", () => {
       expect(mockAuth).toHaveBeenCalledWith(
         expect.any(Object),
         expect.not.objectContaining({ fetchFn: expect.anything() }),
+      );
+    });
+
+    it("preserves path-based MCP endpoints when discovering protected resource metadata", async () => {
+      const previewUrl =
+        "https://mcp.stg.services.atlassian.com/v1/mcp/preview";
+      const resourceMetadata = {
+        resource: previewUrl,
+        authorization_servers: ["https://auth.stg.atlassian.com/example"],
+        bearer_methods_supported: ["header"],
+        scopes_supported: ["search:rovo:agent-interface"],
+      };
+
+      mockDiscoverOAuthProtectedResourceMetadata.mockResolvedValueOnce(
+        resourceMetadata,
+      );
+      mockDiscoverScopes.mockResolvedValue("search:rovo:agent-interface");
+      setup401Error();
+
+      await attemptConnection({
+        ...defaultProps,
+        sseUrl: previewUrl,
+      });
+
+      expect(
+        mockDiscoverOAuthProtectedResourceMetadata.mock.calls[0][0].href,
+      ).toBe(previewUrl);
+      expect(mockDiscoverScopes).toHaveBeenCalledWith(
+        previewUrl,
+        resourceMetadata,
+        expect.any(Function),
+      );
+      expect(mockAuth).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          serverUrl: previewUrl,
+          scope: "search:rovo:agent-interface",
+        }),
       );
     });
   });

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -398,7 +398,7 @@ export function useConnection({
         let resourceMetadata;
         try {
           resourceMetadata = await discoverOAuthProtectedResourceMetadata(
-            new URL("/", sseUrl),
+            new URL(sseUrl),
             {},
             fetchFn,
           );


### PR DESCRIPTION
## Summary
- Preserve the full MCP server URL when discovering OAuth protected resource metadata
- Add a regression test for path-based MCP endpoints such as /v1/mcp/preview

## Why
Some MCP servers expose different protected resource metadata per path. Discovering metadata from the origin URL drops the endpoint path and can cause Inspector to request scopes for the wrong resource.

## Test plan
- npm test -- --runTestsByPath src/lib/hooks/__tests__/useConnection.test.tsx
- npx prettier --check client/src/lib/hooks/useConnection.ts client/src/lib/hooks/__tests__/useConnection.test.tsx
- git diff --check