### PR TITLE
Make sidebar lists, monitor panels, and Tools placeholder fill available height (#1663)

### DIFF
--- a/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
+++ b/clients/web/src/components/groups/NetworkStreamPanel/NetworkStreamPanel.tsx
@@ -34,10 +34,17 @@ const PanelContainer = Paper.withProps({
   variant: "panel",
 });
 
+// Centered in the full-height panel so the empty message sits mid-panel rather
+// than clinging to the top of an otherwise-empty box (matches LogStreamPanel).
+const EmptyCenter = Stack.withProps({
+  flex: 1,
+  align: "center",
+  justify: "center",
+});
+
 const EmptyState = Text.withProps({
   c: "dimmed",
   ta: "center",
-  py: "xl",
 });
 
 function formatTitle(count: number): string {
@@ -133,7 +140,9 @@ export function NetworkStreamPanel({
       </Group>
 
       {!hasResults ? (
-        <EmptyState>No network requests</EmptyState>
+        <EmptyCenter>
+          <EmptyState>No network requests</EmptyState>
+        </EmptyCenter>
       ) : (
         <EmbeddableScrollArea
           embedded={embedded}

--- a/clients/web/src/components/groups/PromptControls/PromptControls.tsx
+++ b/clients/web/src/components/groups/PromptControls/PromptControls.tsx
@@ -17,9 +17,6 @@ export interface PromptControlsProps {
   onSelectPrompt: (name: string) => void;
 }
 
-const LIST_MAX_HEIGHT =
-  "calc(100vh - var(--app-shell-header-height, 0px) - var(--mantine-spacing-xl) * 2 - 160px)";
-
 export function PromptControls({
   prompts,
   selectedName,
@@ -39,7 +36,10 @@ export function PromptControls({
   );
 
   return (
-    <Stack gap="sm">
+    // Fill the full-height `sidebar` Card (a flex column) so the list runs to the
+    // bottom of the card before it scrolls, instead of being capped short by a
+    // fixed max-height. `mih: 0` lets the scroll child shrink and scroll.
+    <Stack gap="sm" flex={1} mih={0}>
       <Group justify="space-between">
         <Title order={4}>Prompts</Title>
         <ListChangedIndicator visible={listChanged} onRefresh={onRefreshList} />
@@ -53,7 +53,7 @@ export function PromptControls({
           searchText ? <ClearButton onClick={() => onSearchChange("")} /> : null
         }
       />
-      <ScrollArea.Autosize viewportRef={viewportRef} mah={LIST_MAX_HEIGHT}>
+      <ScrollArea viewportRef={viewportRef} flex={1} mih={0} type="auto">
         <Stack gap="xs">
           {filteredPrompts.map((prompt) => (
             <PromptListItem
@@ -66,7 +66,7 @@ export function PromptControls({
             />
           ))}
         </Stack>
-      </ScrollArea.Autosize>
+      </ScrollArea>
     </Stack>
   );
 }

--- a/clients/web/src/components/groups/ProtocolListPanel/ProtocolListPanel.tsx
+++ b/clients/web/src/components/groups/ProtocolListPanel/ProtocolListPanel.tsx
@@ -54,10 +54,17 @@ const PanelContainer = Paper.withProps({
   variant: "panel",
 });
 
+// Centered in the full-height panel so the empty message sits mid-panel rather
+// than clinging to the top of an otherwise-empty box (matches LogStreamPanel).
+const EmptyCenter = Stack.withProps({
+  flex: 1,
+  align: "center",
+  justify: "center",
+});
+
 const EmptyState = Text.withProps({
   c: "dimmed",
   ta: "center",
-  py: "xl",
 });
 
 // The section header is a single "pleat" bar (rounded, with the filter-button
@@ -293,7 +300,9 @@ export function ProtocolListPanel({
       </Group>
 
       {!hasResults ? (
-        <EmptyState>No request history</EmptyState>
+        <EmptyCenter>
+          <EmptyState>No request history</EmptyState>
+        </EmptyCenter>
       ) : (
         <EmbeddableScrollArea embedded={embedded} viewportRef={viewportRef}>
           <Stack gap="md">

--- a/clients/web/src/components/groups/ToolControls/ToolControls.tsx
+++ b/clients/web/src/components/groups/ToolControls/ToolControls.tsx
@@ -17,9 +17,6 @@ export interface ToolControlsProps {
   onSelectTool: (name: string) => void;
 }
 
-const LIST_MAX_HEIGHT =
-  "calc(100vh - var(--app-shell-header-height, 0px) - var(--mantine-spacing-xl) * 2 - 160px)";
-
 export function ToolControls({
   tools,
   selectedName,
@@ -40,7 +37,12 @@ export function ToolControls({
     : tools;
 
   return (
-    <Stack gap="sm">
+    // Fill the full-height `sidebar` Card (a flex column) so the scroll region
+    // below claims all the remaining space under the fixed title/search — the
+    // list runs to the bottom of the card before it scrolls, instead of being
+    // capped short by a fixed max-height. `mih: 0` lets the scroll child shrink
+    // and scroll rather than overflow the card.
+    <Stack gap="sm" flex={1} mih={0}>
       <Group justify="space-between">
         <Title order={4}>Tools</Title>
         <ListChangedIndicator visible={listChanged} onRefresh={onRefreshList} />
@@ -54,7 +56,7 @@ export function ToolControls({
           searchText ? <ClearButton onClick={() => onSearchChange("")} /> : null
         }
       />
-      <ScrollArea.Autosize viewportRef={viewportRef} mah={LIST_MAX_HEIGHT}>
+      <ScrollArea viewportRef={viewportRef} flex={1} mih={0} type="auto">
         <Stack gap="xs">
           {filteredTools.map((tool) => (
             <ToolListItem
@@ -67,7 +69,7 @@ export function ToolControls({
             />
           ))}
         </Stack>
-      </ScrollArea.Autosize>
+      </ScrollArea>
     </Stack>
   );
 }

--- a/clients/web/src/components/screens/ConsoleScreen/ConsoleScreen.tsx
+++ b/clients/web/src/components/screens/ConsoleScreen/ConsoleScreen.tsx
@@ -124,7 +124,10 @@ export function ConsoleScreen({
   }, [entries, filterText, sortDirection]);
 
   return (
-    <ScreenLayout h={embedded ? "100%" : undefined}>
+    // See LoggingScreen: only override `h` when embedded, so the standalone
+    // screen keeps ScreenLayout's default full-screen height (a `h={undefined}`
+    // would clobber it and collapse an empty screen to its controls' height).
+    <ScreenLayout {...(embedded ? { h: "100%" } : {})}>
       {embedded ? null : (
         <Sidebar>
           <SidebarCard>

--- a/clients/web/src/components/screens/LoggingScreen/LoggingScreen.tsx
+++ b/clients/web/src/components/screens/LoggingScreen/LoggingScreen.tsx
@@ -78,7 +78,11 @@ export function LoggingScreen({
   }
 
   return (
-    <ScreenLayout h={embedded ? "100%" : undefined}>
+    // Embedded fills the monitoring sidebar column (100%); standalone keeps the
+    // ScreenLayout's default full-screen height. Passing `h={undefined}` here
+    // would clobber that default (withProps plain-spreads), collapsing an empty
+    // screen to its controls' height — so only override `h` when embedded.
+    <ScreenLayout {...(embedded ? { h: "100%" } : {})}>
       {embedded ? null : (
         <Sidebar>
           <SidebarCard>

--- a/clients/web/src/components/screens/NetworkScreen/NetworkScreen.tsx
+++ b/clients/web/src/components/screens/NetworkScreen/NetworkScreen.tsx
@@ -84,7 +84,10 @@ export function NetworkScreen({
   }
 
   return (
-    <ScreenLayout h={embedded ? "100%" : undefined}>
+    // See LoggingScreen: only override `h` when embedded, so the standalone
+    // screen keeps ScreenLayout's default full-screen height (a `h={undefined}`
+    // would clobber it and collapse an empty screen to its controls' height).
+    <ScreenLayout {...(embedded ? { h: "100%" } : {})}>
       {embedded ? null : (
         <Sidebar>
           <SidebarCard>

--- a/clients/web/src/components/screens/PromptsScreen/PromptsScreen.tsx
+++ b/clients/web/src/components/screens/PromptsScreen/PromptsScreen.tsx
@@ -69,9 +69,13 @@ const Sidebar = Stack.withProps({
   flex: "0 0 auto",
 });
 
+// `sidebar` variant makes the card a full-height flex column capped at the
+// screen height, so PromptControls' list fills the card and scrolls internally
+// once it overflows (matching the Resources sidebar).
 const SidebarCard = Card.withProps({
   withBorder: true,
   padding: "lg",
+  variant: "sidebar",
 });
 
 const DetailCard = Card.withProps({

--- a/clients/web/src/components/screens/ProtocolScreen/ProtocolScreen.tsx
+++ b/clients/web/src/components/screens/ProtocolScreen/ProtocolScreen.tsx
@@ -104,7 +104,10 @@ export function ProtocolScreen({
   }, [ui, visibleDirections, onUiChange]);
 
   return (
-    <ScreenLayout h={embedded ? "100%" : undefined}>
+    // See LoggingScreen: only override `h` when embedded, so the standalone
+    // screen keeps ScreenLayout's default full-screen height (a `h={undefined}`
+    // would clobber it and collapse an empty screen to its controls' height).
+    <ScreenLayout {...(embedded ? { h: "100%" } : {})}>
       {embedded ? null : (
         <Sidebar>
           <SidebarCard>

--- a/clients/web/src/components/screens/ToolsScreen/ToolsScreen.tsx
+++ b/clients/web/src/components/screens/ToolsScreen/ToolsScreen.tsx
@@ -79,9 +79,13 @@ const Sidebar = Stack.withProps({
   flex: "0 0 auto",
 });
 
+// `sidebar` variant makes the card a full-height flex column capped at the
+// screen height, so ToolControls' list fills the card and scrolls internally
+// once it overflows (matching the Resources sidebar). (#1417)
 const SidebarCard = Card.withProps({
   withBorder: true,
   padding: "lg",
+  variant: "sidebar",
 });
 
 // Column wrapper: stretches to the screen's available height (capped by the
@@ -100,6 +104,15 @@ const ContentCard = Card.withProps({
   withBorder: true,
   padding: "lg",
   variant: "preview",
+});
+
+// Full-height card for the empty placeholder (used with `flex={1}`) so it fills
+// the screen height like the Prompts/Resources placeholders, rather than
+// shrinking to its text. The result/detail states keep the content-sized
+// `ContentCard` (their inner ScrollArea handles overflow).
+const DetailCard = Card.withProps({
+  withBorder: true,
+  padding: "lg",
 });
 
 const EmptyState = Text.withProps({
@@ -160,21 +173,25 @@ export function ToolsScreen({
         </SidebarCard>
       </Sidebar>
 
-      <ContentPane mah={SCROLL_MAX_HEIGHT}>
-        <ContentCard>
-          {callState?.result ? (
-            // Results replace the input form while present, and the panel's
-            // top-left X dismisses them back to the form (#1661) — the Prompts
-            // screen pattern. `formValues` live in the lifted UI state, so the
-            // form is restored intact for a re-run. A call in flight sets a
-            // `pending` state with no `result` (App.tsx), so the executing form
-            // (progress + cancel) shows until the result lands.
+      {callState?.result ? (
+        // Results replace the input form while present, and the panel's top-left
+        // X dismisses them back to the form (#1661) — the Prompts screen pattern.
+        // `formValues` live in the lifted UI state, so the form is restored
+        // intact for a re-run. A call in flight sets a `pending` state with no
+        // `result` (App.tsx), so the executing form (progress + cancel) shows
+        // until the result lands.
+        <ContentPane mah={SCROLL_MAX_HEIGHT}>
+          <ContentCard>
             <ToolResultPanel
               result={callState.result}
               onClear={() => onClearResult?.()}
               onReadResource={onReadResource}
             />
-          ) : selectedTool ? (
+          </ContentCard>
+        </ContentPane>
+      ) : selectedTool ? (
+        <ContentPane mah={SCROLL_MAX_HEIGHT}>
+          <ContentCard>
             <ToolDetailPanel
               tool={selectedTool}
               formValues={formValues}
@@ -193,11 +210,15 @@ export function ToolsScreen({
               }
               onCancel={() => onCancelCall?.()}
             />
-          ) : (
-            <EmptyState>Select a tool to view details</EmptyState>
-          )}
-        </ContentCard>
-      </ContentPane>
+          </ContentCard>
+        </ContentPane>
+      ) : (
+        // Empty placeholder fills the full screen height (like Prompts/Resources)
+        // rather than shrinking to its text.
+        <DetailCard flex={1}>
+          <EmptyState>Select a tool to view details</EmptyState>
+        </DetailCard>
+      )}
     </ScreenLayout>
   );
 }


### PR DESCRIPTION
Closes #1663

Three related "fill the available height" layout fixes to the connected screens.

## 1. Tools & Prompts sidebar lists
`ToolControls` / `PromptControls` were capped by a fixed magic max-height (`calc(100vh − header − xl*2 − 160px)`) that under-estimated the space, so the list stopped short of the card bottom and scrolled early. Migrated both to the pattern the **Resources** sidebar already uses: the screen's sidebar `Card` gets `variant="sidebar"` (full-height flex column, capped at the screen height), and the control's outer `Stack` becomes `flex={1} mih={0}` with a flex-filling `ScrollArea flex={1} mih={0}`. Apps is intentionally left as-is (its sidebar is content-height by design for the iframe pane).

## 2. Monitor screen panels collapse when empty (Logs / Console / Protocol / Network)
The standalone monitor screens passed `h={embedded ? "100%" : undefined}` to `ScreenLayout`. Mantine's `.withProps` plain-spreads (`{...fixed, ...props}`), so `h={undefined}` **clobbered** the component's default `h: calc(100dvh − header)` — the non-embedded screen had no height and collapsed to its content, leaving an empty stream only as tall as its controls sidebar. Now `h` is overridden **only when embedded** (`{...(embedded ? { h: "100%" } : {})}`), so the standalone screen keeps its full-screen height and the panel fills. Also centered the Network/Protocol empty states so the message sits mid-panel like Logs/Console.

## 3. Tools placeholder doesn't fill the container height
The "Select a tool to view details" placeholder rendered inside the content-sized `ContentCard` (`variant="preview"`), so it shrank to its text. Now it renders in a full-height `DetailCard flex={1}` (matching Prompts/Resources); the result/detail states keep the content-sized `ContentCard`.

## Testing
Local `npm run ci` (validate + per-file ≥90% coverage + smokes + Storybook) run before push; unit tests and Storybook play tests pass for every touched screen/panel. These are CSS/layout changes — no behavior change, no new props.

🤖 Generated with [Claude Code](https://claude.com/claude-code)