### PR TITLE
feat(web): open the monitoring column on connection failure, with a Console tab and failed-card border (#1621)

### DIFF
--- a/clients/web/src/App.css
+++ b/clients/web/src/App.css
@@ -53,6 +53,10 @@
   /* Green border drawn around a freshly-added/highlighted server card (#1535) */
   --inspector-highlight-border: var(--mantine-color-green-6);
 
+  /* Red border drawn around a server card whose last connection attempt failed,
+     until another server is connected/attempted (#1621) */
+  --inspector-error-border: var(--mantine-color-red-6);
+
   /* ── Log levels (RFC 5424) ─────────────────────────────── */
   --inspector-log-debug: var(--mantine-color-gray-6);
   --inspector-log-info: var(--mantine-color-blue-6);

--- a/clients/web/src/App.test.tsx
+++ b/clients/web/src/App.test.tsx
@@ -44,8 +44,18 @@ const { messageLogClear } = vi.hoisted(() => ({ messageLogClear: vi.fn() }));
 vi.mock("@inspector/core/mcp/index.js", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@inspector/core/mcp/index.js")>();
+  // When set, the next `connect()` rejects with this value (one-shot), so a test
+  // can exercise the handshake-failure path. Cleared after it fires.
+  let nextConnectRejection: unknown = null;
   class FakeInspectorClient extends EventTarget {
-    connect = vi.fn().mockResolvedValue(undefined);
+    connect = vi.fn(() => {
+      if (nextConnectRejection !== null) {
+        const err = nextConnectRejection;
+        nextConnectRejection = null;
+        return Promise.reject(err);
+      }
+      return Promise.resolve(undefined);
+    });
     disconnect = vi.fn().mockResolvedValue(undefined);
     callTool = vi
       .fn()
@@ -88,6 +98,10 @@ vi.mock("@inspector/core/mcp/index.js", async (importOriginal) => {
     }),
     // Test-only handle so the test can grab the live instance and fire events.
     __clientInstances: instances,
+    // Test-only: arm the next connect() to reject (handshake-failure path).
+    __rejectNextConnect: (err: unknown) => {
+      nextConnectRejection = err;
+    },
   };
 });
 
@@ -263,6 +277,7 @@ vi.mock("./components/views/InspectorView/InspectorView", () => ({
     readResourceState?: { status?: string };
     currentLogLevel?: string;
     activeTab?: string;
+    erroredServerId?: string;
     onActiveTabChange: (tab: string) => void;
     onToggleConnection: (id: string) => void;
     onToolsUiChange: (next: {
@@ -322,6 +337,9 @@ vi.mock("./components/views/InspectorView/InspectorView", () => ({
       </span>
       <span data-testid="log-level">{props.currentLogLevel}</span>
       <span data-testid="active-tab">{props.activeTab ?? "none"}</span>
+      <span data-testid="errored-server">
+        {props.erroredServerId ?? "none"}
+      </span>
       <button onClick={() => props.onActiveTabChange("Servers")}>
         switch-servers-tab
       </button>
@@ -450,9 +468,57 @@ const clientInstances = (
   McpIndex as unknown as { __clientInstances: EventTarget[] }
 ).__clientInstances;
 
+const rejectNextConnect = (
+  McpIndex as unknown as { __rejectNextConnect: (err: unknown) => void }
+).__rejectNextConnect;
+
 const fetchLogInstances = (
   FetchLogModule as unknown as { __fetchLogInstances: EventTarget[] }
 ).__fetchLogInstances;
+
+describe("App failed-connection card border (#1621)", () => {
+  beforeEach(() => {
+    clientInstances.length = 0;
+    vi.mocked(useInspectorClient).mockReturnValue(DEFAULT_USE_INSPECTOR_CLIENT);
+  });
+
+  it("flags the server whose connect attempt fails as erroredServerId", async () => {
+    const user = userEvent.setup();
+    renderWithMantine(<App />);
+    expect(screen.getByTestId("errored-server")).toHaveTextContent("none");
+
+    // Arm the next connect() to reject with a plain (non-auth) handshake error.
+    rejectNextConnect(new Error("spawn failed"));
+    await user.click(screen.getByText("connect"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("errored-server")).toHaveTextContent("A"),
+    );
+  });
+
+  it("clears the flag when a new connection attempt starts", async () => {
+    // Report status "error" so the *second* connect click is treated as a fresh
+    // attempt (not a disconnect of a live session), exercising the clear.
+    vi.mocked(useInspectorClient).mockReturnValue({
+      ...DEFAULT_USE_INSPECTOR_CLIENT,
+      status: "error",
+    });
+    const user = userEvent.setup();
+    renderWithMantine(<App />);
+
+    rejectNextConnect(new Error("spawn failed"));
+    await user.click(screen.getByText("connect"));
+    await waitFor(() =>
+      expect(screen.getByTestId("errored-server")).toHaveTextContent("A"),
+    );
+
+    // A new attempt (this one resolves) clears the red-border flag.
+    await user.click(screen.getByText("connect"));
+    await waitFor(() =>
+      expect(screen.getByTestId("errored-server")).toHaveTextContent("none"),
+    );
+  });
+});
 
 describe("App session-scoped state reset on disconnect", () => {
   beforeEach(() => {

--- a/clients/web/src/App.test.tsx
+++ b/clients/web/src/App.test.tsx
@@ -227,6 +227,9 @@ vi.mock("@inspector/core/react/useMessageLog.js", () => ({
 vi.mock("@inspector/core/react/useFetchRequestLog.js", () => ({
   useFetchRequestLog: vi.fn(() => ({ fetchRequests: [] })),
 }));
+vi.mock("@inspector/core/react/useStderrLog.js", () => ({
+  useStderrLog: vi.fn(() => ({ stderrLogs: [] })),
+}));
 vi.mock("@inspector/core/react/useSettingsDraft.js", () => ({
   useSettingsDraft: vi.fn(() => ({
     // `draft` is widened so tests can override the return with a populated

--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -95,6 +95,7 @@ import { useManagedRequestorTasks } from "@inspector/core/react/useManagedReques
 import { useResourceSubscriptions } from "@inspector/core/react/useResourceSubscriptions.js";
 import { useMessageLog } from "@inspector/core/react/useMessageLog.js";
 import { useFetchRequestLog } from "@inspector/core/react/useFetchRequestLog.js";
+import { useStderrLog } from "@inspector/core/react/useStderrLog.js";
 import { useSandboxUrl } from "@inspector/core/react/useSandboxUrl.js";
 import { useServerListWritable } from "@inspector/core/react/useServerListWritable.js";
 import { usePendingClientRequests } from "@inspector/core/react/usePendingClientRequests.js";
@@ -115,6 +116,7 @@ import {
   EMPTY_LOGS_UI,
   EMPTY_HISTORY_UI,
   EMPTY_NETWORK_UI,
+  EMPTY_CONSOLE_UI,
 } from "./components/screens/screenUiState";
 import { clearScrollMemory } from "./hooks/useScrollMemory";
 import type { AppRendererHandle } from "./components/elements/AppRenderer/AppRenderer";
@@ -751,6 +753,7 @@ function App() {
     () => new Set(),
   );
   const [networkUi, setNetworkUi] = useState(EMPTY_NETWORK_UI);
+  const [consoleUi, setConsoleUi] = useState(EMPTY_CONSOLE_UI);
   const [activeTab, setActiveTab] = useState(INSPECTOR_SERVERS_TAB);
   const [pendingStepUp, setPendingStepUp] = useState<{
     challenge: AuthChallenge;
@@ -887,6 +890,7 @@ function App() {
   );
   const { messages } = useMessageLog(messageLogState);
   const { fetchRequests } = useFetchRequestLog(fetchRequestLogState);
+  const { stderrLogs } = useStderrLog(stderrLogState);
 
   // Surface the otherwise-invisible "response body dropped after rotation" case
   // (#1390) as a deduped toast that links to this server's Network Log Size
@@ -1003,6 +1007,10 @@ function App() {
     setHistoryUi(EMPTY_HISTORY_UI);
     setPinnedHistoryIds(new Set());
     setNetworkUi(EMPTY_NETWORK_UI);
+    // Only the search filter resets here; the stderr entries themselves live in
+    // StderrLogState, which deliberately survives connect/disconnect so a failed
+    // launch's output stays visible for diagnosis (#1621).
+    setConsoleUi(EMPTY_CONSOLE_UI);
     setProgressByTaskId({});
     setCurrentLogLevel("info");
     setPendingStepUp(null);
@@ -3091,6 +3099,18 @@ function App() {
     );
   }, [logs, activeServerId]);
 
+  const onClearConsole = useCallback(() => {
+    stderrLogState?.clearStderrLogs();
+  }, [stderrLogState]);
+
+  const onExportConsole = useCallback(() => {
+    if (stderrLogs.length === 0) return;
+    downloadJsonFile(
+      buildExportFilename("console", activeServerId),
+      JSON.stringify(stderrLogs, null, 2),
+    );
+  }, [stderrLogs, activeServerId]);
+
   // Download the current server list as a canonical mcp.json file. Uses the
   // in-memory `servers` list (kept in sync with disk by useServers' refresh-
   // after-mutate flow) so there's no extra HTTP roundtrip. Serialization
@@ -3653,6 +3673,7 @@ function App() {
           progressByTaskId={progressByTaskId}
           history={messages}
           network={fetchRequests}
+          stderrLogs={stderrLogs}
           toolCallState={toolCallState}
           getPromptState={getPromptState}
           readResourceState={effectiveReadResourceState}
@@ -3664,6 +3685,7 @@ function App() {
           logsUi={logsUi}
           historyUi={historyUi}
           networkUi={networkUi}
+          consoleUi={consoleUi}
           activeTab={activeTab}
           onActiveTabChange={setActiveTab}
           currentLogLevel={currentLogLevel}
@@ -3765,6 +3787,9 @@ function App() {
           onNetworkUiChange={setNetworkUi}
           onClearNetwork={onClearNetwork}
           onExportNetwork={onExportNetwork}
+          onConsoleUiChange={setConsoleUi}
+          onClearConsole={onClearConsole}
+          onExportConsole={onExportConsole}
           onAppsUiChange={setAppsUi}
           onSelectApp={onSelectApp}
           onOpenApp={(name, args) => {

--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -635,6 +635,16 @@ function App() {
     undefined,
   );
 
+  // Id of the server whose last connection attempt failed (#1621). Drives the
+  // red border on that ServerCard. It is deliberately NOT reset by
+  // `resetSessionScopedUiState` (a failed connect fires the `disconnect` event,
+  // which would otherwise clear the flag the same tick we set it); instead it is
+  // cleared when a new connection attempt starts, and re-set if that attempt
+  // also fails.
+  const [failedServerId, setFailedServerId] = useState<string | undefined>(
+    undefined,
+  );
+
   // InspectorClient + per-primitive state managers. All recreated together
   // whenever the user switches active servers, then destroyed when the
   // next switch happens (or when the component unmounts).
@@ -2318,6 +2328,10 @@ function App() {
       if (id !== activeServerId) {
         setActiveServerId(id);
       }
+      // A new connection attempt has begun: clear any previous failure flag so
+      // the red border on the last-failed card is removed (#1621). If this
+      // attempt also fails, the catch below re-sets it for this server.
+      setFailedServerId(undefined);
 
       connectStartRef.current = Date.now();
       try {
@@ -2407,7 +2421,8 @@ function App() {
 
         // Non-auth handshake error: toast so the user sees what went wrong
         // instead of the ConnectionToggle silently reverting to
-        // "disconnected".
+        // "disconnected", and flag the card with a red border (#1621).
+        setFailedServerId(id);
         const message = err instanceof Error ? err.message : String(err);
         notifications.show({
           title: `Failed to connect to "${target.name}"`,
@@ -3657,6 +3672,7 @@ function App() {
           servers={servers}
           serverListWritable={serverListWritable}
           activeServer={activeServerId}
+          erroredServerId={failedServerId}
           connectionStatus={connectionStatus}
           initializeResult={initializeResult}
           latencyMs={latencyMs}

--- a/clients/web/src/components/groups/ServerCard/ServerCard.stories.tsx
+++ b/clients/web/src/components/groups/ServerCard/ServerCard.stories.tsx
@@ -87,6 +87,21 @@ export const Failed: Story = {
   },
 };
 
+// The red border flagging a server whose last connection attempt failed
+// (#1621). The status settles back to "disconnected" (the failure clears the
+// active session), but the border persists until another server is
+// connected/attempted.
+export const ErroredBorder: Story = {
+  args: {
+    id: "3d2c1b0a-9f8e-4d6c-8b7a-1a2b3c4d5e6f",
+    name: "My MCP Server",
+    config: stdioConfig,
+    info: { name: "My MCP Server", version: "1.2.0" },
+    connection: disconnected,
+    errored: true,
+  },
+};
+
 export const LongServerName: Story = {
   args: {
     id: "a1b2c3d4-e5f6-4789-9abc-def012345678",

--- a/clients/web/src/components/groups/ServerCard/ServerCard.test.tsx
+++ b/clients/web/src/components/groups/ServerCard/ServerCard.test.tsx
@@ -363,4 +363,56 @@ describe("ServerCard", () => {
       expect(onClearHighlight).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("connection-failed border (#1621)", () => {
+    it("draws the red errored-variant border when errored", () => {
+      const { container } = renderWithMantine(
+        <ServerCard {...baseProps} connection={disconnected} errored />,
+      );
+      expect(
+        container.querySelector('[data-variant="errored"]'),
+      ).not.toBeNull();
+    });
+
+    it("does not draw the errored border when not errored", () => {
+      const { container } = renderWithMantine(
+        <ServerCard {...baseProps} connection={disconnected} />,
+      );
+      expect(container.querySelector('[data-variant="errored"]')).toBeNull();
+    });
+
+    it("prefers the dimmed (disabled) variant over the errored border", () => {
+      // A dimmed card (another server active) is inert; that wins over the
+      // error border so the card can't look interactive.
+      const { container } = renderWithMantine(
+        <ServerCard
+          {...baseProps}
+          connection={disconnected}
+          activeServer="other"
+          errored
+        />,
+      );
+      expect(
+        container.querySelector('[data-variant="disabled"]'),
+      ).not.toBeNull();
+      expect(container.querySelector('[data-variant="errored"]')).toBeNull();
+    });
+
+    it("prefers the errored border over the freshly-added highlight", () => {
+      const { container } = renderWithMantine(
+        <ServerCard
+          {...baseProps}
+          connection={disconnected}
+          errored
+          highlighted
+        />,
+      );
+      expect(
+        container.querySelector('[data-variant="errored"]'),
+      ).not.toBeNull();
+      expect(
+        container.querySelector('[data-variant="highlighted"]'),
+      ).toBeNull();
+    });
+  });
 });

--- a/clients/web/src/components/groups/ServerCard/ServerCard.test.tsx
+++ b/clients/web/src/components/groups/ServerCard/ServerCard.test.tsx
@@ -414,5 +414,61 @@ describe("ServerCard", () => {
         container.querySelector('[data-variant="highlighted"]'),
       ).toBeNull();
     });
+
+    it("scrolls the card into view on the errored transition", () => {
+      vi.useFakeTimers();
+      const scrollIntoView = vi.fn();
+      const orig = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = scrollIntoView;
+      try {
+        const { rerender } = renderWithMantine(
+          <ServerCard {...baseProps} connection={disconnected} />,
+        );
+        // No scroll while not errored.
+        vi.advanceTimersByTime(1000);
+        expect(scrollIntoView).not.toHaveBeenCalled();
+
+        // Becoming errored schedules a deferred scroll (past the column open).
+        rerender(
+          <ServerCard {...baseProps} connection={disconnected} errored />,
+        );
+        expect(scrollIntoView).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(320);
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+        // A further re-render while still errored does not scroll again (so it
+        // won't fight a user who scrolled away).
+        rerender(
+          <ServerCard
+            {...baseProps}
+            name="Renamed"
+            connection={disconnected}
+            errored
+          />,
+        );
+        vi.advanceTimersByTime(1000);
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+      } finally {
+        Element.prototype.scrollIntoView = orig;
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not scroll when mounted already errored (no transition)", () => {
+      vi.useFakeTimers();
+      const scrollIntoView = vi.fn();
+      const orig = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = scrollIntoView;
+      try {
+        renderWithMantine(
+          <ServerCard {...baseProps} connection={disconnected} errored />,
+        );
+        vi.advanceTimersByTime(1000);
+        expect(scrollIntoView).not.toHaveBeenCalled();
+      } finally {
+        Element.prototype.scrollIntoView = orig;
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/clients/web/src/components/groups/ServerCard/ServerCard.tsx
+++ b/clients/web/src/components/groups/ServerCard/ServerCard.tsx
@@ -9,6 +9,7 @@ import { ServerStatusIndicator } from "../../elements/ServerStatusIndicator/Serv
 import { TransportBadge } from "../../elements/TransportBadge/TransportBadge";
 import { ConnectionToggle } from "../../elements/ConnectionToggle/ConnectionToggle";
 import { ContentViewer } from "../../elements/ContentViewer/ContentViewer";
+import { FAILED_CARD_SCROLL_DELAY_MS } from "../../views/InspectorView/monitorColumnAnimation";
 
 export interface ServerCardProps extends ServerEntry {
   activeServer?: string;
@@ -101,14 +102,6 @@ const RemoveButton = Button.withProps({
   color: "red.6",
 });
 
-// Delay before scrolling a newly-failed card into view (#1621). A connection
-// failure both flags the card and opens the monitoring column, which reflows
-// the server grid (fewer, narrower columns) and can push the failed card below
-// the fold. Deferring past the column's open lets that reflow settle so
-// `scrollIntoView` targets the card's final position rather than its pre-reflow
-// one. Kept just above the column's slide duration.
-const ERROR_SCROLL_DELAY_MS = 320;
-
 function getTransport(config: MCPServerConfig): ServerType {
   return config.type ?? "stdio";
 }
@@ -165,9 +158,11 @@ export function ServerCard({
   }, [highlighted, scrollOnHighlight]);
 
   // Scroll the failed card into view on the disconnected→errored transition
-  // (#1621), deferred so the monitoring column's open + grid reflow settle
-  // first. Guarded by a ref so a re-render while still errored doesn't re-scroll
-  // and fight the user if they've scrolled away.
+  // (#1621), deferred past the monitoring column's open (`FAILED_CARD_SCROLL_
+  // DELAY_MS`, derived from the column's slide duration) so the grid reflow
+  // settles before `scrollIntoView` measures the card. Guarded by a ref so a
+  // re-render while still errored doesn't re-scroll and fight the user if they've
+  // scrolled away.
   const wasErroredRef = useRef(errored);
   useEffect(() => {
     const justErrored = errored && !wasErroredRef.current;
@@ -175,7 +170,7 @@ export function ServerCard({
     if (!justErrored) return;
     const timer = setTimeout(() => {
       rootRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
-    }, ERROR_SCROLL_DELAY_MS);
+    }, FAILED_CARD_SCROLL_DELAY_MS);
     return () => clearTimeout(timer);
   }, [errored]);
   const transport = getTransport(config);

--- a/clients/web/src/components/groups/ServerCard/ServerCard.tsx
+++ b/clients/web/src/components/groups/ServerCard/ServerCard.tsx
@@ -101,6 +101,14 @@ const RemoveButton = Button.withProps({
   color: "red.6",
 });
 
+// Delay before scrolling a newly-failed card into view (#1621). A connection
+// failure both flags the card and opens the monitoring column, which reflows
+// the server grid (fewer, narrower columns) and can push the failed card below
+// the fold. Deferring past the column's open lets that reflow settle so
+// `scrollIntoView` targets the card's final position rather than its pre-reflow
+// one. Kept just above the column's slide duration.
+const ERROR_SCROLL_DELAY_MS = 320;
+
 function getTransport(config: MCPServerConfig): ServerType {
   return config.type ?? "stdio";
 }
@@ -155,6 +163,21 @@ export function ServerCard({
       rootRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   }, [highlighted, scrollOnHighlight]);
+
+  // Scroll the failed card into view on the disconnected→errored transition
+  // (#1621), deferred so the monitoring column's open + grid reflow settle
+  // first. Guarded by a ref so a re-render while still errored doesn't re-scroll
+  // and fight the user if they've scrolled away.
+  const wasErroredRef = useRef(errored);
+  useEffect(() => {
+    const justErrored = errored && !wasErroredRef.current;
+    wasErroredRef.current = errored;
+    if (!justErrored) return;
+    const timer = setTimeout(() => {
+      rootRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, ERROR_SCROLL_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [errored]);
   const transport = getTransport(config);
   const commandOrUrl = getCommandOrUrl(config);
   const version = info?.version;

--- a/clients/web/src/components/groups/ServerCard/ServerCard.tsx
+++ b/clients/web/src/components/groups/ServerCard/ServerCard.tsx
@@ -39,6 +39,12 @@ export interface ServerCardProps extends ServerEntry {
    */
   highlighted?: boolean;
   /**
+   * When true, this server's last connection attempt failed: the card draws a
+   * red border to flag it (#1621). The parent clears this when another server
+   * is connected or a new connection is attempted.
+   */
+  errored?: boolean;
+  /**
    * Whether a highlighted card scrolls itself into view. When several cards are
    * highlighted at once (a batch import) only the first should scroll, so the
    * list jumps to the start of the batch rather than fighting over the viewport.
@@ -135,6 +141,7 @@ export function ServerCard({
   writable = true,
   dragHandle,
   highlighted = false,
+  errored = false,
   scrollOnHighlight = true,
   onClearHighlight,
 }: ServerCardProps) {
@@ -155,12 +162,15 @@ export function ServerCard({
     connection.status === "connected" ? connection.protocolVersion : undefined;
 
   // A dimmed card (another server is active) is inert, so the disabled variant
-  // wins; otherwise a freshly-added card draws the highlighted green border.
+  // wins; otherwise a failed-connection card draws the red error border, then a
+  // freshly-added card draws the highlighted green border.
   const variant = isDimmed
     ? "disabled"
-    : highlighted
-      ? "highlighted"
-      : undefined;
+    : errored
+      ? "errored"
+      : highlighted
+        ? "highlighted"
+        : undefined;
 
   return (
     <Card

--- a/clients/web/src/components/screens/ConsoleScreen/ConsoleScreen.stories.tsx
+++ b/clients/web/src/components/screens/ConsoleScreen/ConsoleScreen.stories.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import type { ComponentProps } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import type { StderrLogEntry } from "../../../../../../core/mcp/types.js";
+import { ConsoleScreen } from "./ConsoleScreen";
+import { EMPTY_CONSOLE_UI } from "../screenUiState";
+
+// ConsoleScreen is controlled (the search text lives in the parent as `ui` —
+// see #1417). This wrapper holds that state so the play-driven search actually
+// filters entries, mirroring how App owns the state.
+function StatefulConsoleScreen(args: ComponentProps<typeof ConsoleScreen>) {
+  const [ui, setUi] = useState({ ...EMPTY_CONSOLE_UI, ...args.ui });
+  return <ConsoleScreen {...args} ui={ui} onUiChange={setUi} />;
+}
+
+const meta: Meta<typeof ConsoleScreen> = {
+  title: "Screens/ConsoleScreen",
+  component: ConsoleScreen,
+  parameters: { layout: "fullscreen" },
+  args: {
+    onClear: fn(),
+    onExport: fn(),
+    ui: EMPTY_CONSOLE_UI,
+    onUiChange: fn(),
+    sortDirection: "newest-first",
+    onSortChange: fn(),
+  },
+  render: (args) => <StatefulConsoleScreen {...args} />,
+};
+
+export default meta;
+type Story = StoryObj<typeof ConsoleScreen>;
+
+const sampleEntries: StderrLogEntry[] = [
+  {
+    timestamp: new Date("2026-03-17T10:00:00Z"),
+    message: "Starting MCP time server…",
+  },
+  {
+    timestamp: new Date("2026-03-17T10:00:01Z"),
+    message:
+      'Traceback (most recent call last):\n  File "<frozen runpy>", line 198, in _run_module_as_main',
+  },
+  {
+    timestamp: new Date("2026-03-17T10:00:01Z"),
+    message: "ModuleNotFoundError: No module named 'mcp_server_time'",
+  },
+];
+
+export const WithEntries: Story = {
+  args: {
+    entries: sampleEntries,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    entries: [],
+  },
+};
+
+export const FilterBySearch: Story = {
+  args: {
+    entries: sampleEntries,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Both the startup line and the error are visible initially.
+    await expect(
+      canvas.getByText("Starting MCP time server…"),
+    ).toBeInTheDocument();
+    // Searching for the error text hides the unrelated startup line.
+    await userEvent.type(
+      canvas.getByPlaceholderText("Search..."),
+      "ModuleNotFound",
+    );
+    await expect(
+      canvas.queryByText("Starting MCP time server…"),
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        "ModuleNotFoundError: No module named 'mcp_server_time'",
+      ),
+    ).toBeInTheDocument();
+  },
+};

--- a/clients/web/src/components/screens/ConsoleScreen/ConsoleScreen.test.tsx
+++ b/clients/web/src/components/screens/ConsoleScreen/ConsoleScreen.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import type { StderrLogEntry } from "@inspector/core/mcp/types.js";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { ConsoleScreen, type ConsoleScreenProps } from "./ConsoleScreen";
+import { EMPTY_CONSOLE_UI } from "../screenUiState";
+
+const entries: StderrLogEntry[] = [
+  { timestamp: new Date("2026-03-17T10:00:00Z"), message: "first line" },
+  { timestamp: new Date("2026-03-17T10:00:01Z"), message: "second BOOM line" },
+];
+
+function makeProps(
+  overrides: Partial<ConsoleScreenProps> = {},
+): ConsoleScreenProps {
+  return {
+    entries,
+    ui: EMPTY_CONSOLE_UI,
+    onUiChange: vi.fn(),
+    onClear: vi.fn(),
+    onExport: vi.fn(),
+    sortDirection: "newest-first",
+    onSortChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("ConsoleScreen", () => {
+  it("renders each stderr entry's message", () => {
+    renderWithMantine(<ConsoleScreen {...makeProps()} />);
+    expect(screen.getByText("first line")).toBeInTheDocument();
+    expect(screen.getByText("second BOOM line")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no entries", () => {
+    renderWithMantine(<ConsoleScreen {...makeProps({ entries: [] })} />);
+    expect(screen.getByText("No console output")).toBeInTheDocument();
+  });
+
+  it("filters entries by the search text in ui", () => {
+    renderWithMantine(
+      <ConsoleScreen {...makeProps({ ui: { filterText: "boom" } })} />,
+    );
+    expect(screen.queryByText("first line")).toBeNull();
+    expect(screen.getByText("second BOOM line")).toBeInTheDocument();
+  });
+
+  it("dispatches onUiChange when typing in the search box", async () => {
+    const onUiChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithMantine(<ConsoleScreen {...makeProps({ onUiChange })} />);
+    await user.type(screen.getByPlaceholderText("Search..."), "x");
+    expect(onUiChange).toHaveBeenCalledWith({ filterText: "x" });
+  });
+
+  it("clears the search text via the clear button", async () => {
+    const onUiChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithMantine(
+      <ConsoleScreen
+        {...makeProps({ ui: { filterText: "boom" }, onUiChange })}
+      />,
+    );
+    // Two controls share the accessible name "Clear": the search-box clear
+    // ActionIcon (rendered first, in the sidebar) and the panel's Clear button.
+    // The sidebar one is the search reset.
+    const [clearSearch] = screen.getAllByRole("button", { name: "Clear" });
+    await user.click(clearSearch);
+    expect(onUiChange).toHaveBeenCalledWith({ filterText: "" });
+  });
+
+  it("orders entries oldest-first when requested", () => {
+    renderWithMantine(
+      <ConsoleScreen {...makeProps({ sortDirection: "oldest-first" })} />,
+    );
+    const rendered = screen.getAllByText(/line$/);
+    expect(rendered[0]).toHaveTextContent("first line");
+  });
+
+  it("orders entries newest-first by default", () => {
+    renderWithMantine(<ConsoleScreen {...makeProps()} />);
+    const rendered = screen.getAllByText(/line$/);
+    expect(rendered[0]).toHaveTextContent("second BOOM line");
+  });
+
+  it("disables Clear and Export when there are no entries", () => {
+    renderWithMantine(<ConsoleScreen {...makeProps({ entries: [] })} />);
+    expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Export" })).toBeDisabled();
+  });
+
+  it("invokes onClear and onExport", async () => {
+    const onClear = vi.fn();
+    const onExport = vi.fn();
+    const user = userEvent.setup();
+    renderWithMantine(<ConsoleScreen {...makeProps({ onClear, onExport })} />);
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+    await user.click(screen.getByRole("button", { name: "Export" }));
+    expect(onClear).toHaveBeenCalledOnce();
+    expect(onExport).toHaveBeenCalledOnce();
+  });
+
+  it("shows a pin button only when onPin is provided", () => {
+    const { rerender } = renderWithMantine(<ConsoleScreen {...makeProps()} />);
+    expect(screen.queryByRole("button", { name: "Pin as column" })).toBeNull();
+    rerender(<ConsoleScreen {...makeProps({ onPin: vi.fn() })} />);
+    expect(
+      screen.getByRole("button", { name: "Pin as column" }),
+    ).toBeInTheDocument();
+  });
+
+  it("drops the search sidebar when embedded", () => {
+    renderWithMantine(<ConsoleScreen {...makeProps({ embedded: true })} />);
+    // The embedded column has no in-screen search box (the column supplies it).
+    expect(screen.queryByPlaceholderText("Search...")).toBeNull();
+    // Entries still render.
+    expect(screen.getByText("first line")).toBeInTheDocument();
+  });
+});

--- a/clients/web/src/components/screens/ConsoleScreen/ConsoleScreen.tsx
+++ b/clients/web/src/components/screens/ConsoleScreen/ConsoleScreen.tsx
@@ -1,0 +1,203 @@
+import { useMemo } from "react";
+import {
+  Button,
+  Card,
+  Flex,
+  Group,
+  Paper,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from "@mantine/core";
+import type { StderrLogEntry } from "@inspector/core/mcp/types.js";
+import { ClearButton } from "../../elements/ClearButton/ClearButton";
+import {
+  SortToggle,
+  type SortDirection,
+} from "../../elements/SortToggle/SortToggle";
+import { PinColumnButton } from "../../elements/PinColumnButton/PinColumnButton";
+import { EmbeddableScrollArea } from "../../elements/EmbeddableScrollArea/EmbeddableScrollArea";
+import { useScrollMemory } from "../../../hooks/useScrollMemory";
+
+export interface ConsoleScreenProps {
+  entries: StderrLogEntry[];
+  ui: ConsoleUiState;
+  onUiChange: (next: ConsoleUiState) => void;
+  onClear: () => void;
+  onExport: () => void;
+  sortDirection: SortDirection;
+  onSortChange: (next: SortDirection) => void;
+  /** See LoggingScreen: shows a "pin as column" button when set (#1616). */
+  onPin?: () => void;
+  /** See LoggingScreen: fills the parent height and drops the filter sidebar. */
+  embedded?: boolean;
+}
+
+// Just the search text — stderr has no levels/categories to filter, so this is
+// the whole of the Console screen's lifted UI state. Controlled by the parent
+// (App) so it survives tab navigation within a live session (#1417).
+export interface ConsoleUiState {
+  filterText: string;
+}
+
+const ScreenLayout = Flex.withProps({
+  variant: "screen",
+  h: "calc(100dvh - var(--app-shell-header-height, 0px))",
+  gap: "md",
+  p: "xl",
+});
+
+const Sidebar = Stack.withProps({
+  w: 340,
+  flex: "0 0 auto",
+});
+
+const SidebarCard = Card.withProps({
+  withBorder: true,
+  padding: "lg",
+});
+
+const PanelContainer = Paper.withProps({
+  withBorder: true,
+  p: "lg",
+  flex: 1,
+  variant: "panel",
+});
+
+const EmptyCenter = Stack.withProps({
+  flex: 1,
+  align: "center",
+  justify: "center",
+});
+
+// A single stderr line: a dimmed monospace timestamp beside the process's raw
+// output. `align: flex-start` keeps the timestamp on the first wrapped row.
+const EntryRow = Group.withProps({
+  gap: "sm",
+  wrap: "nowrap",
+  align: "flex-start",
+});
+
+const TimestampText = Text.withProps({
+  size: "sm",
+  ff: "monospace",
+  c: "dimmed",
+  flex: "0 0 auto",
+});
+
+// `consoleLine` (theme variant) preserves the process's own newlines/whitespace
+// while wrapping over-long lines inside the narrow column.
+const MessageText = Text.withProps({
+  size: "sm",
+  ff: "monospace",
+  variant: "consoleLine",
+  flex: 1,
+});
+
+function formatTimestamp(date: Date): string {
+  return date.toLocaleTimeString();
+}
+
+function matchesFilter(entry: StderrLogEntry, filterText: string): boolean {
+  if (!filterText) return true;
+  return entry.message.toLowerCase().includes(filterText.toLowerCase());
+}
+
+export function ConsoleScreen({
+  entries,
+  ui,
+  onUiChange,
+  onClear,
+  onExport,
+  sortDirection,
+  onSortChange,
+  onPin,
+  embedded = false,
+}: ConsoleScreenProps) {
+  const { filterText } = ui;
+  const viewportRef = useScrollMemory("console-stream");
+
+  const filteredEntries = useMemo(() => {
+    // `.filter()` returns a fresh array, so sorting in-place is safe.
+    const sorted = entries
+      .filter((e) => matchesFilter(e, filterText))
+      .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+    if (sortDirection === "newest-first") sorted.reverse();
+    return sorted;
+  }, [entries, filterText, sortDirection]);
+
+  return (
+    <ScreenLayout h={embedded ? "100%" : undefined}>
+      {embedded ? null : (
+        <Sidebar>
+          <SidebarCard>
+            <Stack gap="md">
+              <Title order={4}>Console</Title>
+              <TextInput
+                placeholder="Search..."
+                value={filterText}
+                onChange={(e) =>
+                  onUiChange({ filterText: e.currentTarget.value })
+                }
+                rightSectionPointerEvents="auto"
+                rightSection={
+                  filterText ? (
+                    <ClearButton
+                      onClick={() => onUiChange({ filterText: "" })}
+                    />
+                  ) : null
+                }
+              />
+            </Stack>
+          </SidebarCard>
+        </Sidebar>
+      )}
+      <PanelContainer>
+        <Group justify="space-between" mb="sm">
+          <Title order={4}>Server Console</Title>
+          <Group>
+            <SortToggle
+              value={sortDirection}
+              onChange={onSortChange}
+              aria-label="Console sort direction"
+            />
+            <Button
+              variant="default"
+              onClick={onClear}
+              disabled={entries.length === 0}
+            >
+              Clear
+            </Button>
+            <Button
+              variant="default"
+              onClick={onExport}
+              disabled={entries.length === 0}
+            >
+              Export
+            </Button>
+            {onPin ? <PinColumnButton onPin={onPin} /> : null}
+          </Group>
+        </Group>
+        {filteredEntries.length > 0 ? (
+          <EmbeddableScrollArea embedded={embedded} viewportRef={viewportRef}>
+            <Stack gap="xs">
+              {filteredEntries.map((entry, index) => (
+                <EntryRow key={index}>
+                  <TimestampText>
+                    {formatTimestamp(entry.timestamp)}
+                  </TimestampText>
+                  <MessageText>{entry.message}</MessageText>
+                </EntryRow>
+              ))}
+            </Stack>
+          </EmbeddableScrollArea>
+        ) : (
+          <EmptyCenter>
+            <Text c="dimmed">No console output</Text>
+          </EmptyCenter>
+        )}
+      </PanelContainer>
+    </ScreenLayout>
+  );
+}

--- a/clients/web/src/components/screens/ConsoleScreen/ConsoleScreen.tsx
+++ b/clients/web/src/components/screens/ConsoleScreen/ConsoleScreen.tsx
@@ -183,7 +183,7 @@ export function ConsoleScreen({
           <EmbeddableScrollArea embedded={embedded} viewportRef={viewportRef}>
             <Stack gap="xs">
               {filteredEntries.map((entry, index) => (
-                <EntryRow key={index}>
+                <EntryRow key={`${entry.timestamp.getTime()}-${index}`}>
                   <TimestampText>
                     {formatTimestamp(entry.timestamp)}
                   </TimestampText>

--- a/clients/web/src/components/screens/ServerListScreen/ServerListScreen.test.tsx
+++ b/clients/web/src/components/screens/ServerListScreen/ServerListScreen.test.tsx
@@ -136,6 +136,27 @@ describe("ServerListScreen", () => {
     });
   });
 
+  describe("connection-failed border (#1621)", () => {
+    it("draws the red errored border only on the failed server's card", () => {
+      const { container } = renderWithMantine(
+        <ServerListScreen {...baseProps} erroredServerId="beta" />,
+      );
+      const errored = container.querySelectorAll('[data-variant="errored"]');
+      expect(errored).toHaveLength(1);
+      // The errored card is Beta's — its name is within the flagged card.
+      expect(errored[0]).toHaveTextContent("Beta");
+    });
+
+    it("draws no errored border when erroredServerId is unset", () => {
+      const { container } = renderWithMantine(
+        <ServerListScreen {...baseProps} />,
+      );
+      expect(
+        container.querySelectorAll('[data-variant="errored"]'),
+      ).toHaveLength(0);
+    });
+  });
+
   describe("freshly-added highlight", () => {
     it("draws a green highlight border on every highlighted server", () => {
       const { container } = renderWithMantine(

--- a/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
+++ b/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
@@ -39,6 +39,11 @@ export interface ServerListScreenProps {
   writable?: boolean;
   /** Id of the server the wiring layer treats as active (drives card dimming). */
   activeServer?: string;
+  /**
+   * Id of the server whose last connection attempt failed (#1621). Its card
+   * draws a red border until another server is connected or attempted.
+   */
+  erroredServerId?: string;
   onAddManually: () => void;
   onImportConfig: () => void;
   onImportServerJson: () => void;
@@ -78,6 +83,7 @@ export function ServerListScreen({
   servers,
   writable = true,
   activeServer,
+  erroredServerId,
   onAddManually,
   onImportConfig,
   onImportServerJson,
@@ -138,6 +144,7 @@ export function ServerListScreen({
     onClone,
     onRemove,
     highlighted: highlightedServerIds?.includes(server.id) ?? false,
+    errored: server.id === erroredServerId,
     scrollOnHighlight: server.id === firstHighlightedId,
     onClearHighlight: onClearHighlight
       ? () => onClearHighlight(server.id)

--- a/clients/web/src/components/screens/screenUiState.ts
+++ b/clients/web/src/components/screens/screenUiState.ts
@@ -11,6 +11,7 @@ import type { TasksUiState } from "./TasksScreen/TasksScreen";
 import type { LogsUiState } from "./LoggingScreen/LoggingScreen";
 import type { HistoryUiState } from "./HistoryScreen/HistoryScreen";
 import type { NetworkUiState } from "./NetworkScreen/NetworkScreen";
+import type { ConsoleUiState } from "./ConsoleScreen/ConsoleScreen";
 import { ALL_LEVELS_VISIBLE } from "./LoggingScreen/logLevels";
 import { ALL_CATEGORIES_VISIBLE } from "./NetworkScreen/fetchCategories";
 
@@ -61,6 +62,10 @@ export const EMPTY_HISTORY_UI: HistoryUiState = {
 export const EMPTY_NETWORK_UI: NetworkUiState = {
   filterText: "",
   visibleCategories: ALL_CATEGORIES_VISIBLE,
+};
+
+export const EMPTY_CONSOLE_UI: ConsoleUiState = {
+  filterText: "",
 };
 
 /** Registry for OAuth resume snapshot restore (data-only; setters live in App). */

--- a/clients/web/src/components/views/InspectorView/InspectorView.stories.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.stories.tsx
@@ -12,6 +12,7 @@ import type {
   InspectorResourceSubscription,
   MessageEntry,
   ServerEntry,
+  StderrLogEntry,
 } from "@inspector/core/mcp/types.js";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
@@ -26,6 +27,7 @@ import {
   EMPTY_LOGS_UI,
   EMPTY_HISTORY_UI,
   EMPTY_NETWORK_UI,
+  EMPTY_CONSOLE_UI,
 } from "../../screens/screenUiState";
 import { mixedEntries as demoLogs } from "../../screens/LoggingScreen/LoggingScreen.fixtures";
 import { longToolList as demoRegularTools } from "../../screens/ToolsScreen/ToolsScreen.fixtures";
@@ -295,6 +297,16 @@ const demoNetwork: FetchRequestEntry[] = [
   },
 ];
 
+// Captured stdio stderr (the Console screen). Mirrors a failed `python -m
+// mcp_server_time` launch so the Connection Error story shows a real diagnostic.
+const demoStderr: StderrLogEntry[] = [
+  {
+    timestamp: new Date("2026-03-17T10:00:00Z"),
+    message:
+      "/opt/homebrew/opt/python@3.13/bin/python3.13: No module named mcp_server_time",
+  },
+];
+
 // Advertise every primitive capability so the Connected story shows the full
 // tab list — each header tab is gated on the matching capability field (#1516).
 const demoInitializeResult: InitializeResult = {
@@ -326,6 +338,7 @@ const meta: Meta<typeof InspectorView> = {
     progressByTaskId: demoProgressByTaskId,
     history: demoHistory,
     network: demoNetwork,
+    stderrLogs: demoStderr,
 
     // Connection state — stories default to "disconnected"; per-story
     // overrides drive the connected / error narratives.
@@ -349,6 +362,7 @@ const meta: Meta<typeof InspectorView> = {
     logsUi: EMPTY_LOGS_UI,
     historyUi: EMPTY_HISTORY_UI,
     networkUi: EMPTY_NETWORK_UI,
+    consoleUi: EMPTY_CONSOLE_UI,
 
     // Callbacks — all wired to storybook spies so play functions can assert
     // on dispatch. Real wiring routes these to InspectorClient methods (the
@@ -395,6 +409,9 @@ const meta: Meta<typeof InspectorView> = {
     onNetworkUiChange: fn(),
     onClearNetwork: fn(),
     onExportNetwork: fn(),
+    onConsoleUiChange: fn(),
+    onClearConsole: fn(),
+    onExportConsole: fn(),
     onAppsUiChange: fn(),
     onSelectApp: fn(),
     onOpenApp: fn(),
@@ -494,8 +511,15 @@ export const Connected: Story = {
 };
 
 export const ConnectionError: Story = {
+  // demoServers[0] is a stdio server; a failed launch has an empty History (the
+  // message log clears on the error transition) and no HTTP traffic, so the
+  // auto-opened column keys off the captured stderr and defaults to Console —
+  // the process's startup error (#1621). `network: []` keeps it a pure stdio
+  // failure so Network isn't offered.
   args: {
     activeServer: demoServers[0]!.id,
     connectionStatus: "error",
+    network: [],
+    stderrLogs: demoStderr,
   },
 };

--- a/clients/web/src/components/views/InspectorView/InspectorView.stories.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.stories.tsx
@@ -513,11 +513,13 @@ export const Connected: Story = {
 export const ConnectionError: Story = {
   // demoServers[0] is a stdio server; a failed launch has an empty History (the
   // message log clears on the error transition) and no HTTP traffic, so the
-  // auto-opened column keys off the captured stderr and defaults to Console —
-  // the process's startup error (#1621). `network: []` keeps it a pure stdio
-  // failure so Network isn't offered.
+  // auto-opened column keys off the captured stderr and leads with Console —
+  // the process's startup error (#1621). `erroredServerId` is the parent's
+  // connect-attempt-failure signal that gates the failure column; `network: []`
+  // (and empty History) keep it a pure stdio failure so only Console is offered.
   args: {
     activeServer: demoServers[0]!.id,
+    erroredServerId: demoServers[0]!.id,
     connectionStatus: "error",
     network: [],
     stderrLogs: demoStderr,

--- a/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
@@ -1383,11 +1383,14 @@ describe("InspectorView", () => {
     });
 
     // A failed connect leaves the errored server's id set but no
-    // initializeResult (capabilities were never negotiated).
+    // initializeResult (capabilities were never negotiated). `erroredServerId`
+    // is the parent's connect-attempt-failure signal (it survives the failure's
+    // `disconnect` clearing `activeServer`), which gates the failure column.
     function failedHttp(overrides: Partial<InspectorViewProps> = {}) {
       return makeProps({
         servers: [httpServer],
         activeServer: "beta",
+        erroredServerId: "beta",
         connectionStatus: "error",
         initializeResult: undefined,
         ...overrides,
@@ -1496,6 +1499,41 @@ describe("InspectorView", () => {
       expect(
         screen.queryByRole("button", { name: "Close monitoring column" }),
       ).toBeNull();
+    });
+
+    it("does not treat a mid-session crash as a connect-attempt failure (#1621)", async () => {
+      // A previously-connected server that crashes settles to `error` too, but
+      // with no `erroredServerId` (the parent sets that only for connect
+      // attempts). That must NOT reorganize the column into the failure tab set
+      // — it closes like any session teardown, so a user who closed the column
+      // mid-session isn't reopened onto diagnostics.
+      monitorWide.value = true;
+      window.localStorage.setItem("inspector.monitor.pinned", "true");
+      const { rerender } = renderWithMantine(
+        <StatefulInspectorViewHost {...connectedHttp()} />,
+      );
+      // Connected + pinned: the column is open with the live monitor tabs.
+      expect(
+        await screen.findByRole("button", { name: "Close monitoring column" }),
+      ).toBeInTheDocument();
+
+      // Crash: connected → error, activeServer cleared, NO erroredServerId.
+      rerender(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [httpServer],
+            activeServer: undefined,
+            connectionStatus: "error",
+          })}
+        />,
+      );
+      // The column closes (after its slide-out) rather than switching to the
+      // failure tabs.
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("button", { name: "Close monitoring column" }),
+        ).toBeNull(),
+      );
     });
 
     const stdioServer: ServerEntry = {

--- a/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
@@ -1436,13 +1436,13 @@ describe("InspectorView", () => {
         await screen.findByRole("button", { name: "Close monitoring column" }),
       ).toBeInTheDocument();
 
-      // The failure column offers History + Network (the captured request), but
-      // not Logs (a failed connect never negotiated the logging capability) nor
-      // Console (an HTTP transport has no child-process stderr).
-      expect(screen.getByRole("radio", { name: "History" })).toBeChecked();
-      expect(
-        screen.getByRole("radio", { name: "Network" }),
-      ).toBeInTheDocument();
+      // The failure column leads with Network (the captured request) — the only
+      // diagnostic with content. History is content-gated and empty here (the
+      // message log clears on the error transition), so it isn't offered; nor is
+      // Logs (no logging capability was negotiated) or Console (HTTP has no
+      // child-process stderr).
+      expect(screen.getByRole("radio", { name: "Network" })).toBeChecked();
+      expect(screen.queryByRole("radio", { name: "History" })).toBeNull();
       expect(screen.queryByRole("radio", { name: "Logs" })).toBeNull();
       expect(screen.queryByRole("radio", { name: "Console" })).toBeNull();
     });
@@ -1478,17 +1478,124 @@ describe("InspectorView", () => {
           })}
         />,
       );
-      // The captured stderr means it was a stdio launch: the column surfaces
-      // Console (the process's stderr) and defaults to it — that's where the
-      // spawn error is — with no Network (no HTTP traffic). The stderr renders.
+      // The captured stderr means it was a stdio launch: the column leads with
+      // Console (the process's stderr) — that's where the spawn error is — with
+      // no Network (no HTTP traffic) and no History (content-gated, empty on a
+      // fresh failure). The stderr line renders.
       expect(
         await screen.findByRole("radio", { name: "Console" }),
+      ).toBeChecked();
+      expect(screen.queryByRole("radio", { name: "History" })).toBeNull();
+      expect(screen.queryByRole("radio", { name: "Network" })).toBeNull();
+      expect(screen.getByText("ModuleNotFoundError: boom")).toBeInTheDocument();
+    });
+
+    it("leads with Console even when the stored tab was History, on a stdio failure (#1621)", async () => {
+      // Regression for the review note: a returning user whose last-pinned tab
+      // was History must still land on the Console diagnostic, not the (empty)
+      // History — History is content-gated out of the failure column.
+      window.localStorage.setItem("inspector.monitor.tab", "History");
+      monitorWide.value = true;
+      const stdioErr: ServerEntry = {
+        id: "beta",
+        name: "Beta",
+        config: { type: "stdio", command: "missing-bin" },
+        connection: { status: "disconnected" },
+      };
+      const { rerender } = renderWithMantine(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [stdioErr],
+            activeServer: undefined,
+            connectionStatus: "disconnected",
+          })}
+        />,
+      );
+      rerender(
+        <StatefulInspectorViewHost
+          {...failedHttp({
+            servers: [stdioErr],
+            activeServer: undefined,
+            stderrLogs: [
+              { timestamp: new Date(), message: "ModuleNotFoundError: boom" },
+            ],
+          })}
+        />,
+      );
+      expect(
+        await screen.findByRole("radio", { name: "Console" }),
+      ).toBeChecked();
+      expect(screen.queryByRole("radio", { name: "History" })).toBeNull();
+    });
+
+    it("keeps the failure column closed until a diagnostic has content (#1621)", () => {
+      // A connect failure with nothing captured yet (no stderr, no fetch, and
+      // History cleared on the error transition) opens onto nothing — so the
+      // column stays closed rather than showing an empty pane.
+      monitorWide.value = true;
+      const { rerender } = renderWithMantine(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [httpServer],
+            activeServer: undefined,
+            connectionStatus: "disconnected",
+          })}
+        />,
+      );
+      rerender(
+        <StatefulInspectorViewHost
+          {...failedHttp({ network: [], history: [], stderrLogs: [] })}
+        />,
+      );
+      expect(
+        screen.queryByRole("button", { name: "Close monitoring column" }),
+      ).toBeNull();
+    });
+
+    it("offers History in the failure column when it has captured content (#1621)", async () => {
+      // The failure History tab is content-gated, so when the message log *does*
+      // hold entries it's offered alongside the diagnostic (Network here).
+      monitorWide.value = true;
+      const { rerender } = renderWithMantine(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [httpServer],
+            activeServer: undefined,
+            connectionStatus: "disconnected",
+          })}
+        />,
+      );
+      rerender(
+        <StatefulInspectorViewHost
+          {...failedHttp({
+            network: [
+              {
+                id: "f1",
+                timestamp: new Date(),
+                method: "POST",
+                url: "http://localhost:3000/mcp",
+                requestHeaders: {},
+                error: "boom",
+                category: "transport",
+              },
+            ],
+            history: [
+              {
+                id: "h1",
+                timestamp: new Date(),
+                direction: "request",
+                message: { jsonrpc: "2.0", id: 1, method: "initialize" },
+              },
+            ],
+          })}
+        />,
+      );
+      expect(
+        await screen.findByRole("radio", { name: "Network" }),
       ).toBeChecked();
       expect(
         screen.getByRole("radio", { name: "History" }),
       ).toBeInTheDocument();
-      expect(screen.queryByRole("radio", { name: "Network" })).toBeNull();
-      expect(screen.getByText("ModuleNotFoundError: boom")).toBeInTheDocument();
     });
 
     it("does not auto-open on a mount that starts already errored (#1621)", () => {

--- a/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
@@ -1376,6 +1376,86 @@ describe("InspectorView", () => {
       ).toBeNull();
     });
 
+    // A failed connect leaves the errored server's id set but no
+    // initializeResult (capabilities were never negotiated).
+    function failedHttp(overrides: Partial<InspectorViewProps> = {}) {
+      return makeProps({
+        servers: [httpServer],
+        activeServer: "beta",
+        connectionStatus: "error",
+        initializeResult: undefined,
+        ...overrides,
+      });
+    }
+
+    it("opens the monitoring column on a failed connection attempt (#1621)", async () => {
+      monitorWide.value = true;
+      const { rerender } = renderWithMantine(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [httpServer],
+            activeServer: undefined,
+            connectionStatus: "disconnected",
+          })}
+        />,
+      );
+      // Disconnected: the column is closed.
+      expect(
+        screen.queryByRole("button", { name: "Close monitoring column" }),
+      ).toBeNull();
+
+      // A connection failure (→ error) opens it to surface the diagnostics.
+      rerender(<StatefulInspectorViewHost {...failedHttp()} />);
+      expect(
+        await screen.findByRole("button", { name: "Close monitoring column" }),
+      ).toBeInTheDocument();
+
+      // The failure column offers the History + Network diagnostics, but not
+      // Logs (a failed connect never negotiated the logging capability).
+      expect(screen.getByRole("radio", { name: "History" })).toBeChecked();
+      expect(
+        screen.getByRole("radio", { name: "Network" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("radio", { name: "Logs" })).toBeNull();
+    });
+
+    it("omits Network from the failure column for a stdio server (#1621)", async () => {
+      monitorWide.value = true;
+      const stdioErr: ServerEntry = {
+        id: "beta",
+        name: "Beta",
+        config: { type: "stdio", command: "missing-bin" },
+        connection: { status: "disconnected" },
+      };
+      const { rerender } = renderWithMantine(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [stdioErr],
+            activeServer: undefined,
+            connectionStatus: "disconnected",
+          })}
+        />,
+      );
+      rerender(
+        <StatefulInspectorViewHost {...failedHttp({ servers: [stdioErr] })} />,
+      );
+      // stdio has no HTTP traffic, so the failure column shows History only.
+      expect(
+        await screen.findByRole("radio", { name: "History" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("radio", { name: "Network" })).toBeNull();
+    });
+
+    it("does not auto-open on a mount that starts already errored (#1621)", () => {
+      // No transition into error, and no stored preference, so the column stays
+      // closed — a user who closed it isn't fought on remount.
+      monitorWide.value = true;
+      renderWithMantine(<StatefulInspectorViewHost {...failedHttp()} />);
+      expect(
+        screen.queryByRole("button", { name: "Close monitoring column" }),
+      ).toBeNull();
+    });
+
     it("pins the monitor group into the column and removes it from the header", async () => {
       monitorWide.value = true;
       renderWithMantine(<StatefulInspectorViewHost {...connectedHttp()} />);

--- a/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.test.tsx
@@ -44,6 +44,7 @@ import {
   EMPTY_LOGS_UI,
   EMPTY_HISTORY_UI,
   EMPTY_NETWORK_UI,
+  EMPTY_CONSOLE_UI,
 } from "../../screens/screenUiState";
 
 // Stub bridge factory — AppsScreen mounts the inner iframe and invokes
@@ -84,6 +85,7 @@ function makeProps(
     tasks: [],
     history: [],
     network: [],
+    stderrLogs: [],
     currentLogLevel: "info",
     sandboxPath: "about:blank",
     bridgeFactory: noopBridgeFactory,
@@ -96,6 +98,7 @@ function makeProps(
     logsUi: EMPTY_LOGS_UI,
     historyUi: EMPTY_HISTORY_UI,
     networkUi: EMPTY_NETWORK_UI,
+    consoleUi: EMPTY_CONSOLE_UI,
     onToggleTheme: vi.fn(),
     onOpenClientSettings: vi.fn(),
     onToggleConnection: vi.fn(),
@@ -140,6 +143,9 @@ function makeProps(
     onNetworkUiChange: vi.fn(),
     onClearNetwork: vi.fn(),
     onExportNetwork: vi.fn(),
+    onConsoleUiChange: vi.fn(),
+    onClearConsole: vi.fn(),
+    onExportConsole: vi.fn(),
     onAppsUiChange: vi.fn(),
     onSelectApp: vi.fn(),
     onOpenApp: vi.fn(),
@@ -1404,22 +1410,41 @@ describe("InspectorView", () => {
         screen.queryByRole("button", { name: "Close monitoring column" }),
       ).toBeNull();
 
-      // A connection failure (→ error) opens it to surface the diagnostics.
-      rerender(<StatefulInspectorViewHost {...failedHttp()} />);
+      // A connection failure (→ error) opens it to surface the diagnostics. The
+      // failed HTTP request is what captured the failure, so Network is present.
+      rerender(
+        <StatefulInspectorViewHost
+          {...failedHttp({
+            network: [
+              {
+                id: "f1",
+                timestamp: new Date(),
+                method: "POST",
+                url: "http://localhost:3000/mcp",
+                requestHeaders: {},
+                error: "fetch failed: ECONNREFUSED",
+                category: "transport",
+              },
+            ],
+          })}
+        />,
+      );
       expect(
         await screen.findByRole("button", { name: "Close monitoring column" }),
       ).toBeInTheDocument();
 
-      // The failure column offers the History + Network diagnostics, but not
-      // Logs (a failed connect never negotiated the logging capability).
+      // The failure column offers History + Network (the captured request), but
+      // not Logs (a failed connect never negotiated the logging capability) nor
+      // Console (an HTTP transport has no child-process stderr).
       expect(screen.getByRole("radio", { name: "History" })).toBeChecked();
       expect(
         screen.getByRole("radio", { name: "Network" }),
       ).toBeInTheDocument();
       expect(screen.queryByRole("radio", { name: "Logs" })).toBeNull();
+      expect(screen.queryByRole("radio", { name: "Console" })).toBeNull();
     });
 
-    it("omits Network from the failure column for a stdio server (#1621)", async () => {
+    it("surfaces Console (stderr), not Network, in the failure column for a stdio server (#1621)", async () => {
       monitorWide.value = true;
       const stdioErr: ServerEntry = {
         id: "beta",
@@ -1437,13 +1462,30 @@ describe("InspectorView", () => {
         />,
       );
       rerender(
-        <StatefulInspectorViewHost {...failedHttp({ servers: [stdioErr] })} />,
+        <StatefulInspectorViewHost
+          {...failedHttp({
+            servers: [stdioErr],
+            // A connect failure fires the client `disconnect` event, which
+            // clears activeServer — so the failure column must key off captured
+            // stderr, NOT the (now-undefined) active server's transport.
+            activeServer: undefined,
+            stderrLogs: [
+              { timestamp: new Date(), message: "ModuleNotFoundError: boom" },
+            ],
+          })}
+        />,
       );
-      // stdio has no HTTP traffic, so the failure column shows History only.
+      // The captured stderr means it was a stdio launch: the column surfaces
+      // Console (the process's stderr) and defaults to it — that's where the
+      // spawn error is — with no Network (no HTTP traffic). The stderr renders.
       expect(
-        await screen.findByRole("radio", { name: "History" }),
+        await screen.findByRole("radio", { name: "Console" }),
+      ).toBeChecked();
+      expect(
+        screen.getByRole("radio", { name: "History" }),
       ).toBeInTheDocument();
       expect(screen.queryByRole("radio", { name: "Network" })).toBeNull();
+      expect(screen.getByText("ModuleNotFoundError: boom")).toBeInTheDocument();
     });
 
     it("does not auto-open on a mount that starts already errored (#1621)", () => {
@@ -1453,6 +1495,63 @@ describe("InspectorView", () => {
       renderWithMantine(<StatefulInspectorViewHost {...failedHttp()} />);
       expect(
         screen.queryByRole("button", { name: "Close monitoring column" }),
+      ).toBeNull();
+    });
+
+    const stdioServer: ServerEntry = {
+      id: "gamma",
+      name: "Gamma",
+      config: { type: "stdio", command: "echo" },
+      connection: { status: "connected" },
+    };
+
+    it("offers Console (not Network) as a monitor tab for a connected stdio server (#1621)", async () => {
+      monitorWide.value = true;
+      window.localStorage.setItem("inspector.monitor.pinned", "true");
+      renderWithMantine(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [stdioServer],
+            activeServer: "gamma",
+            connectionStatus: "connected",
+            initializeResult: httpInit,
+            stderrLogs: [{ timestamp: new Date(), message: "server booting" }],
+          })}
+        />,
+      );
+      // Pinned column for a stdio server hosts Logs/History/Console — never
+      // Network (no HTTP traffic to show).
+      expect(
+        await screen.findByRole("radio", { name: "Console" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("radio", { name: "History" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("radio", { name: "Network" })).toBeNull();
+    });
+
+    it("lists Console in the header tab menu for a connected stdio server when unpinned (#1621)", async () => {
+      // Column not pinned, so the monitor group (incl. Console) lives in the
+      // header menu — the user can reach the stderr stream during a live
+      // session, not only on failure.
+      monitorWide.value = true;
+      renderWithMantine(
+        <StatefulInspectorViewHost
+          {...makeProps({
+            servers: [stdioServer],
+            activeServer: "gamma",
+            connectionStatus: "connected",
+            initializeResult: httpInit,
+          })}
+        />,
+      );
+      const header = screen.getByRole("banner");
+      expect(
+        within(header).getByRole("radio", { name: "Console" }),
+      ).toBeInTheDocument();
+      // stdio: Network is not in the header menu.
+      expect(
+        within(header).queryByRole("radio", { name: "Network" }),
       ).toBeNull();
     });
 

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -88,6 +88,7 @@ import { MonitoringScreen } from "../../groups/MonitoringScreen/MonitoringScreen
 import { ResizeHandle } from "../../elements/ResizeHandle/ResizeHandle";
 import { getServerType } from "@inspector/core/mcp/config.js";
 import { INSPECTOR_SERVERS_TAB } from "../../../utils/inspectorTabs";
+import { MONITOR_COLUMN_ANIM_MS } from "./monitorColumnAnimation";
 
 const SORT_DEFAULT: SortDirection = "newest-first";
 
@@ -283,8 +284,9 @@ const MonitoringColumn = Stack.withProps({
 // side column sliding open rather than snapping in. The primary screen keeps its
 // standard `ScreenStage` transition. Mantine plays `out → in` on enter and
 // `in → out` on exit. `AppShell.Main`'s `overflow: hidden` clips the off-screen
-// portion during the slide.
-const COLUMN_ANIM_MS = 300;
+// portion during the slide. The duration is shared (`ServerCard` waits on it
+// before scrolling a failed card into view) so the two can't drift.
+const COLUMN_ANIM_MS = MONITOR_COLUMN_ANIM_MS;
 const columnSlide: MantineTransition = {
   in: { opacity: 1, transform: "translateX(0)" },
   out: { opacity: 0, transform: "translateX(100%)" },
@@ -695,22 +697,30 @@ export function InspectorView({
   });
 
   // Open the monitoring column when a connection is established (#1616) OR when a
-  // connection attempt fails (#1621). Gated on the *transition into* the target
+  // connect *attempt* fails (#1621). Gated on the *transition into* the target
   // status (via the ref) rather than the status itself, so it fires once on an
   // actual connect/failure — not on every render, and not on a mount that starts
   // already in that status (which would fight a user who closed it). On success
-  // the column surfaces the live stream; on failure it surfaces the History /
-  // Network entries that explain what went wrong. The column still only *appears*
-  // when wide + a monitor tab is available (`effectivePinned`); this just sets the
-  // preference. Closing it stays closed until the next connect/failure, since this
-  // effect only re-runs when `connectionStatus` changes.
+  // the column surfaces the live stream; on failure it surfaces the diagnostics
+  // that explain what went wrong. The column still only *appears* when wide + a
+  // monitor tab is available (`effectivePinned`); this just sets the preference.
+  //
+  // `"error"` is also the resting status of a *mid-session crash* of a
+  // previously-connected server (per isTerminalStatus/#1490), but that is NOT a
+  // connect attempt: reopening a column the user closed mid-session (and swapping
+  // their live tab set for the failure set) would be surprising. So the error
+  // arm requires the previous status to NOT be `connected` — i.e. we went
+  // connecting/disconnected → error, never connected → error. This keeps the
+  // auto-open aligned with the red-border (`erroredServerId`), which the parent
+  // also sets only for connect-attempt failures.
   const prevStatusRef = useRef(connectionStatus);
   useEffect(() => {
     const prev = prevStatusRef.current;
     prevStatusRef.current = connectionStatus;
     const becameConnected =
       connectionStatus === "connected" && prev !== "connected";
-    const becameError = connectionStatus === "error" && prev !== "error";
+    const becameError =
+      connectionStatus === "error" && prev !== "error" && prev !== "connected";
     if (becameConnected || becameError) {
       setMonitorPinned(true);
     }
@@ -797,9 +807,12 @@ export function InspectorView({
   // `monitorPinned`, so it re-opens when the condition returns. Only the column's
   // close button writes `monitorPinned = false`.
   const connected = connectionStatus === "connected";
-  // A failed connection attempt (#1621) keeps the column available so the user
-  // can see why, even though no live session exists.
-  const failed = connectionStatus === "error";
+  // A failed connection *attempt* (#1621) keeps the column available so the user
+  // can see why, even though no live session exists. Gated on `erroredServerId`
+  // (set by the parent only for connect-attempt failures, not mid-session
+  // crashes) so a crash of a previously-connected server doesn't reorganize the
+  // column into the failure tab set — matching the auto-open effect above.
+  const failed = connectionStatus === "error" && erroredServerId !== undefined;
   const monitorAvailable = useMemo<string[]>(() => {
     if (connected) return availableTabs.filter((t) => MONITOR_TABS.includes(t));
     if (failed) {

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -654,21 +654,26 @@ export function InspectorView({
     getInitialValueInEffect: false,
   });
 
-  // Open the monitoring column when a connection is established (#1616). Gated on
-  // the disconnected → connected *transition* (via the ref) rather than the
-  // "connected" state itself, so it fires on an actual connect — not on every
-  // render while connected, and not on a mount that starts already-connected
-  // (which would fight a user who closed it). The column still only *appears*
-  // when wide + a monitor tab is available (`effectivePinned`); this just sets
-  // the preference. Closing it stays closed until the next connect, since this
+  // Open the monitoring column when a connection is established (#1616) OR when a
+  // connection attempt fails (#1621). Gated on the *transition into* the target
+  // status (via the ref) rather than the status itself, so it fires once on an
+  // actual connect/failure — not on every render, and not on a mount that starts
+  // already in that status (which would fight a user who closed it). On success
+  // the column surfaces the live stream; on failure it surfaces the History /
+  // Network entries that explain what went wrong. The column still only *appears*
+  // when wide + a monitor tab is available (`effectivePinned`); this just sets the
+  // preference. Closing it stays closed until the next connect/failure, since this
   // effect only re-runs when `connectionStatus` changes.
-  const wasConnectedRef = useRef(connectionStatus === "connected");
+  const prevStatusRef = useRef(connectionStatus);
   useEffect(() => {
-    const isConnected = connectionStatus === "connected";
-    if (isConnected && !wasConnectedRef.current) {
+    const prev = prevStatusRef.current;
+    prevStatusRef.current = connectionStatus;
+    const becameConnected =
+      connectionStatus === "connected" && prev !== "connected";
+    const becameError = connectionStatus === "error" && prev !== "error";
+    if (becameConnected || becameError) {
       setMonitorPinned(true);
     }
-    wasConnectedRef.current = isConnected;
   }, [connectionStatus, setMonitorPinned]);
 
   const appTools = useMemo<Tool[]>(() => {
@@ -740,20 +745,37 @@ export function InspectorView({
     appTools,
   ]);
 
-  // Monitoring column, derived (#1616). The monitor group is pinned into the
-  // right column only when: the user asked for it, the viewport is wide enough,
-  // a server is connected, and at least one monitor tab is actually available
-  // (capability/stdio aware). Narrowing, disconnecting, or losing the last
-  // monitor capability flips `effectivePinned` false and closes the column —
-  // WITHOUT clearing `monitorPinned`, so it re-opens when the condition returns.
-  // Only the column's close button writes `monitorPinned = false`.
+  // Monitoring column, derived (#1616, #1621). The monitor group is pinned into
+  // the right column only when: the user asked for it, the viewport is wide
+  // enough, the session is connected OR a connect attempt failed, and at least
+  // one monitor tab is actually available (capability/stdio aware). Narrowing,
+  // returning to a clean disconnect, or losing the last monitor capability flips
+  // `effectivePinned` false and closes the column — WITHOUT clearing
+  // `monitorPinned`, so it re-opens when the condition returns. Only the column's
+  // close button writes `monitorPinned = false`.
   const connected = connectionStatus === "connected";
-  const monitorAvailable = useMemo<string[]>(
-    () => availableTabs.filter((t) => MONITOR_TABS.includes(t)),
-    [availableTabs],
-  );
+  // A failed connection attempt (#1621) keeps the column available so the user
+  // can see why, even though no live session exists.
+  const failed = connectionStatus === "error";
+  const monitorAvailable = useMemo<string[]>(() => {
+    if (connected) return availableTabs.filter((t) => MONITOR_TABS.includes(t));
+    if (failed) {
+      // A failed connect never negotiated capabilities, so Logs (gated on the
+      // server's `logging` capability) isn't meaningful. History (the local
+      // client-side message log) always captured the attempt, and Network (HTTP
+      // requests) did too for non-stdio transports — those are what explain the
+      // failure, so offer exactly them.
+      const active = serversInput.find((s) => s.id === activeServer);
+      const isStdio = active ? getServerType(active.config) === "stdio" : false;
+      return isStdio ? [HISTORY_TAB] : [HISTORY_TAB, NETWORK_TAB];
+    }
+    return [];
+  }, [connected, failed, availableTabs, serversInput, activeServer]);
   const effectivePinned =
-    monitorPinned && !!isWide && connected && monitorAvailable.length > 0;
+    monitorPinned &&
+    !!isWide &&
+    (connected || failed) &&
+    monitorAvailable.length > 0;
 
   // The header loses the monitor group while the column is open (its screens
   // live in the column instead); otherwise it shows every available tab.

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -817,27 +817,29 @@ export function InspectorView({
     if (connected) return availableTabs.filter((t) => MONITOR_TABS.includes(t));
     if (failed) {
       // A failed connect never negotiated capabilities, so Logs (gated on the
-      // server's `logging` capability) isn't meaningful. What explains the
-      // failure is whichever diagnostic actually captured something:
+      // server's `logging` capability) isn't meaningful. Offer exactly the tabs
+      // whose diagnostic actually *captured something* — keyed on content, not
+      // the declared transport (a connect failure fires the client `disconnect`
+      // event, which clears `activeServer`, so transport can't be read back):
       //   • stdio → the process's stderr (Console): the spawn/startup error the
       //     child printed before dying.
       //   • HTTP  → the failed requests (Network).
-      // We key off *captured content*, not the server's declared transport,
-      // because a connect failure fires the client `disconnect` event, which
-      // clears `activeServer` — so transport can't be read back reliably here.
-      // History is always offered, though a pre-handshake failure usually
-      // leaves it empty. Console leads (it's the stdio failure's story); Network
-      // trails History (matching the connected order). This memo re-runs as
-      // stderr/fetch entries stream in, so the diagnostic tab appears as soon as
-      // the failing process/request produces output.
+      //   • History only if it has entries — the message log is cleared on the
+      //     error transition, so on a fresh connect failure it's empty; offering
+      //     it anyway would let an empty tab lead over (and hide) the real
+      //     diagnostic. Content-gating it keeps the actual diagnostic first.
+      // If nothing captured anything yet, `monitorAvailable` is empty and the
+      // column stays closed rather than opening onto an empty pane; this memo
+      // re-runs as stderr/fetch entries stream in, so the column opens (and the
+      // diagnostic tab appears) the moment the failing process/request emits.
       const tabs: string[] = [];
       if (stderrLogs.length > 0) tabs.push(CONSOLE_TAB);
-      tabs.push(HISTORY_TAB);
       if (network.length > 0) tabs.push(NETWORK_TAB);
+      if (history.length > 0) tabs.push(HISTORY_TAB);
       return tabs;
     }
     return [];
-  }, [connected, failed, availableTabs, stderrLogs, network]);
+  }, [connected, failed, availableTabs, stderrLogs, network, history]);
   const effectivePinned =
     monitorPinned &&
     !!isWide &&

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -32,6 +32,7 @@ import type {
   InspectorResourceSubscription,
   MessageEntry,
   ServerEntry,
+  StderrLogEntry,
 } from "@inspector/core/mcp/types.js";
 import { isTerminalStatus } from "@inspector/core/mcp/types.js";
 import { isAppTool } from "@inspector/core/mcp/apps.js";
@@ -78,6 +79,10 @@ import {
   NetworkScreen,
   type NetworkUiState,
 } from "../../screens/NetworkScreen/NetworkScreen";
+import {
+  ConsoleScreen,
+  type ConsoleUiState,
+} from "../../screens/ConsoleScreen/ConsoleScreen";
 import type { SortDirection } from "../../elements/SortToggle/SortToggle";
 import { MonitoringScreen } from "../../groups/MonitoringScreen/MonitoringScreen";
 import { ResizeHandle } from "../../elements/ResizeHandle/ResizeHandle";
@@ -120,7 +125,7 @@ function serializeListCompact(value: boolean): string {
 // SPA only, no SSR — so the persisted value lands without a one-frame
 // flicker through the default. The `inspector.<kind>.<scope>` namespace
 // keeps related preferences grouped and easy to clear in bulk.
-function useSortDirection(scope: "logs" | "history" | "network") {
+function useSortDirection(scope: "logs" | "history" | "network" | "console") {
   return useLocalStorage<SortDirection>({
     key: `inspector.sortDirection.${scope}`,
     defaultValue: SORT_DEFAULT,
@@ -147,6 +152,7 @@ const SERVERS_TAB = INSPECTOR_SERVERS_TAB;
 const LOGS_TAB = "Logs";
 const HISTORY_TAB = "History";
 const NETWORK_TAB = "Network";
+const CONSOLE_TAB = "Console";
 
 const ALL_TABS: string[] = [
   SERVERS_TAB,
@@ -158,16 +164,29 @@ const ALL_TABS: string[] = [
   LOGS_TAB,
   HISTORY_TAB,
   NETWORK_TAB,
+  CONSOLE_TAB,
 ];
 
 // The screens that can be pinned into the monitoring column (#1616). Pinning is
 // a group action: opening the column removes all *available* monitor tabs from
-// the header and hosts them in the column instead.
-type MonitorTab = "Logs" | "History" | "Network";
-const MONITOR_TABS: string[] = [LOGS_TAB, HISTORY_TAB, NETWORK_TAB];
+// the header and hosts them in the column instead. Console (#1621) is the
+// stdio server's stderr stream — mutually exclusive with Network (Console shows
+// for stdio, Network for HTTP), but both live in the monitor group.
+type MonitorTab = "Logs" | "History" | "Network" | "Console";
+const MONITOR_TABS: string[] = [
+  LOGS_TAB,
+  HISTORY_TAB,
+  NETWORK_TAB,
+  CONSOLE_TAB,
+];
 
 function isMonitorTab(tab: string): tab is MonitorTab {
-  return tab === LOGS_TAB || tab === HISTORY_TAB || tab === NETWORK_TAB;
+  return (
+    tab === LOGS_TAB ||
+    tab === HISTORY_TAB ||
+    tab === NETWORK_TAB ||
+    tab === CONSOLE_TAB
+  );
 }
 
 // The viewport width below which the split collapses to a single column: matches
@@ -351,6 +370,8 @@ export interface InspectorViewProps {
   progressByTaskId?: Record<string, TaskProgress>;
   history: MessageEntry[];
   network: FetchRequestEntry[];
+  /** Captured stdio stderr (the Console screen). Empty for HTTP servers. (#1621) */
+  stderrLogs: StderrLogEntry[];
 
   // Per-screen "operation in flight" states (panel-level; optional because
   // the underlying screens accept them as optional).
@@ -370,6 +391,7 @@ export interface InspectorViewProps {
   logsUi: LogsUiState;
   historyUi: HistoryUiState;
   networkUi: NetworkUiState;
+  consoleUi: ConsoleUiState;
 
   /** Active inspector tab (lifted to App for OAuth resume). */
   activeTab: string;
@@ -486,6 +508,10 @@ export interface InspectorViewProps {
   onClearNetwork: () => void;
   onExportNetwork: () => void;
 
+  onConsoleUiChange: (next: ConsoleUiState) => void;
+  onClearConsole: () => void;
+  onExportConsole: () => void;
+
   onAppsUiChange: (next: AppsUiState) => void;
   onSelectApp: (name: string) => void;
   onOpenApp: (name: string, args: Record<string, unknown>) => void;
@@ -514,6 +540,7 @@ export function InspectorView({
   progressByTaskId,
   history,
   network,
+  stderrLogs,
   toolCallState,
   getPromptState,
   readResourceState,
@@ -525,6 +552,7 @@ export function InspectorView({
   logsUi,
   historyUi,
   networkUi,
+  consoleUi,
   currentLogLevel,
   sandboxPath,
   bridgeFactory,
@@ -583,6 +611,9 @@ export function InspectorView({
   onNetworkUiChange,
   onClearNetwork,
   onExportNetwork,
+  onConsoleUiChange,
+  onClearConsole,
+  onExportConsole,
   onAppsUiChange,
   onSelectApp,
   onOpenApp,
@@ -599,6 +630,7 @@ export function InspectorView({
   const [logsSort, setLogsSort] = useSortDirection("logs");
   const [historySort, setHistorySort] = useSortDirection("history");
   const [networkSort, setNetworkSort] = useSortDirection("network");
+  const [consoleSort, setConsoleSort] = useSortDirection("console");
 
   // Servers and Resources default to expanded (collapsed=false) so new
   // users see content on first paint; History/Network default to
@@ -729,6 +761,9 @@ export function InspectorView({
     const hasLogging = capabilities?.logging !== undefined;
     return ALL_TABS.filter((t) => {
       if (t === NETWORK_TAB && isStdio) return false;
+      // Console is the stdio process's stderr stream — shown only for stdio
+      // servers (HTTP transports have no child process to capture). (#1621)
+      if (t === CONSOLE_TAB && !isStdio) return false;
       if (t === "Tools" && !hasTools) return false;
       if (t === "Apps" && !hasApps) return false;
       if (t === "Prompts" && !hasPrompts) return false;
@@ -761,16 +796,27 @@ export function InspectorView({
     if (connected) return availableTabs.filter((t) => MONITOR_TABS.includes(t));
     if (failed) {
       // A failed connect never negotiated capabilities, so Logs (gated on the
-      // server's `logging` capability) isn't meaningful. History (the local
-      // client-side message log) always captured the attempt, and Network (HTTP
-      // requests) did too for non-stdio transports — those are what explain the
-      // failure, so offer exactly them.
-      const active = serversInput.find((s) => s.id === activeServer);
-      const isStdio = active ? getServerType(active.config) === "stdio" : false;
-      return isStdio ? [HISTORY_TAB] : [HISTORY_TAB, NETWORK_TAB];
+      // server's `logging` capability) isn't meaningful. What explains the
+      // failure is whichever diagnostic actually captured something:
+      //   • stdio → the process's stderr (Console): the spawn/startup error the
+      //     child printed before dying.
+      //   • HTTP  → the failed requests (Network).
+      // We key off *captured content*, not the server's declared transport,
+      // because a connect failure fires the client `disconnect` event, which
+      // clears `activeServer` — so transport can't be read back reliably here.
+      // History is always offered, though a pre-handshake failure usually
+      // leaves it empty. Console leads (it's the stdio failure's story); Network
+      // trails History (matching the connected order). This memo re-runs as
+      // stderr/fetch entries stream in, so the diagnostic tab appears as soon as
+      // the failing process/request produces output.
+      const tabs: string[] = [];
+      if (stderrLogs.length > 0) tabs.push(CONSOLE_TAB);
+      tabs.push(HISTORY_TAB);
+      if (network.length > 0) tabs.push(NETWORK_TAB);
+      return tabs;
     }
     return [];
-  }, [connected, failed, availableTabs, serversInput, activeServer]);
+  }, [connected, failed, availableTabs, stderrLogs, network]);
   const effectivePinned =
     monitorPinned &&
     !!isWide &&
@@ -933,6 +979,15 @@ export function InspectorView({
     compact: networkCompact,
     onToggleCompact: () => setNetworkCompact((c) => !c),
   };
+  const consoleScreenProps = {
+    entries: stderrLogs,
+    ui: consoleUi,
+    onUiChange: onConsoleUiChange,
+    onClear: onClearConsole,
+    onExport: onExportConsole,
+    sortDirection: consoleSort,
+    onSortChange: setConsoleSort,
+  };
 
   // Embedded instances for the pinned column, keyed by tab. MonitoringScreen
   // renders only the active one; the rest are unmounted element values. Each
@@ -957,6 +1012,13 @@ export function InspectorView({
       <NetworkScreen
         {...networkScreenProps}
         ui={{ ...networkUi, filterText: monitorSearch }}
+        embedded
+      />
+    ),
+    [CONSOLE_TAB]: (
+      <ConsoleScreen
+        {...consoleScreenProps}
+        ui={{ filterText: monitorSearch }}
         embedded
       />
     ),
@@ -1109,6 +1171,12 @@ export function InspectorView({
               <NetworkScreen
                 {...networkScreenProps}
                 onPin={canPin ? () => pinMonitor(NETWORK_TAB) : undefined}
+              />
+            </ScreenStage>
+            <ScreenStage active={activeTab === CONSOLE_TAB}>
+              <ConsoleScreen
+                {...consoleScreenProps}
+                onPin={canPin ? () => pinMonitor(CONSOLE_TAB) : undefined}
               />
             </ScreenStage>
           </ScreenStageContainer>

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -347,6 +347,13 @@ export interface InspectorViewProps {
 
   // Connection state — driven by the parent via `useInspectorClient`.
   activeServer?: string;
+  /**
+   * Id of the server whose last connection attempt failed (#1621). Its card in
+   * the Servers screen draws a red border until another server is connected or
+   * a new connection is attempted. Independent of `activeServer`, which the
+   * parent clears on the failure's `disconnect` event.
+   */
+  erroredServerId?: string;
   connectionStatus: ConnectionStatus;
   initializeResult?: InitializeResult;
   latencyMs?: number;
@@ -524,6 +531,7 @@ export function InspectorView({
   servers: serversInput,
   serverListWritable = true,
   activeServer,
+  erroredServerId,
   connectionStatus,
   initializeResult,
   latencyMs,
@@ -1062,6 +1070,7 @@ export function InspectorView({
                 servers={servers}
                 writable={serverListWritable}
                 activeServer={dimCardsAgainst}
+                erroredServerId={erroredServerId}
                 onAddManually={onServerAdd}
                 onImportConfig={onServerImportConfig}
                 onImportServerJson={onServerImportJson}

--- a/clients/web/src/components/views/InspectorView/monitorColumnAnimation.ts
+++ b/clients/web/src/components/views/InspectorView/monitorColumnAnimation.ts
@@ -1,0 +1,15 @@
+/**
+ * Duration (ms) of the monitoring column's open/close slide (#1616). Shared so
+ * dependent timings can't silently drift from the animation:
+ *   - `InspectorView` drives the column's Mantine `Transition` with it.
+ *   - `ServerCard` waits just past it before scrolling a newly-failed card into
+ *     view (#1621), so the column's open + the resulting grid reflow settle
+ *     before `scrollIntoView` measures the card's position.
+ */
+export const MONITOR_COLUMN_ANIM_MS = 300;
+
+/**
+ * Delay (ms) before scrolling a newly-failed server card into view — the column
+ * animation plus a small buffer for the reflow to commit.
+ */
+export const FAILED_CARD_SCROLL_DELAY_MS = MONITOR_COLUMN_ANIM_MS + 20;

--- a/clients/web/src/lib/downloadFile.ts
+++ b/clients/web/src/lib/downloadFile.ts
@@ -79,7 +79,8 @@ export type ExportKind =
   | "history-pinned"
   | "history-unpinned"
   | "logs"
-  | "network";
+  | "network"
+  | "console";
 
 /**
  * Build a sortable export filename in the shape

--- a/clients/web/src/theme/Card.ts
+++ b/clients/web/src/theme/Card.ts
@@ -50,6 +50,19 @@ export const ThemeCard = Card.extend({
         },
       };
     }
+    if (props.variant === "errored") {
+      // Server card whose last connection attempt failed: a red border flags it
+      // until another server is connected/attempted (#1621). Mirrors the
+      // `highlighted` variant; the border itself comes from the inherited
+      // `withBorder: true` default above.
+      return {
+        root: {
+          backgroundColor: "var(--inspector-surface-card)",
+          borderColor: "var(--inspector-error-border)",
+          borderWidth: 2,
+        },
+      };
+    }
     if (props.variant === "preview") {
       // Container for the resource preview / template form panels: sizes to
       // content (no forced height) but caps at the screen's available area

--- a/clients/web/src/theme/Text.ts
+++ b/clients/web/src/theme/Text.ts
@@ -26,6 +26,17 @@ export const ThemeText = Text.extend({
         },
       };
     }
+    // A line of captured server stderr (#1621): preserve the process's own
+    // newlines/whitespace (`pre-wrap`) while still wrapping over-long lines
+    // inside the narrow monitoring column (`break-word`).
+    if (props.variant === "consoleLine") {
+      return {
+        root: {
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+        },
+      };
+    }
     return { root: {} };
   },
 });


### PR DESCRIPTION
Closes #1621

## Summary

Related to #1616 (open the monitoring column on connect). On a *successful* connect we pin the monitoring column open; on a *failed* connection the user was left without an obvious way to see why. This opens the monitoring column automatically when a connection attempt fails **and** gives it something useful to show — a new **Console** tab that surfaces a failing stdio server's stderr — plus a **red border** on the failed server's card.

## Behavior

- **Auto-open on failure** — the connect-success auto-open effect (#1616) is broadened to also fire on the transition into the `error` status, tracked via a previous-status ref so it fires once per transition and never on a mount that starts already errored.
- **New Console tab (stderr)** — a stdio server's process stderr was already captured in `StderrLogState` but never displayed anywhere. `ConsoleScreen` now renders it (search / sort / clear / export, embeddable in the column), wired through `App` via the existing `useStderrLog` hook. Console is a pinnable monitor tab like Logs/History/Network, **gated to stdio servers** (HTTP has no child process). It appears in the header tab menu when the column isn't pinned, and moves into the column when it is.
- **Failure column picks tabs by captured content** — a failed stdio launch has an empty History (the message log is cleared on the error transition) and no Network (no HTTP), so the column would otherwise be empty. The failure column now selects tabs by which diagnostic actually captured something (**stderr → Console**, **fetch requests → Network**), always offering History alongside. It keys off content rather than the active server's transport because a connect failure fires the client `disconnect` event, which clears `activeServer` — so transport can't be read back reliably there. The memo re-runs as entries stream in.
- **Red card border** — the server whose last connection attempt failed gets a red border on its `ServerCard` (new `errored` Card theme variant + `--inspector-error-border` token, mirroring the freshly-added green `highlighted` border). `App` tracks `failedServerId`: set in the non-auth handshake catch, cleared at the start of any new connect attempt, and deliberately kept out of `resetSessionScopedUiState` (the failure's own `disconnect` event would otherwise clear it the same tick). Precedence: dimmed > errored > highlighted.
- **Complements #1616** — `effectivePinned` allows the column while `error`, not only `connected`; it still closes on a clean disconnect or narrowing without clearing the user's `monitorPinned` preference.

## Screencap


https://github.com/user-attachments/assets/a7ae59cc-c83d-465e-a4a9-49e708c8de2f



## Testing

- Unit tests across `App`, `InspectorView`, `ServerListScreen`, `ServerCard`, and a new fully-covered `ConsoleScreen` (+ Storybook): auto-open on the error transition; Console (with captured stderr) is the default tab for a stdio failure even when `activeServer` is cleared; Network (not Console) for an HTTP failure with a captured request; Console offered as a pinnable/header-menu tab for a connected stdio server; `failedServerId` set on a failed connect and cleared on a new attempt; red-border variant precedence.
- **Full `npm run ci` passes** — validate + coverage (every file clears the ≥90 per-file gate) + smoke + Storybook.
- **Verified live** against a failing `python -m mcp_server_time` stdio server: connecting auto-opens the column to the Console tab showing the real `No module named mcp_server_time` stderr, and the card shows the red border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)