### PR TITLE
fix: use auth provider's current token instead of a connect-time snapshot

### DIFF
--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -1387,6 +1387,63 @@ describe("useConnection", () => {
     });
   });
 
+  describe("Direct connection OAuth token handling (#1434)", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockSSETransport.options = undefined;
+      mockStreamableHTTPTransport.options = undefined;
+    });
+
+    test("does NOT bake the OAuth provider token into requestInit for direct connections", async () => {
+      // Regression test for #1434: the OAuth token must not be snapshotted into
+      // requestInit at connect time. The SDK's authProvider is the single,
+      // always-current source and refreshes the token on 401; a baked snapshot
+      // shadows the refreshed token and leaves the session stuck on the stale
+      // one after a successful refresh.
+      const directProps = {
+        ...defaultProps,
+        connectionType: "direct" as const,
+      };
+
+      const { result } = renderHook(() => useConnection(directProps));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      const headers = mockSSETransport.options?.requestInit?.headers;
+      // The provider (mocked to return "mock-token") must NOT be baked in.
+      expect(headers).not.toHaveProperty("Authorization");
+      // ...instead the authProvider is wired up so the SDK injects and
+      // refreshes the token per request.
+      expect(mockSSETransport.options?.authProvider).toBeDefined();
+    });
+
+    test("still sends a user-supplied static Authorization header for direct connections", async () => {
+      // A user-provided static Authorization header is an intentional override
+      // of the provider and must still flow through untouched.
+      const customHeaders: CustomHeaders = [
+        { name: "Authorization", value: "Bearer user-token", enabled: true },
+      ];
+
+      const directProps = {
+        ...defaultProps,
+        connectionType: "direct" as const,
+        customHeaders,
+      };
+
+      const { result } = renderHook(() => useConnection(directProps));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      const headers = mockSSETransport.options?.requestInit?.headers;
+      expect(headers).toHaveProperty("Authorization", "Bearer user-token");
+      expect(mockSSETransport.options?.authProvider).toBeDefined();
+    });
+  });
+
   describe("Connection URL Verification", () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -1387,7 +1387,7 @@ describe("useConnection", () => {
     });
   });
 
-  describe("Direct connection OAuth token handling (#1434)", () => {
+  describe("Direct connection OAuth token handling", () => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockSSETransport.options = undefined;

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -590,7 +590,8 @@ export function useConnection({
         // shadow the refreshed token and leave the session permanently sending
         // the stale token after a refresh (#1434). A user-supplied static
         // Authorization header must still override the provider, so only strip
-        // the header here when it was injected from the OAuth provider.
+        // the header here when it was injected from the OAuth provider (the
+        // header we inject is always named exactly "Authorization").
         if (oauthTokenInjected) {
           delete requestHeaders["Authorization"];
         }

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -525,9 +525,17 @@ export function useConnection({
           header.name.trim().toLowerCase() === "authorization",
       );
 
+      // Track whether the Authorization header was injected from the OAuth
+      // provider (as opposed to a user-supplied static header). For direct
+      // connections this token must NOT be baked into requestInit, because the
+      // SDK's authProvider already injects and refreshes it on every request; a
+      // baked connect-time snapshot would shadow the refreshed token (#1434).
+      let oauthTokenInjected = false;
+
       if (needsOAuthToken) {
         const oauthToken = (await serverAuthProvider.tokens())?.access_token;
         if (oauthToken) {
+          oauthTokenInjected = true;
           // Add the OAuth token
           finalHeaders = [
             // Remove any existing Authorization headers with empty tokens
@@ -575,6 +583,17 @@ export function useConnection({
         serverUrl = new URL(sseUrl);
 
         const requestHeaders = { ...headers };
+        // For direct connections the SDK's authProvider is the single,
+        // always-current source of the OAuth Authorization header: it injects
+        // the token on every request and refreshes it on 401. Baking a
+        // connect-time token snapshot into requestInit/the custom fetch would
+        // shadow the refreshed token and leave the session permanently sending
+        // the stale token after a refresh (#1434). A user-supplied static
+        // Authorization header must still override the provider, so only strip
+        // the header here when it was injected from the OAuth provider.
+        if (oauthTokenInjected) {
+          delete requestHeaders["Authorization"];
+        }
         if (mcpSessionId) {
           requestHeaders["mcp-session-id"] = mcpSessionId;
         }
@@ -588,9 +607,13 @@ export function useConnection({
                 url: string | URL | globalThis.Request,
                 init?: RequestInit,
               ) => {
+                // Let the SDK-provided init (which already merges the
+                // provider's fresh Authorization with requestInit.headers)
+                // win over the connect-time snapshot, so a refreshed token is
+                // actually sent (#1434).
                 const response = await fetch(url, {
-                  ...init,
                   headers: requestHeaders,
+                  ...init,
                 });
 
                 // Capture protocol-related headers from response


### PR DESCRIPTION
## Summary

After a successful OAuth token refresh, **direct (non-proxy)** connections keep sending the **old** access token, so the session enters a `401` loop it can't recover from. Once the initial access token expires:

1. `POST /mcp` returns `401`, the SDK refreshes, `POST …/token` (`grant_type=refresh_token`) returns `200`, and the provider stores the new token.
2. The retried `POST /mcp` still carries the **old** `Authorization: Bearer …`, gets another `401`.
3. The SDK's circuit breaker throws **"Server returned 401 after successful authentication"** straight to the UI — no further refresh, no fallback to a fresh login. The session is stuck until the user manually reconnects.

This is rarely hit with a long token TTL, but a short TTL breaks the session at the first expiry. Confirmed against a real OAuth server by hashing (SHA-256, never raw tokens) the token issued by a successful refresh vs. the bearer token sent on the very next request — the retry token was byte-identical to the pre-refresh token and different from the one just issued.

> **Note:** Inspector V2 is under development. This is a V1 **bug fix** for MCP spec compliance.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

### Root cause

When relying on OAuth, `useConnection` read the access token from the provider **once at connection setup** and baked `Authorization: Bearer <token>` into `requestInit.headers` (and the custom `fetch` wrapper's header override).

The transports already receive that same provider as their `authProvider`, so the SDK adds a fresh `Authorization` from it on every request (and refreshes it on `401`). But the SDK's `_commonHeaders()` spreads `requestInit.headers` **after** the provider token:

```js
const headers = {};
if (this._authProvider) {
  const tokens = await this._authProvider.tokens();       // fresh token (post-refresh)
  headers['Authorization'] = `Bearer ${tokens.access_token}`;
}
const extraHeaders = normalizeHeaders(this._requestInit?.headers); // connect-time snapshot
return new Headers({ ...headers, ...extraHeaders });      // ← snapshot wins
```

So the connect-time snapshot always shadowed the provider's current token. The provider *does* store the refreshed token — it just never got used.

### Fix

For direct connections, stop snapshotting the OAuth-provider token into `requestInit`. The provider is the single, always-current source of the token, and the SDK injects and refreshes it per request. Specifically:

- Track whether the `Authorization` header was injected from the OAuth provider (vs. supplied by the user) and, for direct connections, strip that provider-injected header from `requestHeaders` so it isn't baked into `requestInit`.
- A user-supplied **static** `Authorization` custom header still flows through and intentionally overrides the provider.
- Reorder the SSE custom `fetch` wrapper so the SDK-provided `init` (which already carries the fresh, provider-injected token) wins over the connect-time header snapshot, matching the streamable-http wrapper.

The proxy-connection path is intentionally left unchanged in this PR.

This affects connections that use the SDK's OAuth `authProvider` and is independent of the malformed-`Content-Type` fix (#1160).

## Related Issues

Fixes #1434

## Testing

- [ ] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [x] Tested with SSE transport
- [x] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [ ] Manual testing performed

### Test Results and/or Instructions

Added `useConnection.test.tsx` cases asserting that, for **direct** connections:

- the OAuth provider token is **not** baked into `requestInit.headers` (and `authProvider` is wired up so the SDK injects/refreshes it), and
- a user-supplied static `Authorization` header still flows through unchanged.

`npm run prettier-fix`, client `npm run lint`, `tsc --noEmit`, and the full `useConnection.test.tsx` suite (48 tests) pass.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)



---

_AI Generated, Human reviewed_
