### PR TITLE
Web UI polish: footer (version/copyright), toolbar + monitoring column tweaks

### DIFF
--- a/clients/web/server/web-server-config.ts
+++ b/clients/web/server/web-server-config.ts
@@ -14,7 +14,13 @@ import {
   LEGACY_AUTH_TOKEN_ENV,
 } from "../../../core/mcp/remote/constants.ts";
 import type { InitialConfigPayload } from "../../../core/mcp/remote/node/server.ts";
+import { readInspectorVersion } from "../../../core/node/version.ts";
 import { resolveSandboxPort } from "./sandbox-controller.js";
+
+// The single-source Inspector version (root package.json), read once at load.
+// The browser can't read the filesystem the way the CLI/TUI do, so the backend
+// reads it here and hands it to the client via GET /api/config.
+const inspectorVersion = readInspectorVersion(import.meta.url);
 
 export interface WebServerConfig {
   port: number;
@@ -92,11 +98,18 @@ function defaultEnvironmentFromProcess(
 }
 
 /**
- * Convert WebServerConfig.initialMcpConfig to the shape expected by GET /api/config.
+ * Convert WebServerConfig.initialMcpConfig to the shape expected by GET
+ * /api/config, tagging on the single-source Inspector `version` so the browser
+ * can display it.
  */
 export function webServerConfigToInitialPayload(
   config: WebServerConfig,
 ): InitialConfigPayload {
+  return { ...transportDefaults(config), version: inspectorVersion };
+}
+
+/** The transport-specific defaults half of the `/api/config` payload. */
+function transportDefaults(config: WebServerConfig): InitialConfigPayload {
   const mc = config.initialMcpConfig;
   const defaultEnvironment = defaultEnvironmentFromProcess(
     mc && "env" in mc && mc.env ? mc.env : undefined,

--- a/clients/web/server/web-server-config.ts
+++ b/clients/web/server/web-server-config.ts
@@ -14,13 +14,15 @@ import {
   LEGACY_AUTH_TOKEN_ENV,
 } from "../../../core/mcp/remote/constants.ts";
 import type { InitialConfigPayload } from "../../../core/mcp/remote/node/server.ts";
-import { readInspectorVersion } from "../../../core/node/version.ts";
+import { readInspectorVersionSafe } from "../../../core/node/version.ts";
 import { resolveSandboxPort } from "./sandbox-controller.js";
 
 // The single-source Inspector version (root package.json), read once at load.
 // The browser can't read the filesystem the way the CLI/TUI do, so the backend
-// reads it here and hands it to the client via GET /api/config.
-const inspectorVersion = readInspectorVersion(import.meta.url);
+// reads it here and hands it to the client via GET /api/config. Uses the
+// non-throwing read: the version is cosmetic, so a resolution failure hides the
+// badge (version omitted from the payload) rather than crashing the backend.
+const inspectorVersion = readInspectorVersionSafe(import.meta.url);
 
 export interface WebServerConfig {
   port: number;

--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -98,8 +98,10 @@ import { useFetchRequestLog } from "@inspector/core/react/useFetchRequestLog.js"
 import { useStderrLog } from "@inspector/core/react/useStderrLog.js";
 import { useSandboxUrl } from "@inspector/core/react/useSandboxUrl.js";
 import { useServerListWritable } from "@inspector/core/react/useServerListWritable.js";
+import { useInspectorVersion } from "@inspector/core/react/useInspectorVersion.js";
 import { usePendingClientRequests } from "@inspector/core/react/usePendingClientRequests.js";
 import { InspectorView } from "./components/views/InspectorView/InspectorView";
+import { VersionBadge } from "./components/elements/VersionBadge/VersionBadge";
 import type {
   ToolCallState,
   ToolsUiState,
@@ -666,6 +668,12 @@ function App() {
   // Read-only sessions (launched with `--config` or an ad-hoc server) hide
   // catalog CRUD; the default catalog and `--catalog` stay writable.
   const { writable: serverListWritable } = useServerListWritable({
+    baseUrl: configBaseUrl,
+    authToken: getAuthToken(),
+  });
+  // The Inspector version (root package.json), shown in the lower-right corner.
+  // The browser can't read it off disk, so the backend sends it via /api/config.
+  const { version: inspectorVersion } = useInspectorVersion({
     baseUrl: configBaseUrl,
     authToken: getAuthToken(),
   });
@@ -3816,6 +3824,7 @@ function App() {
           onRefreshApps={onRefreshTools}
         />
       </Box>
+      <VersionBadge version={inspectorVersion} />
       <ServerConfigModal
         opened={configModal !== null}
         mode={configModal?.mode ?? "add"}

--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -102,6 +102,7 @@ import { useInspectorVersion } from "@inspector/core/react/useInspectorVersion.j
 import { usePendingClientRequests } from "@inspector/core/react/usePendingClientRequests.js";
 import { InspectorView } from "./components/views/InspectorView/InspectorView";
 import { VersionBadge } from "./components/elements/VersionBadge/VersionBadge";
+import { CopyrightBadge } from "./components/elements/CopyrightBadge/CopyrightBadge";
 import type {
   ToolCallState,
   ToolsUiState,
@@ -3824,6 +3825,7 @@ function App() {
           onRefreshApps={onRefreshTools}
         />
       </Box>
+      <CopyrightBadge />
       <VersionBadge version={inspectorVersion} />
       <ServerConfigModal
         opened={configModal !== null}

--- a/clients/web/src/components/elements/CopyrightBadge/CopyrightBadge.stories.tsx
+++ b/clients/web/src/components/elements/CopyrightBadge/CopyrightBadge.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { CopyrightBadge, COPYRIGHT_NOTICE } from "./CopyrightBadge";
+
+const meta: Meta<typeof CopyrightBadge> = {
+  title: "Elements/CopyrightBadge",
+  component: CopyrightBadge,
+};
+
+export default meta;
+type Story = StoryObj<typeof CopyrightBadge>;
+
+// The grey copyright notice pinned to the lower-left corner of the viewport.
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(COPYRIGHT_NOTICE)).toBeInTheDocument();
+  },
+};

--- a/clients/web/src/components/elements/CopyrightBadge/CopyrightBadge.test.tsx
+++ b/clients/web/src/components/elements/CopyrightBadge/CopyrightBadge.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { CopyrightBadge, COPYRIGHT_NOTICE } from "./CopyrightBadge";
+
+describe("CopyrightBadge", () => {
+  it("renders the project copyright notice", () => {
+    renderWithMantine(<CopyrightBadge />);
+    expect(screen.getByText(COPYRIGHT_NOTICE)).toBeInTheDocument();
+  });
+
+  it("names the Model Context Protocol and LF Projects", () => {
+    renderWithMantine(<CopyrightBadge />);
+    expect(
+      screen.getByText(/Model Context Protocol.*Series of LF Projects, LLC\./),
+    ).toBeInTheDocument();
+  });
+});

--- a/clients/web/src/components/elements/CopyrightBadge/CopyrightBadge.tsx
+++ b/clients/web/src/components/elements/CopyrightBadge/CopyrightBadge.tsx
@@ -1,0 +1,18 @@
+import { Text } from "@mantine/core";
+
+/** The project's copyright notice. */
+export const COPYRIGHT_NOTICE =
+  "Copyright © Model Context Protocol a Series of LF Projects, LLC.";
+
+// The `copyrightBadge` variant (src/theme/Text.ts) pins it to the lower-right
+// corner in grey, on the same row as the version badge, and non-interactive.
+const CopyrightText = Text.withProps({ variant: "copyrightBadge" });
+
+/**
+ * The project copyright notice, fixed to the lower-right corner of the screen
+ * (#1639) — the grey, non-interactive twin of the lower-left version badge,
+ * sharing its row.
+ */
+export function CopyrightBadge() {
+  return <CopyrightText>{COPYRIGHT_NOTICE}</CopyrightText>;
+}

--- a/clients/web/src/components/elements/ListToggle/ListToggle.tsx
+++ b/clients/web/src/components/elements/ListToggle/ListToggle.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Button } from "@mantine/core";
+import { ActionIcon } from "@mantine/core";
 import { RiExpandVerticalLine, RiCollapseVerticalLine } from "react-icons/ri";
 
 export interface ListToggleProps {
@@ -29,9 +29,16 @@ export function ListToggle({
     );
   }
 
+  // `size={36}` matches the header's theme / client-settings ActionIcons so the
+  // toolbar's toggle reads as the same size icon button.
   return (
-    <Button size="sm" variant="subtle" aria-label={label} onClick={onToggle}>
+    <ActionIcon
+      variant="subtle"
+      size={36}
+      aria-label={label}
+      onClick={onToggle}
+    >
       <Icon size={20} />
-    </Button>
+    </ActionIcon>
   );
 }

--- a/clients/web/src/components/elements/PinColumnButton/PinColumnButton.test.tsx
+++ b/clients/web/src/components/elements/PinColumnButton/PinColumnButton.test.tsx
@@ -18,4 +18,14 @@ describe("PinColumnButton", () => {
     await user.click(screen.getByRole("button", { name: "Pin as column" }));
     expect(onPin).toHaveBeenCalledTimes(1);
   });
+
+  it("uses a custom accessible label when provided", () => {
+    renderWithMantine(
+      <PinColumnButton onPin={vi.fn()} label="Open monitoring column" />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Open monitoring column" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Pin as column" })).toBeNull();
+  });
 });

--- a/clients/web/src/components/elements/PinColumnButton/PinColumnButton.tsx
+++ b/clients/web/src/components/elements/PinColumnButton/PinColumnButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@mantine/core";
+import { ActionIcon } from "@mantine/core";
 import { TbLayoutSidebarRightExpand } from "react-icons/tb";
 
 export interface PinColumnButtonProps {
@@ -14,15 +14,16 @@ export interface PinColumnButtonProps {
  * that screen in as a column; on the server list it just opens the column (a
  * different `label`). Distinct from `PinToggle` (which pins individual history
  * entries) — this one opens a side column, so it uses a right-sidebar glyph.
- * Styled to match the panel's expand/collapse `ListToggle` (subtle icon button).
+ * `size={36}` matches the header's theme / client-settings ActionIcons and the
+ * toolbar's `ListToggle`, so all these icon buttons share one width.
  */
 export function PinColumnButton({
   onPin,
   label = "Pin as column",
 }: PinColumnButtonProps) {
   return (
-    <Button size="sm" variant="subtle" aria-label={label} onClick={onPin}>
+    <ActionIcon variant="subtle" size={36} aria-label={label} onClick={onPin}>
       <TbLayoutSidebarRightExpand size={20} />
-    </Button>
+    </ActionIcon>
   );
 }

--- a/clients/web/src/components/elements/PinColumnButton/PinColumnButton.tsx
+++ b/clients/web/src/components/elements/PinColumnButton/PinColumnButton.tsx
@@ -4,23 +4,24 @@ import { TbLayoutSidebarRightExpand } from "react-icons/tb";
 export interface PinColumnButtonProps {
   /** Pin this screen into the monitoring column to the right. */
   onPin: () => void;
+  /** Accessible label. Defaults to "Pin as column" (its monitor-screen use). */
+  label?: string;
 }
 
 /**
- * Toolbar button that pins the owning monitor screen (Logs / Protocol / Network)
- * into the resizable column on the right of the InspectorView (#1616). Distinct
- * from `PinToggle` (which pins individual history entries) — this one opens a
- * side column, so it uses a right-sidebar glyph and an "as column" label. Styled
- * to match the panel's expand/collapse `ListToggle` (subtle icon button).
+ * Toolbar button that opens the resizable monitoring column on the right of the
+ * InspectorView (#1616). On a monitor screen (Logs / Protocol / Network) it pins
+ * that screen in as a column; on the server list it just opens the column (a
+ * different `label`). Distinct from `PinToggle` (which pins individual history
+ * entries) — this one opens a side column, so it uses a right-sidebar glyph.
+ * Styled to match the panel's expand/collapse `ListToggle` (subtle icon button).
  */
-export function PinColumnButton({ onPin }: PinColumnButtonProps) {
+export function PinColumnButton({
+  onPin,
+  label = "Pin as column",
+}: PinColumnButtonProps) {
   return (
-    <Button
-      size="sm"
-      variant="subtle"
-      aria-label="Pin as column"
-      onClick={onPin}
-    >
+    <Button size="sm" variant="subtle" aria-label={label} onClick={onPin}>
       <TbLayoutSidebarRightExpand size={20} />
     </Button>
   );

--- a/clients/web/src/components/elements/ScreenStage/ScreenStage.test.tsx
+++ b/clients/web/src/components/elements/ScreenStage/ScreenStage.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { ScreenStage } from "./ScreenStage";
+
+describe("ScreenStage", () => {
+  it("renders its screen when active", () => {
+    renderWithMantine(
+      <ScreenStage active>
+        <div>active screen</div>
+      </ScreenStage>,
+    );
+    expect(screen.getByText("active screen")).toBeInTheDocument();
+  });
+
+  it("renders nothing when inactive (outgoing screen unmounts)", () => {
+    renderWithMantine(
+      <ScreenStage active={false}>
+        <div>inactive screen</div>
+      </ScreenStage>,
+    );
+    expect(screen.queryByText("inactive screen")).toBeNull();
+  });
+
+  it("still renders its screen in the fill variant", () => {
+    renderWithMantine(
+      <ScreenStage active fill>
+        <div>filled screen</div>
+      </ScreenStage>,
+    );
+    expect(screen.getByText("filled screen")).toBeInTheDocument();
+  });
+});

--- a/clients/web/src/components/elements/ScreenStage/ScreenStage.tsx
+++ b/clients/web/src/components/elements/ScreenStage/ScreenStage.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import { Box, Transition } from "@mantine/core";
+
+/** Screen enter / exit durations for the shared `fade-up` stage transition. */
+export const SCREEN_ENTER_MS = 350;
+export const SCREEN_EXIT_MS = 250;
+
+export interface ScreenStageProps {
+  /** True when this stage's screen is the active one. */
+  active: boolean;
+  children: ReactNode;
+  /**
+   * Stretch the stage to fill its relative-positioned parent (adds `bottom: 0`).
+   * Needed where the screen relies on the parent for height (e.g. an inner
+   * ScrollArea in the monitoring column). Off by default so callers whose
+   * screens size themselves keep the top/left/right anchoring.
+   */
+  fill?: boolean;
+}
+
+/**
+ * Wraps a screen in a Mantine `fade-up` Transition so that, on switch, the
+ * incoming screen slides up and fades in while the outgoing one fades down and
+ * out — both mounted at once via absolute positioning. With Transition's default
+ * (`keepMounted={false}`) the outgoing screen unmounts after its exit animation,
+ * resetting any local screen state (search filters, scroll, expanded sections).
+ *
+ * Shared by the primary InspectorView pane and the pinned monitoring column so
+ * both use identical enter/exit motion (#1639-follow-up). Must be rendered
+ * inside a `position: relative` container.
+ */
+export function ScreenStage({
+  active,
+  children,
+  fill = false,
+}: ScreenStageProps) {
+  return (
+    <Transition
+      mounted={active}
+      transition="fade-up"
+      duration={SCREEN_ENTER_MS}
+      exitDuration={SCREEN_EXIT_MS}
+      timingFunction="ease"
+    >
+      {(styles) => (
+        // `style={styles}` is the runtime transition state from Mantine's
+        // Transition API — interpolated values, not static styling.
+        <Box
+          style={styles}
+          pos="absolute"
+          top={0}
+          left={0}
+          right={0}
+          bottom={fill ? 0 : undefined}
+        >
+          {children}
+        </Box>
+      )}
+    </Transition>
+  );
+}

--- a/clients/web/src/components/elements/VersionBadge/VersionBadge.stories.tsx
+++ b/clients/web/src/components/elements/VersionBadge/VersionBadge.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { VersionBadge } from "./VersionBadge";
+
+const meta: Meta<typeof VersionBadge> = {
+  title: "Elements/VersionBadge",
+  component: VersionBadge,
+  args: { version: "2.0.0" },
+};
+
+export default meta;
+type Story = StoryObj<typeof VersionBadge>;
+
+// Default: a grey `v2.0.0` pinned to the lower-right corner of the viewport.
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const badge = await canvas.findByText("v2.0.0");
+    await expect(badge).toBeInTheDocument();
+    await expect(badge).toHaveAttribute(
+      "aria-label",
+      "Inspector version 2.0.0",
+    );
+  },
+};
+
+// No version yet (initial load / legacy backend): renders nothing.
+export const Hidden: Story = {
+  args: { version: undefined },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText(/^v/)).toBeNull();
+  },
+};

--- a/clients/web/src/components/elements/VersionBadge/VersionBadge.test.tsx
+++ b/clients/web/src/components/elements/VersionBadge/VersionBadge.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { VersionBadge } from "./VersionBadge";
+
+describe("VersionBadge", () => {
+  it("renders the version with a `v` prefix and an accessible label", () => {
+    renderWithMantine(<VersionBadge version="2.0.0" />);
+    const badge = screen.getByText("v2.0.0");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("aria-label", "Inspector version 2.0.0");
+  });
+
+  it("renders nothing when the version is undefined", () => {
+    renderWithMantine(<VersionBadge version={undefined} />);
+    expect(screen.queryByText(/^v/)).toBeNull();
+  });
+
+  it("renders nothing when the version is an empty string", () => {
+    renderWithMantine(<VersionBadge version="" />);
+    expect(screen.queryByText(/^v/)).toBeNull();
+  });
+});

--- a/clients/web/src/components/elements/VersionBadge/VersionBadge.tsx
+++ b/clients/web/src/components/elements/VersionBadge/VersionBadge.tsx
@@ -1,0 +1,25 @@
+import { Text } from "@mantine/core";
+
+export interface VersionBadgeProps {
+  /** The Inspector version to show, e.g. `"2.0.0"`. Renders nothing when absent. */
+  version?: string;
+}
+
+// The `versionBadge` variant (src/theme/Text.ts) pins it to the lower-right
+// corner in grey and makes it non-interactive.
+const VersionText = Text.withProps({ variant: "versionBadge" });
+
+/**
+ * A small, unobtrusive build-version label fixed to the lower-right corner of
+ * the screen (#1639). Sourced from the root `package.json` via the backend's
+ * `GET /api/config`; renders nothing until the version is known (or on a legacy
+ * backend that omits it).
+ */
+export function VersionBadge({ version }: VersionBadgeProps) {
+  if (!version) return null;
+  return (
+    <VersionText aria-label={`Inspector version ${version}`}>
+      v{version}
+    </VersionText>
+  );
+}

--- a/clients/web/src/components/elements/VersionBadge/VersionBadge.tsx
+++ b/clients/web/src/components/elements/VersionBadge/VersionBadge.tsx
@@ -5,12 +5,12 @@ export interface VersionBadgeProps {
   version?: string;
 }
 
-// The `versionBadge` variant (src/theme/Text.ts) pins it to the lower-right
+// The `versionBadge` variant (src/theme/Text.ts) pins it to the lower-left
 // corner in grey and makes it non-interactive.
 const VersionText = Text.withProps({ variant: "versionBadge" });
 
 /**
- * A small, unobtrusive build-version label fixed to the lower-right corner of
+ * A small, unobtrusive build-version label fixed to the lower-left corner of
  * the screen (#1639). Sourced from the root `package.json` via the backend's
  * `GET /api/config`; renders nothing until the version is known (or on a legacy
  * backend that omits it).

--- a/clients/web/src/components/groups/MonitoringControls/MonitoringControls.tsx
+++ b/clients/web/src/components/groups/MonitoringControls/MonitoringControls.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, SegmentedControl, TextInput } from "@mantine/core";
+import { Button, Group, SegmentedControl, TextInput } from "@mantine/core";
 import { TbLayoutSidebarRightCollapse } from "react-icons/tb";
 import { ClearButton } from "../../elements/ClearButton/ClearButton";
 
@@ -69,15 +69,14 @@ export function MonitoringControls({
           ) : null
         }
       />
-      <ActionIcon
+      <Button
+        size="sm"
         variant="subtle"
-        color="gray"
-        size="lg"
         aria-label="Close monitoring column"
         onClick={onClose}
       >
         <TbLayoutSidebarRightCollapse size={20} />
-      </ActionIcon>
+      </Button>
     </ControlsBar>
   );
 }

--- a/clients/web/src/components/groups/MonitoringControls/MonitoringControls.tsx
+++ b/clients/web/src/components/groups/MonitoringControls/MonitoringControls.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, SegmentedControl, TextInput } from "@mantine/core";
+import { ActionIcon, Group, SegmentedControl, TextInput } from "@mantine/core";
 import { TbLayoutSidebarRightCollapse } from "react-icons/tb";
 import { ClearButton } from "../../elements/ClearButton/ClearButton";
 
@@ -69,14 +69,14 @@ export function MonitoringControls({
           ) : null
         }
       />
-      <Button
-        size="sm"
+      <ActionIcon
         variant="subtle"
+        size={36}
         aria-label="Close monitoring column"
         onClick={onClose}
       >
         <TbLayoutSidebarRightCollapse size={20} />
-      </Button>
+      </ActionIcon>
     </ControlsBar>
   );
 }

--- a/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.tsx
+++ b/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Divider, Stack } from "@mantine/core";
 import { MonitoringControls } from "../MonitoringControls/MonitoringControls";
+import { ScreenStage } from "../../elements/ScreenStage/ScreenStage";
 
 export interface MonitoringScreenProps {
   /** Available monitor tabs (Logs/Protocol/Network, filtered by capability). */
@@ -26,7 +27,10 @@ const ColumnLayout = Stack.withProps({
   gap: 0,
 });
 
+// Relative-positioned host so each tab's `ScreenStage` (absolutely positioned)
+// can cross-fade over it. `mih: 0` lets the inner ScrollArea bound its height.
 const ScreenSlot = Stack.withProps({
+  pos: "relative",
   flex: 1,
   mih: 0,
   gap: 0,
@@ -57,7 +61,13 @@ export function MonitoringScreen({
         onClose={onClose}
       />
       <Divider />
-      <ScreenSlot>{screens[value]}</ScreenSlot>
+      <ScreenSlot>
+        {tabs.map((tab) => (
+          <ScreenStage key={tab} active={tab === value} fill>
+            {screens[tab]}
+          </ScreenStage>
+        ))}
+      </ScreenSlot>
     </ColumnLayout>
   );
 }

--- a/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.tsx
+++ b/clients/web/src/components/groups/MonitoringScreen/MonitoringScreen.tsx
@@ -6,7 +6,8 @@ import { ScreenStage } from "../../elements/ScreenStage/ScreenStage";
 export interface MonitoringScreenProps {
   /** Available monitor tabs (Logs/Protocol/Network, filtered by capability). */
   tabs: string[];
-  /** Active monitor tab; keys into `screens` to pick what renders below. */
+  /** Active monitor tab; the matching screen is the mounted one below (the rest
+   *  are cross-faded out via `ScreenStage`). */
   value: string;
   onChange: (tab: string) => void;
   /** Search text for the active screen; wired by the caller to its filter state. */
@@ -38,8 +39,9 @@ const ScreenSlot = Stack.withProps({
 
 /**
  * The pinned monitoring column's content (#1616): a `MonitoringControls` tab row
- * over the currently-selected monitor screen. Layout-only — it renders whichever
- * embedded screen node the caller supplies for the active tab.
+ * over the selected monitor screen. Layout-only — it wraps each supplied screen
+ * node in a `ScreenStage`, so switching tabs cross-fades (only the active tab's
+ * screen is mounted) the same way the primary pane does.
  */
 export function MonitoringScreen({
   tabs,

--- a/clients/web/src/components/groups/ServerListControls/ServerListControls.test.tsx
+++ b/clients/web/src/components/groups/ServerListControls/ServerListControls.test.tsx
@@ -24,6 +24,31 @@ describe("ServerListControls", () => {
     ).toBeInTheDocument();
   });
 
+  it("hides the open-monitor button unless onOpenMonitor is provided", () => {
+    renderWithMantine(<ServerListControls {...baseProps} serverCount={2} />);
+    expect(
+      screen.queryByRole("button", { name: "Open monitoring column" }),
+    ).toBeNull();
+  });
+
+  it("shows and wires the open-monitor button when onOpenMonitor is provided", async () => {
+    const user = userEvent.setup();
+    const onOpenMonitor = vi.fn();
+    renderWithMantine(
+      <ServerListControls
+        {...baseProps}
+        serverCount={2}
+        onOpenMonitor={onOpenMonitor}
+      />,
+    );
+    const openBtn = screen.getByRole("button", {
+      name: "Open monitoring column",
+    });
+    expect(openBtn).toBeInTheDocument();
+    await user.click(openBtn);
+    expect(onOpenMonitor).toHaveBeenCalledTimes(1);
+  });
+
   it("shows the list toggle alongside Export + Add Servers when servers exist", () => {
     renderWithMantine(<ServerListControls {...baseProps} serverCount={2} />);
     expect(screen.getAllByRole("button")).toHaveLength(3);

--- a/clients/web/src/components/groups/ServerListControls/ServerListControls.test.tsx
+++ b/clients/web/src/components/groups/ServerListControls/ServerListControls.test.tsx
@@ -39,8 +39,9 @@ describe("ServerListControls", () => {
         onToggleList={onToggleList}
       />,
     );
-    const buttons = screen.getAllByRole("button");
-    await user.click(buttons[0]);
+    await user.click(
+      screen.getByRole("button", { name: /Expand all|Collapse all/ }),
+    );
     expect(onToggleList).toHaveBeenCalledTimes(1);
   });
 

--- a/clients/web/src/components/groups/ServerListControls/ServerListControls.tsx
+++ b/clients/web/src/components/groups/ServerListControls/ServerListControls.tsx
@@ -27,9 +27,6 @@ export function ServerListControls({
 }: ServerListControlsProps) {
   return (
     <Group justify="flex-end">
-      {serverCount > 0 && (
-        <ListToggle compact={compact} onToggle={onToggleList} />
-      )}
       <Button variant="default" onClick={onExport} disabled={serverCount === 0}>
         Export
       </Button>
@@ -39,6 +36,9 @@ export function ServerListControls({
           onImportConfig={onImportConfig}
           onImportServerJson={onImportServerJson}
         />
+      )}
+      {serverCount > 0 && (
+        <ListToggle compact={compact} onToggle={onToggleList} />
       )}
     </Group>
   );

--- a/clients/web/src/components/groups/ServerListControls/ServerListControls.tsx
+++ b/clients/web/src/components/groups/ServerListControls/ServerListControls.tsx
@@ -1,5 +1,6 @@
 import { Button, Group } from "@mantine/core";
 import { ListToggle } from "../../elements/ListToggle/ListToggle";
+import { PinColumnButton } from "../../elements/PinColumnButton/PinColumnButton";
 import {
   ServerAddMenu,
   type AddServerMenuProps,
@@ -13,6 +14,12 @@ export interface ServerListControlsProps extends AddServerMenuProps {
   onExport: () => void;
   /** When false (read-only session), the Add menu is hidden. Defaults to true. */
   writable?: boolean;
+  /**
+   * Open the monitoring column. Provided (by the caller) only when a server is
+   * connected, the column can open, and it isn't already shown — otherwise
+   * omitted so the open-sidebar affordance is hidden.
+   */
+  onOpenMonitor?: () => void;
 }
 
 export function ServerListControls({
@@ -24,6 +31,7 @@ export function ServerListControls({
   onImportServerJson,
   onExport,
   writable = true,
+  onOpenMonitor,
 }: ServerListControlsProps) {
   return (
     <Group justify="flex-end">
@@ -39,6 +47,9 @@ export function ServerListControls({
       )}
       {serverCount > 0 && (
         <ListToggle compact={compact} onToggle={onToggleList} />
+      )}
+      {onOpenMonitor && (
+        <PinColumnButton onPin={onOpenMonitor} label="Open monitoring column" />
       )}
     </Group>
   );

--- a/clients/web/src/components/groups/ServerListControls/ServerListControls.tsx
+++ b/clients/web/src/components/groups/ServerListControls/ServerListControls.tsx
@@ -34,7 +34,9 @@ export function ServerListControls({
   onOpenMonitor,
 }: ServerListControlsProps) {
   return (
-    <Group justify="flex-end">
+    // `gap="sm"` matches the header's control spacing (its RightSection group),
+    // so these buttons sit the same distance apart as the header icons.
+    <Group justify="flex-end" gap="sm">
       <Button variant="default" onClick={onExport} disabled={serverCount === 0}>
         Export
       </Button>

--- a/clients/web/src/components/groups/TaskListPanel/TaskListPanel.test.tsx
+++ b/clients/web/src/components/groups/TaskListPanel/TaskListPanel.test.tsx
@@ -169,13 +169,12 @@ describe("TaskListPanel", () => {
       screen.getAllByRole("button", { name: "Collapse" }).length,
     ).toBeGreaterThan(0);
 
-    const buttons = screen.getAllByRole("button");
-    const toggle = buttons.find(
-      (b) =>
-        b.textContent === "" && b.classList.contains("mantine-Button-root"),
-    );
-    expect(toggle).toBeDefined();
-    await user.click(toggle!);
+    // The ListToggle is labelled "Collapse all" / "Expand all" — distinct from
+    // the per-entry "Collapse" / "Expand" buttons.
+    const toggle = screen.getByRole("button", {
+      name: /Collapse all|Expand all/,
+    });
+    await user.click(toggle);
 
     // After toggle, entries collapsed — they show Expand
     expect(

--- a/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
+++ b/clients/web/src/components/screens/ServerListScreen/ServerListScreen.tsx
@@ -67,6 +67,12 @@ export interface ServerListScreenProps {
   onClearHighlight?: (id: string) => void;
   compact: boolean;
   onToggleCompact: () => void;
+  /**
+   * Open the monitoring column. Provided only when a server is connected, the
+   * column can open, and it isn't already shown; forwarded to the controls to
+   * reveal an open-sidebar button beside the list toggle.
+   */
+  onOpenMonitor?: () => void;
 }
 
 const PageContainer = Stack.withProps({
@@ -99,6 +105,7 @@ export function ServerListScreen({
   onClearHighlight,
   compact,
   onToggleCompact,
+  onOpenMonitor,
 }: ServerListScreenProps) {
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -196,6 +203,7 @@ export function ServerListScreen({
         onImportConfig={onImportConfig}
         onImportServerJson={onImportServerJson}
         onExport={onExport}
+        onOpenMonitor={onOpenMonitor}
       />
 
       <ScrollArea.Autosize

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -850,6 +850,10 @@ export function InspectorView({
   // column. Gated by `canPin` so the pin affordance only appears when a click
   // would actually take effect (wide + connected).
   const canPin = !!isWide && connected;
+  // Offer an "open monitoring column" affordance on the server list when a
+  // connected server has monitor screens to show but the column isn't open yet.
+  const canOpenMonitor =
+    canPin && monitorAvailable.length > 0 && !effectivePinned;
   function pinMonitor(tab: MonitorTab) {
     setMonitorTab(tab);
     setMonitorPinned(true);
@@ -1068,6 +1072,11 @@ export function InspectorView({
                 onClearHighlight={onClearHighlight}
                 compact={serversCompact}
                 onToggleCompact={() => setServersCompact((c) => !c)}
+                onOpenMonitor={
+                  canOpenMonitor
+                    ? () => pinMonitor(effectiveMonitorTab)
+                    : undefined
+                }
               />
             </ScreenStage>
             <ScreenStage active={activeTab === "Tools"}>

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -8,7 +8,6 @@ import {
 } from "react";
 import {
   AppShell,
-  Box,
   Flex,
   Group,
   Stack,
@@ -84,6 +83,7 @@ import {
   type ConsoleUiState,
 } from "../../screens/ConsoleScreen/ConsoleScreen";
 import type { SortDirection } from "../../elements/SortToggle/SortToggle";
+import { ScreenStage } from "../../elements/ScreenStage/ScreenStage";
 import { MonitoringScreen } from "../../groups/MonitoringScreen/MonitoringScreen";
 import { ResizeHandle } from "../../elements/ResizeHandle/ResizeHandle";
 import { getServerType } from "@inspector/core/mcp/config.js";
@@ -241,9 +241,6 @@ function serializeMonitorWidth(value: number): string {
   return String(value);
 }
 
-const SCREEN_ENTER_MS = 350;
-const SCREEN_EXIT_MS = 250;
-
 // Relative-positioned wrapper for the absolutely-positioned `ScreenStage`
 // children. `mih: "100%"` requires `AppShell.Main` to provide a definite
 // height for the stack itself to fill — the absolute children render
@@ -305,36 +302,6 @@ const MonitorColumnGroup = Group.withProps({
   h: "100%",
   flex: "0 0 auto",
 });
-
-// Wraps each screen in a Mantine Transition. With Transition's default
-// (`keepMounted={false}`), the outgoing screen unmounts after its exit
-// animation — any local screen state (search filters, scroll position,
-// expanded sections) is reset on tab switch.
-function ScreenStage({
-  active,
-  children,
-}: {
-  active: boolean;
-  children: ReactNode;
-}) {
-  return (
-    <Transition
-      mounted={active}
-      transition="fade-up"
-      duration={SCREEN_ENTER_MS}
-      exitDuration={SCREEN_EXIT_MS}
-      timingFunction="ease"
-    >
-      {(styles) => (
-        // `style={styles}` is the runtime transition state from Mantine's
-        // Transition API — these are interpolated values, not static styling.
-        <Box style={styles} pos="absolute" top={0} left={0} right={0}>
-          {children}
-        </Box>
-      )}
-    </Transition>
-  );
-}
 
 export interface InspectorViewProps {
   // Server list (static config; runtime connection state comes from the

--- a/clients/web/src/test/core/react/useInspectorVersion.test.tsx
+++ b/clients/web/src/test/core/react/useInspectorVersion.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Tests for useInspectorVersion — runs in happy-dom under the unit project. Uses
+ * a controlled fake `fetch` so each branch (present / absent / non-string / HTTP
+ * error / network throw / post-unmount guards) and the auth header are asserted
+ * directly. Mirrors useSandboxUrl's test (same `/api/config` fetch shape).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useInspectorVersion } from "@inspector/core/react/useInspectorVersion";
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 401,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("useInspectorVersion", () => {
+  it("starts loading, then resolves the version from the config payload", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ version: "2.0.0" }));
+
+    const { result } = renderHook(() =>
+      useInspectorVersion({ baseUrl: "http://test.local", fetchFn }),
+    );
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.version).toBeUndefined();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.version).toBe("2.0.0");
+  });
+
+  it("sends the bearer auth header when a token is provided", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({}));
+
+    renderHook(() =>
+      useInspectorVersion({
+        baseUrl: "http://test.local/",
+        authToken: "secret-token",
+        fetchFn,
+      }),
+    );
+
+    await waitFor(() => expect(fetchFn).toHaveBeenCalled());
+    const [url, init] = fetchFn.mock.calls[0];
+    // Trailing slash on baseUrl is normalized away.
+    expect(url).toBe("http://test.local/api/config");
+    expect(init.method).toBe("GET");
+    expect(init.headers["x-mcp-remote-auth"]).toBe("Bearer secret-token");
+  });
+
+  it("omits the auth header when no token is provided", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({}));
+
+    renderHook(() =>
+      useInspectorVersion({ baseUrl: "http://test.local", fetchFn }),
+    );
+
+    await waitFor(() => expect(fetchFn).toHaveBeenCalled());
+    const [, init] = fetchFn.mock.calls[0];
+    expect(init.headers["x-mcp-remote-auth"]).toBeUndefined();
+  });
+
+  it("leaves version undefined when the payload omits it", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ defaultEnvironment: {} }));
+
+    const { result } = renderHook(() =>
+      useInspectorVersion({ baseUrl: "http://test.local", fetchFn }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.version).toBeUndefined();
+  });
+
+  it("leaves version undefined when the field is not a usable string", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ version: "" }));
+
+    const { result } = renderHook(() =>
+      useInspectorVersion({ baseUrl: "http://test.local", fetchFn }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.version).toBeUndefined();
+  });
+
+  it("leaves version undefined on a non-ok response", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ version: "9.9.9" }, false));
+
+    const { result } = renderHook(() =>
+      useInspectorVersion({ baseUrl: "http://test.local", fetchFn }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.version).toBeUndefined();
+  });
+
+  it("leaves version undefined when the fetch throws", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() =>
+      useInspectorVersion({ baseUrl: "http://test.local", fetchFn }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.version).toBeUndefined();
+  });
+
+  it("falls back to globalThis.fetch when no fetchFn is provided", async () => {
+    const globalFetch = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ version: "3.1.4" }));
+    const original = globalThis.fetch;
+    globalThis.fetch = globalFetch as unknown as typeof fetch;
+    try {
+      const { result } = renderHook(() =>
+        useInspectorVersion({ baseUrl: "http://test.local" }),
+      );
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(globalFetch).toHaveBeenCalledWith(
+        "http://test.local/api/config",
+        expect.objectContaining({ method: "GET" }),
+      );
+      expect(result.current.version).toBe("3.1.4");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("drops a response that resolves after unmount (no state update)", async () => {
+    let resolveFetch: ((r: Response) => void) | undefined;
+    const fetchFn = vi.fn().mockReturnValue(
+      new Promise<Response>((r) => {
+        resolveFetch = r;
+      }),
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useInspectorVersion({ baseUrl: "http://test.local", fetchFn }),
+    );
+    expect(result.current.loading).toBe(true);
+
+    unmount();
+    resolveFetch?.(jsonResponse({ version: "2.0.0" }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.current.version).toBeUndefined();
+  });
+
+  it("drops a response whose json resolves after unmount", async () => {
+    let resolveJson: ((v: unknown) => void) | undefined;
+    const res = {
+      ok: true,
+      status: 200,
+      json: () =>
+        new Promise((r) => {
+          resolveJson = r;
+        }),
+    } as unknown as Response;
+    const fetchFn = vi.fn().mockResolvedValue(res);
+
+    const { result, unmount } = renderHook(() =>
+      useInspectorVersion({ baseUrl: "http://test.local", fetchFn }),
+    );
+    await waitFor(() => expect(fetchFn).toHaveBeenCalled());
+    await Promise.resolve();
+
+    unmount();
+    resolveJson?.({ version: "2.0.0" });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.current.version).toBeUndefined();
+  });
+});

--- a/clients/web/src/test/integration/node/version.test.ts
+++ b/clients/web/src/test/integration/node/version.test.ts
@@ -11,6 +11,7 @@ import { join, dirname } from "path";
 import { pathToFileURL, fileURLToPath } from "url";
 import {
   readInspectorVersion,
+  readInspectorVersionSafe,
   ROOT_PACKAGE_NAME,
 } from "@inspector/core/node/version.js";
 
@@ -65,5 +66,21 @@ describe("readInspectorVersion", () => {
     } finally {
       rmSync(work, { recursive: true, force: true });
     }
+  });
+});
+
+describe("readInspectorVersionSafe", () => {
+  it("returns the version when the root manifest resolves", () => {
+    expect(readInspectorVersionSafe(import.meta.url)).toBe(readRootVersion());
+  });
+
+  it("returns undefined instead of throwing when the root can't be resolved", () => {
+    // A caller rooted in the OS temp dir (outside the repo) has no inspector
+    // root manifest above it — readInspectorVersion would throw, but the safe
+    // variant swallows it so a cosmetic version read never crashes the caller.
+    const callerUrl = pathToFileURL(
+      join(tmpdir(), "nowhere", "caller.js"),
+    ).href;
+    expect(readInspectorVersionSafe(callerUrl)).toBeUndefined();
   });
 });

--- a/clients/web/src/test/integration/server/web-server-config.test.ts
+++ b/clients/web/src/test/integration/server/web-server-config.test.ts
@@ -260,6 +260,12 @@ describe("webServerConfigToInitialPayload", () => {
     expect(payload.defaultTransport).toBeUndefined();
   });
 
+  it("tags the payload with the single-source Inspector version", () => {
+    // Read from the root package.json via readInspectorVersion() at module load.
+    const payload = webServerConfigToInitialPayload(baseConfig());
+    expect(payload.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
   it("emits stdio defaults when initialMcpConfig.type === 'stdio'", () => {
     const cfg = baseConfig();
     cfg.initialMcpConfig = {

--- a/clients/web/src/test/setup.ts
+++ b/clients/web/src/test/setup.ts
@@ -57,6 +57,32 @@ Object.defineProperty(globalThis, "fetch", {
     ),
 });
 
+// happy-dom doesn't implement `matchMedia`, so Mantine's `useReducedMotion`
+// resolves to "motion allowed" and every `Transition` (ScreenStage, Modal, …)
+// schedules real enter/exit `setTimeout`s. A timer that outlives its test fires
+// after the environment is torn down and throws `window is not defined` from
+// deep in react-dom — an unhandled error that fails the run even though every
+// test passed. Report `prefers-reduced-motion: reduce` so Mantine transitions
+// render instantly (no timers); all other queries stay `false`, matching the
+// prior (absent-matchMedia) behavior so `useMediaQuery`-driven layout is
+// unchanged. Tests that need specific media results still mock `@mantine/hooks`
+// or stub `matchMedia` themselves.
+Object.defineProperty(window, "matchMedia", {
+  configurable: true,
+  writable: true,
+  value: (query: string): MediaQueryList =>
+    ({
+      matches: /prefers-reduced-motion/.test(query),
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList,
+});
+
 afterEach(() => {
   cleanup();
   window.localStorage.clear();

--- a/clients/web/src/theme/Text.ts
+++ b/clients/web/src/theme/Text.ts
@@ -37,6 +37,23 @@ export const ThemeText = Text.extend({
         },
       };
     }
+    // A small, unobtrusive build-version label pinned to the lower-right corner
+    // of the screen (#1639): grey, non-interactive (clicks pass through), and
+    // out of the tab/selection flow so it never interferes with the UI beneath.
+    if (props.variant === "versionBadge") {
+      return {
+        root: {
+          position: "fixed",
+          bottom: "0.35rem",
+          right: "0.6rem",
+          zIndex: 100,
+          color: "var(--inspector-text-secondary)",
+          fontSize: "var(--mantine-font-size-xs)",
+          pointerEvents: "none",
+          userSelect: "none",
+        },
+      };
+    }
     return { root: {} };
   },
 });

--- a/clients/web/src/theme/Text.ts
+++ b/clients/web/src/theme/Text.ts
@@ -37,15 +37,29 @@ export const ThemeText = Text.extend({
         },
       };
     }
-    // A small, unobtrusive build-version label pinned to the lower-right corner
-    // of the screen (#1639): grey, non-interactive (clicks pass through), and
-    // out of the tab/selection flow so it never interferes with the UI beneath.
-    if (props.variant === "versionBadge") {
+    // Two small, unobtrusive labels pinned to the bottom corners of the screen
+    // on the same row (#1639): the build version (bottom-left) and the
+    // copyright notice (bottom-right). Each occupies the full-height `xl` bottom
+    // margin band (`height: xl` + flex centering) so the text sits vertically
+    // centered in it, and insets by `xl` horizontally to line up with the
+    // content's left/right margins. Both are grey, non-interactive (clicks pass
+    // through), and out of the tab/selection flow.
+    if (
+      props.variant === "versionBadge" ||
+      props.variant === "copyrightBadge"
+    ) {
+      const horizontal =
+        props.variant === "versionBadge"
+          ? { left: "var(--mantine-spacing-xl)" }
+          : { right: "var(--mantine-spacing-xl)" };
       return {
         root: {
           position: "fixed",
-          bottom: "0.35rem",
-          right: "0.6rem",
+          bottom: 0,
+          height: "var(--mantine-spacing-xl)",
+          display: "flex",
+          alignItems: "center",
+          ...horizontal,
           zIndex: 100,
           color: "var(--inspector-text-secondary)",
           fontSize: "var(--mantine-font-size-xs)",

--- a/core/mcp/remote/node/server.ts
+++ b/core/mcp/remote/node/server.ts
@@ -91,6 +91,12 @@ export interface InitialConfigPayload {
    * shows catalog CRUD affordances.
    */
   writable?: boolean;
+  /**
+   * The Inspector version (from the root `package.json`), so the browser — which
+   * can't read the filesystem the way the CLI/TUI do — can display it. Absent on
+   * a legacy backend that predates the field; the UI just shows nothing then.
+   */
+  version?: string;
 }
 
 export interface RemoteServerOptions {

--- a/core/node/version.ts
+++ b/core/node/version.ts
@@ -64,3 +64,23 @@ export function readInspectorVersion(callerUrl: string): string {
     `Could not locate the ${ROOT_PACKAGE_NAME} root package.json above ${startDir}`,
   );
 }
+
+/**
+ * Non-throwing variant of {@link readInspectorVersion}: returns `undefined`
+ * instead of throwing when the root manifest can't be resolved. For callers
+ * where the version is cosmetic (e.g. the web backend surfacing it to the
+ * browser) — a resolution failure should hide the version, not take the caller
+ * down at startup.
+ *
+ * @param callerUrl the calling module's `import.meta.url`
+ * @returns the root version, or `undefined` if it can't be resolved
+ */
+export function readInspectorVersionSafe(
+  callerUrl: string,
+): string | undefined {
+  try {
+    return readInspectorVersion(callerUrl);
+  } catch {
+    return undefined;
+  }
+}

--- a/core/react/useInspectorVersion.ts
+++ b/core/react/useInspectorVersion.ts
@@ -1,0 +1,83 @@
+/**
+ * React hook over the `GET /api/config` endpoint that recovers the Inspector
+ * `version` the backend reads from the root `package.json`. The browser can't
+ * read the filesystem the way the CLI/TUI do, so the version is delivered on the
+ * config payload (see `webServerConfigToInitialPayload`) and surfaced here.
+ *
+ * Mirrors {@link useSandboxUrl} / {@link useServerListWritable} (same
+ * `/api/config` source, same fetch shape). `version` is `undefined` until the
+ * fetch resolves, and stays `undefined` if the backend omits it (a legacy
+ * backend that predates the field) — the UI simply renders nothing then.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface UseInspectorVersionOptions {
+  /** Base URL of the remote server (typically `window.location.origin`). */
+  baseUrl: string;
+  /** Optional auth token for the `x-mcp-remote-auth` header. */
+  authToken?: string;
+  /** Fetch function to use (default: globalThis.fetch). Useful in tests. */
+  fetchFn?: typeof fetch;
+}
+
+export interface UseInspectorVersionResult {
+  /** The Inspector version, or undefined when unavailable / not yet loaded. */
+  version: string | undefined;
+  /** True while the initial fetch is in flight. */
+  loading: boolean;
+}
+
+/** Minimal shape we read from the `/api/config` payload. */
+interface ConfigPayload {
+  version?: unknown;
+}
+
+export function useInspectorVersion(
+  opts: UseInspectorVersionOptions,
+): UseInspectorVersionResult {
+  const { baseUrl, authToken, fetchFn } = opts;
+  const doFetch = fetchFn ?? globalThis.fetch;
+  const base = baseUrl.replace(/\/$/, "");
+
+  const [version, setVersion] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  const load = useCallback(
+    async (isCancelled: () => boolean): Promise<void> => {
+      const headers: Record<string, string> = {};
+      if (authToken) headers["x-mcp-remote-auth"] = `Bearer ${authToken}`;
+      try {
+        const res = await doFetch(`${base}/api/config`, {
+          method: "GET",
+          headers,
+        });
+        if (isCancelled() || !res.ok) return;
+        const body = (await res.json()) as ConfigPayload;
+        if (isCancelled()) return;
+        // Tolerate a missing/non-string field — a legacy backend that omits it
+        // leaves the version hidden rather than showing a bogus value.
+        setVersion(
+          typeof body.version === "string" && body.version
+            ? body.version
+            : undefined,
+        );
+      } catch {
+        // Network error / aborted fetch: leave version undefined (hidden).
+      } finally {
+        if (!isCancelled()) setLoading(false);
+      }
+    },
+    [base, authToken, doFetch],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void load(() => cancelled);
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  return { version, loading };
+}


### PR DESCRIPTION
Closes #1642
Closes #1639

Re-targeted continuation of #1641 (which GitHub auto-closed when its stacked base branch `1636-v2-publish-bundle` was deleted on #1637's merge). Same head branch, same commits — now based directly on `v2/main` (which already contains #1637's shared `readInspectorVersion()` reader). All review feedback from #1641 is already addressed here.

Web UI polish batch (umbrella #1642), including the version display (#1639):

- **Version display (#1639)** — Inspector version (root `package.json`) in the footer, via the backend's `GET /api/config` + a `useInspectorVersion` hook + `VersionBadge`. Backend uses the non-throwing `readInspectorVersionSafe()` so a resolution failure hides the badge rather than crashing.
- **Footer copyright** — grey copyright bottom-right, version bottom-left, centered in the `xl` band and aligned to the content margins.
- **Toolbar** — list toggle moved right of "Add Servers"; the toggle / open-close-monitoring icons are `ActionIcon size={36}` matching the header's theme/settings icons in both width and `sm` spacing.
- **Monitoring column** — its screens use the shared `ScreenStage` `fade-up` cross-fade (same as the primary pane); an "open monitoring column" button appears on the server list when connected + column closed.
- **Test infra** — `matchMedia` mocked to `prefers-reduced-motion: reduce` so Mantine transition timers don't leak past teardown.

> ⚠️ Targets `v2/main` (non-default branch), so `Closes` keywords are cross-references only — close #1639 / #1642 and move their board cards to Done manually on merge, per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
