### PR TITLE
fix: don't corrupt refresh_token Content-Type on direct connections

### DIFF
--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -1387,10 +1387,53 @@ describe("useConnection", () => {
     });
   });
 
-  describe("Direct connection OAuth token Content-Type (#1160)", () => {
+  describe("Direct connection OAuth token Content-Type", () => {
     beforeEach(() => {
       jest.clearAllMocks();
+      mockSSETransport.options = undefined;
       mockStreamableHTTPTransport.options = undefined;
+    });
+
+    test("does not mutate the shared requestInit headers with a Content-Type", async () => {
+      // Regression test for #1160. The streamable-http custom fetch must not
+      // write a capitalized `Content-Type: application/json` onto the shared
+      // `requestHeaders` object, because that object is also passed as
+      // `requestInit.headers`, which the SDK reuses for OAuth token requests.
+      // If it is mutated here, the token request's own lowercase
+      // `content-type: application/x-www-form-urlencoded` collides (by case)
+      // with it and produces a malformed comma-joined value that strict
+      // servers reject with 415.
+      const directProps = {
+        ...defaultProps,
+        transportType: "streamable-http" as const,
+        connectionType: "direct" as const,
+      };
+
+      const { result } = renderHook(() => useConnection(directProps));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      const customFetch = mockStreamableHTTPTransport.options?.fetch;
+      expect(customFetch).toBeDefined();
+
+      // Issue an ordinary MCP request through the wrapper, exactly as the SDK
+      // would. In the buggy version this mutated the shared requestInit
+      // headers.
+      await customFetch?.("http://test.com/mcp", {
+        method: "POST",
+        headers: new Headers({
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        }),
+      });
+
+      // The connect-time headers baked into requestInit must remain free of a
+      // Content-Type so they cannot corrupt the SDK's token request.
+      expect(
+        mockStreamableHTTPTransport.options?.requestInit?.headers,
+      ).not.toHaveProperty("Content-Type");
     });
 
     // Mirrors the SDK's shared `createFetchWithInit`, which wraps the custom
@@ -1406,12 +1449,9 @@ describe("useConnection", () => {
     };
 
     test("refresh_token request keeps a single application/x-www-form-urlencoded Content-Type", async () => {
-      // Regression test for #1160: the streamable-http custom fetch must not
-      // mutate the shared requestInit headers with a capitalized
-      // `Content-Type: application/json`. If it does, the SDK's token request
-      // (lowercase `content-type: application/x-www-form-urlencoded`) merges
-      // with it by object spread, and the case mismatch yields a malformed
-      // comma-joined `Content-Type` that strict servers reject with 415.
+      // End-to-end evidence for #1160: replays the exact SDK token-request
+      // composition and asserts the Content-Type that ends up on the wire is
+      // not the malformed comma-joined value.
       const directProps = {
         ...defaultProps,
         transportType: "streamable-http" as const,
@@ -1462,9 +1502,9 @@ describe("useConnection", () => {
       );
 
       // Inspect the Content-Type actually put on the wire for the token request.
-      const lastCall = (global.fetch as jest.Mock).mock.calls.at(-1);
+      const calls = (global.fetch as jest.Mock).mock.calls;
       const sentHeaders = new Headers(
-        lastCall?.[1]?.headers as HeadersInit | undefined,
+        calls[calls.length - 1]?.[1]?.headers as HeadersInit | undefined,
       );
       expect(sentHeaders.get("content-type")).toBe(
         "application/x-www-form-urlencoded",

--- a/client/src/lib/hooks/__tests__/useConnection.test.tsx
+++ b/client/src/lib/hooks/__tests__/useConnection.test.tsx
@@ -1387,6 +1387,91 @@ describe("useConnection", () => {
     });
   });
 
+  describe("Direct connection OAuth token Content-Type (#1160)", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockStreamableHTTPTransport.options = undefined;
+    });
+
+    // Mirrors the SDK's shared `createFetchWithInit`, which wraps the custom
+    // `fetch` with the connect-time `requestInit` and is what the SDK uses for
+    // OAuth token requests. See @modelcontextprotocol/sdk shared/transport.ts.
+    const normalizeHeaders = (
+      headers: HeadersInit | undefined,
+    ): Record<string, string> => {
+      if (!headers) return {};
+      if (headers instanceof Headers) return Object.fromEntries(headers);
+      if (Array.isArray(headers)) return Object.fromEntries(headers);
+      return { ...(headers as Record<string, string>) };
+    };
+
+    test("refresh_token request keeps a single application/x-www-form-urlencoded Content-Type", async () => {
+      // Regression test for #1160: the streamable-http custom fetch must not
+      // mutate the shared requestInit headers with a capitalized
+      // `Content-Type: application/json`. If it does, the SDK's token request
+      // (lowercase `content-type: application/x-www-form-urlencoded`) merges
+      // with it by object spread, and the case mismatch yields a malformed
+      // comma-joined `Content-Type` that strict servers reject with 415.
+      const directProps = {
+        ...defaultProps,
+        transportType: "streamable-http" as const,
+        connectionType: "direct" as const,
+      };
+
+      const { result } = renderHook(() => useConnection(directProps));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      const customFetch = mockStreamableHTTPTransport.options?.fetch;
+      const requestInit = mockStreamableHTTPTransport.options?.requestInit;
+      expect(customFetch).toBeDefined();
+
+      // 1) An ordinary MCP request runs first (as the SDK would issue it). In
+      //    the buggy version this mutated the shared requestInit headers.
+      await customFetch?.("http://test.com/mcp", {
+        method: "POST",
+        headers: new Headers({
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        }),
+      });
+
+      // 2) The SDK then issues the refresh_token request through
+      //    createFetchWithInit(customFetch, requestInit).
+      const tokenInit: RequestInit = {
+        method: "POST",
+        body: "grant_type=refresh_token&refresh_token=abc",
+        headers: new Headers({
+          "content-type": "application/x-www-form-urlencoded",
+          accept: "application/json",
+        }),
+      };
+      const mergedInit = {
+        ...requestInit,
+        ...tokenInit,
+        headers: {
+          ...normalizeHeaders(requestInit?.headers),
+          ...normalizeHeaders(tokenInit.headers),
+        },
+      };
+      await customFetch?.(
+        "http://test.com/mcp-oauth/token",
+        mergedInit as RequestInit,
+      );
+
+      // Inspect the Content-Type actually put on the wire for the token request.
+      const lastCall = (global.fetch as jest.Mock).mock.calls.at(-1);
+      const sentHeaders = new Headers(
+        lastCall?.[1]?.headers as HeadersInit | undefined,
+      );
+      expect(sentHeaders.get("content-type")).toBe(
+        "application/x-www-form-urlencoded",
+      );
+    });
+  });
+
   describe("Connection URL Verification", () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -610,9 +610,17 @@ export function useConnection({
                 url: string | URL | globalThis.Request,
                 init?: RequestInit,
               ) => {
-                requestHeaders["Accept"] =
-                  "text/event-stream, application/json";
-                requestHeaders["Content-Type"] = "application/json";
+                // NOTE: do not mutate the shared `requestHeaders` object here.
+                // It is also passed as `requestInit.headers`, and the SDK reuses
+                // that same object for OAuth token requests via
+                // `createFetchWithInit`. Injecting a capitalized
+                // `Content-Type: application/json` would then collide (by case)
+                // with the token request's own lowercase
+                // `content-type: application/x-www-form-urlencoded`, producing a
+                // malformed comma-joined value that a strict server rejects with
+                // 415 before OAuth handling runs (#1160). The SDK already sets
+                // the correct Accept/Content-Type on each MCP request itself, so
+                // `...init` supplies them for the actual message requests.
                 const response = await fetch(url, {
                   headers: requestHeaders,
                   ...init,


### PR DESCRIPTION
## Summary

The **initial** OAuth token exchange (`grant_type=authorization_code`) correctly sends:

```
Content-Type: application/x-www-form-urlencoded
```

But the **refresh** exchange (`grant_type=refresh_token`) — and *only* that one — sends a malformed, comma-joined value:

```
Content-Type: application/json, application/x-www-form-urlencoded
```

That value fails RFC 9110 media-type syntax (it's two media types, not one). A strict server may reject it with `415 Unsupported Media Type` **before** reaching any OAuth-specific handling — e.g. Fastify validates `Content-Type` syntax in the framework layer, ahead of any registered content-type parser. When that happens, the SDK's `auth()` helper receives a non-`OAuthError` failure from the refresh attempt and falls through to a **full interactive re-authorization**, forcing the user to log in again on every token expiry instead of refreshing silently.

Reproduced directly against a real server:

```
curl -X POST https://.../mcp-oauth/token \
  -H "Content-Type: application/json, application/x-www-form-urlencoded" \
  --data "grant_type=refresh_token&refresh_token=..."
→ HTTP 415 {"code":"FST_ERR_CTP_INVALID_MEDIA_TYPE",...}
```

> **Note:** Inspector V2 is under development. This is a V1 **bug fix** for MCP spec compliance.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

### Root cause

This is an Inspector bug, not an SDK bug — the SDK routes both grant types through the same `executeTokenRequest`, which sets exactly `Content-Type: application/x-www-form-urlencoded`.

The streamable-http **direct-connection** custom `fetch` wrapper in `useConnection.ts` mutated the **shared** `requestHeaders` object:

```js
requestHeaders["Content-Type"] = "application/json"; // capitalized
```

That same object is also passed as `requestInit.headers`. The SDK reuses `requestInit` for OAuth token requests via `createFetchWithInit`, which merges the connect-time headers with the token request's own headers using **plain object spread**:

```js
headers: { ...normalizeHeaders(baseInit.headers), ...normalizeHeaders(init.headers) }
//          { "Content-Type": "application/json" }   { "content-type": "application/x-www-form-urlencoded" }
```

Because the keys differ only by case, both survive the spread. The resulting two-entry object is then handed to `fetch()`, whose `Headers` constructor combines same-name headers into a single comma-joined value → `application/json, application/x-www-form-urlencoded`.

(The `authorization_code` exchange happens at connect time, before the wrapper ever mutates `requestHeaders`, which is why only the refresh exchange is affected.)

### Fix

Stop mutating the shared `requestHeaders` in the streamable-http custom `fetch`. `requestInit.headers` no longer carries a capitalized `Content-Type`, so it can no longer pollute token requests.

#### Why dropping these headers is safe for MCP requests

The content-negotiation headers the wrapper used to set were already dead for the actual MCP requests — the SDK sets them itself on every request it routes through the custom `fetch`, and the wrapper forwards them via the `...init` spread (`fetch(url, { headers: requestHeaders, ...init })`, so `init.headers` wins). Verified in `@modelcontextprotocol/sdk` (1.26.0) `client/streamableHttp.js`:

| SDK method | Request | Headers the SDK sets before calling the custom `fetch` |
|---|---|---|
| `send()` | `POST` (JSON-RPC message) | `content-type: application/json` **and** `accept: application/json, text/event-stream` |
| `_startOrAuthSse()` | `GET` (event stream) | `Accept: text/event-stream` |
| terminate | `DELETE` | `_commonHeaders()` only |

`Content-Type` is (correctly) only set on the body-bearing `POST`; the `GET`/`DELETE` requests have no body and therefore no `Content-Type`. In every case the SDK builds these on a `Headers` object it passes as `init.headers`, so `...init` overrides the wrapper's `requestHeaders` for MCP requests — which is exactly why the wrapper's assignment never reached the wire and only leaked into `requestInit`. Dropping it therefore does not change the `Content-Type`/`Accept` sent on any MCP request.

Independent of the stale-token refresh fix (#1434).

## Related Issues

Fixes #1160

## Testing

- [ ] Tested in UI mode
- [ ] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [x] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [ ] Manual testing performed

### Test Results and/or Instructions

Added a `useConnection.test.tsx` regression test that faithfully reproduces the token-request path: it issues an ordinary MCP request through the transport's custom `fetch`, then replays the refresh_token request through the same `createFetchWithInit(customFetch, requestInit)` composition the SDK uses, and asserts the `Content-Type` on the wire is exactly `application/x-www-form-urlencoded`.

Verified the test **fails** on `main` (`Received: "application/json, application/x-www-form-urlencoded"`) and **passes** with the fix. `npm run prettier-fix`, client `npm run lint`, `tsc --noEmit`, and the full `useConnection.test.tsx` suite (47 tests) pass.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)




---

_AI Generated, Human reviewed_
