### PR TITLE
fix: route proxy OAuth flow through proxy fetch to bypass CORS

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -603,7 +603,7 @@ const App = () => {
     (serverUrl: string) => {
       setSseUrl(serverUrl);
       setIsAuthDebuggerVisible(false);
-      void connectMcpServer();
+      void connectMcpServer(undefined, 0, serverUrl);
     },
     [connectMcpServer],
   );
@@ -1350,7 +1350,11 @@ const App = () => {
     );
     return (
       <Suspense fallback={<div>Loading...</div>}>
-        <OAuthCallback onConnect={onOAuthConnect} />
+        <OAuthCallback
+          onConnect={onOAuthConnect}
+          connectionType={connectionType}
+          config={config}
+        />
       </Suspense>
     );
   }

--- a/client/src/components/OAuthCallback.tsx
+++ b/client/src/components/OAuthCallback.tsx
@@ -7,12 +7,20 @@ import {
   generateOAuthErrorDescription,
   parseOAuthCallbackParams,
 } from "@/utils/oauthUtils.ts";
+import { createProxyFetch } from "@/lib/proxyFetch";
+import type { InspectorConfig } from "@/lib/configurationTypes";
 
 interface OAuthCallbackProps {
   onConnect: (serverUrl: string) => void;
+  connectionType?: "direct" | "proxy";
+  config?: InspectorConfig;
 }
 
-const OAuthCallback = ({ onConnect }: OAuthCallbackProps) => {
+const OAuthCallback = ({
+  onConnect,
+  connectionType,
+  config,
+}: OAuthCallbackProps) => {
   const { toast } = useToast();
   const hasProcessedRef = useRef(false);
 
@@ -46,9 +54,15 @@ const OAuthCallback = ({ onConnect }: OAuthCallbackProps) => {
         // Create an auth provider with the current server URL
         const serverAuthProvider = new InspectorOAuthClientProvider(serverUrl);
 
+        const fetchFn =
+          connectionType === "proxy" && config
+            ? createProxyFetch(config)
+            : undefined;
+
         result = await auth(serverAuthProvider, {
           serverUrl,
           authorizationCode: params.code,
+          ...(fetchFn ? { fetchFn } : {}),
         });
       } catch (error) {
         console.error("OAuth callback error:", error);

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -444,7 +444,11 @@ export function useConnection({
     }
   };
 
-  const connect = async (_e?: unknown, retryCount: number = 0) => {
+  const connect = async (
+    _e?: unknown,
+    retryCount: number = 0,
+    serverUrlOverride?: string,
+  ) => {
     const clientCapabilities = {
       capabilities: {
         sampling: {},
@@ -496,7 +500,9 @@ export function useConnection({
       const headers: HeadersInit = {};
 
       // Create an auth provider with the current server URL
-      const serverAuthProvider = new InspectorOAuthClientProvider(sseUrl);
+      const serverAuthProvider = new InspectorOAuthClientProvider(
+        serverUrlOverride ?? sseUrl,
+      );
 
       // Use custom headers (migration is handled in App.tsx)
       let finalHeaders: CustomHeaders = customHeaders || [];
@@ -694,7 +700,6 @@ export function useConnection({
               );
             }
             transportOptions = {
-              authProvider: serverAuthProvider,
               eventSourceInit: {
                 fetch: (
                   url: string | URL | globalThis.Request,
@@ -716,7 +721,6 @@ export function useConnection({
             mcpProxyServerUrl = new URL(`${getMCPProxyAddress(config)}/mcp`);
             mcpProxyServerUrl.searchParams.append("url", sseUrl);
             transportOptions = {
-              authProvider: serverAuthProvider,
               eventSourceInit: {
                 fetch: (
                   url: string | URL | globalThis.Request,


### PR DESCRIPTION
## Summary

When using **Via Proxy** connection mode, the browser-side token exchange POST to the OAuth token endpoint is CORS-blocked by corporate MCP gateways (and any auth server that doesn't return `Access-Control-Allow-Origin` on POST responses). This causes `TypeError: Failed to fetch` after the OAuth redirect completes, leaving the inspector unable to connect.

This PR fixes three related failure modes in the proxy OAuth flow. It is related to #1342 (which fixes the same `OAuthCallback` CORS issue) but additionally addresses two further bugs that appear after the token exchange succeeds.

> **Note:** Inspector V2 is under development to address architectural and UX improvements. During this time, V1 contributions should focus on **bug fixes and MCP spec compliance**. See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

1. **`OAuthCallback.tsx`**: accept `config` and `connectionType` props; pass `createProxyFetch(config)` as `fetchFn` to `auth()` when `connectionType === "proxy"`, routing the token exchange through the Node.js proxy instead of the browser. This is the same pattern already used in `useConnection.handleAuthError` and `AuthDebugger`.

2. **`useConnection.ts` - React state race fix**: `onOAuthConnect` in `App.tsx` calls `setSseUrl(serverUrl)` immediately followed by `connectMcpServer()`. Because `setSseUrl` is async, `connectMcpServer` still sees the stale `sseUrl` and looks up the OAuth token under the wrong sessionStorage key, finding nothing. Fixed by adding an optional `serverUrlOverride` parameter to `connect()` and passing the URL directly from `onOAuthConnect`.

3. **`useConnection.ts` - spurious redirect fix**: In proxy mode, `authProvider: serverAuthProvider` was passed to `StreamableHTTPClientTransport` and `SSEClientTransport`. When the transport receives a 401, the SDK calls `auth()` with `serverUrl` set to the **proxy URL** (`localhost:6277/mcp`), not the real MCP server. This causes OAuth discovery against the proxy, which returns 404, and the SDK then redirects the browser to `localhost:6277/authorize`. Removed `authProvider` from proxy transport options -- the Bearer token is already injected manually into headers before the connection is made.

4. **`App.tsx`**: thread `connectionType` and `config` down to `OAuthCallback`; pass `serverUrl` explicitly to `connectMcpServer` after the OAuth callback.

## Related Issues

- Related to #817 (CORS errors in OAuth flow)
- Related to #1342 (same `OAuthCallback` CORS fix; this PR adds fixes for two additional failure modes)

## Testing

- [x] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [x] Tested with Streamable HTTP transport
- [ ] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

Validated end-to-end against a real corporate MCP gateway backed by Azure AD, which enforces strict CORS on the token endpoint.

**Without this fix:**
1. Click Connect -> 401 -> OAuth browser redirect opens
2. User logs in -> redirected back to `/oauth/callback`
3. Token exchange fails with `TypeError: Failed to fetch` (CORS-blocked)
4. Even if exchange somehow succeeds (e.g. token was cached), auto-connect after callback silently fails because `connectMcpServer` reads the wrong sessionStorage key
5. Manual retry triggers bogus redirect to `localhost:6277/authorize`

**With this fix:**
1. Click Connect -> OAuth redirect opens
2. User logs in -> token exchange completes via Node.js proxy (no CORS)
3. Inspector auto-connects immediately using the stored token

`npm test` -> 535/535 pass
`npm run test:e2e` -> 24/24 pass
`npm run prettier-check` -> passes on all changed files

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None. `OAuthCallback` gains two optional props; the single call site in `App.tsx` is updated. The `connect()` signature change is additive (optional third parameter).

## Additional Context

The three bugs form a cascade: fix (1) alone and you hit (2); fix (1) and (2) and you hit (3). All three need to be addressed together for the proxy OAuth flow to work reliably against real-world auth servers with strict CORS policies.
