### PR TITLE
Era-aware connection model & capability gating (#1626)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,7 @@ gh project item-edit --project-id PVT_kwDOCt2Azc4BJVxt --id "$ITEM_ID" --field-i
 - Follow TypeScript best practices and coding standards
 - NEVER use 'any' as a type
 - NEVER suppress error types (e.g., no-unused-vars, no-explicit-any) in the typescript or eslint configuration as a way of satisfying the linter or compiler.
+- AVOID double casts (`as unknown as T`). They erase all type safety and usually signal that the real type is being worked around. Prefer a type guard, a narrower single `as` cast, or fixing the underlying type. When a double cast is genuinely unavoidable (e.g. a documented gap in a third-party type, or bridging a structurally-identical shape TS can't relate), it MUST carry an inline comment justifying why it is safe and why no better option exists — an unjustified `as unknown as` is not acceptable in review.
 - Utilize type annotations and interfaces to improve code clarity and maintainability
 - Leverage TypeScript's type inference and static analysis features for better code quality and refactoring
 - Use type guards and type assertions to handle potential type mismatches and ensure type safety

--- a/clients/cli/src/cli.ts
+++ b/clients/cli/src/cli.ts
@@ -9,6 +9,7 @@ import type {
 import {
   DEFAULT_MAX_FETCH_REQUESTS,
   DEFAULT_TASK_TTL_MS,
+  eraToVersionNegotiation,
 } from "@inspector/core/mcp/types.js";
 import { InspectorClient } from "@inspector/core/mcp/index.js";
 import {
@@ -162,6 +163,11 @@ async function callMethod(
     sample: false,
     elicit: false,
     serverSettings,
+    // Per-server protocol era (SEP §7.8) from mcp.json → SDK versionNegotiation.
+    // Absent era defaults to legacy in the InspectorClient constructor (#1626).
+    ...(serverSettings?.protocolEra && {
+      versionNegotiation: eraToVersionNegotiation(serverSettings.protocolEra),
+    }),
     ...clientAuthOptions,
   });
 

--- a/clients/tui/src/App.tsx
+++ b/clients/tui/src/App.tsx
@@ -20,6 +20,7 @@ import type {
   GetPromptResult,
 } from "@modelcontextprotocol/client";
 import { InspectorClient } from "@inspector/core/mcp/index.js";
+import { eraToVersionNegotiation } from "@inspector/core/mcp/types.js";
 import {
   ManagedToolsState,
   ManagedResourcesState,
@@ -303,6 +304,13 @@ function App({
               defaultMetadata,
             }),
           ...(savedSettings && { serverSettings: savedSettings }),
+          // Per-server protocol era (SEP §7.8) from mcp.json → SDK
+          // versionNegotiation; absent era defaults to legacy (#1626).
+          ...(savedSettings?.protocolEra && {
+            versionNegotiation: eraToVersionNegotiation(
+              savedSettings.protocolEra,
+            ),
+          }),
           ...clientAuthOptions,
         };
         if (isOAuthCapableServerConfig(serverConfig)) {

--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -43,6 +43,7 @@ import type {
 import {
   DEFAULT_MAX_FETCH_REQUESTS,
   DEFAULT_TASK_TTL_MS,
+  eraToVersionNegotiation,
 } from "@inspector/core/mcp/types.js";
 import {
   API_SERVER_ENV_VARS,
@@ -905,6 +906,8 @@ function App() {
     serverInfo,
     instructions,
     protocolVersion,
+    protocolEra,
+    discoverResult,
     lastError,
   } = useInspectorClient(inspectorClient);
   const {
@@ -2137,6 +2140,14 @@ function App() {
           installEnterpriseManagedAuth: clientConfig.enterpriseManagedAuth,
         }),
         ...(savedSettings && { serverSettings: savedSettings }),
+        // Per-server protocol era (SEP §7.8) → SDK versionNegotiation. Absent
+        // settings or an unset era default to legacy inside
+        // eraToVersionNegotiation / the InspectorClient constructor (#1626).
+        ...(savedSettings?.protocolEra && {
+          versionNegotiation: eraToVersionNegotiation(
+            savedSettings.protocolEra,
+          ),
+        }),
         // Set on the `/oauth/callback` rebuild so the client's `saveSession`
         // events (and any later persistence) key off the same OAuth authId
         // the pre-redirect page saved under.
@@ -4042,6 +4053,8 @@ function App() {
           initializeResult={initializeResult}
           clientCapabilities={clientCapabilities}
           transport={connectionInfoTransport}
+          protocolEra={protocolEra}
+          discoverResult={discoverResult}
           oauth={connectionInfoOAuth}
           onClearOAuth={
             connectionInfoCanClearOAuth ? handleClearConnectionOAuth : undefined

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
@@ -42,6 +42,33 @@ export const FullCapabilities: Story = {
   },
 };
 
+export const ModernEra: Story = {
+  args: {
+    initializeResult: {
+      protocolVersion: "2026-07-28",
+      serverInfo: { name: "Modern Server", version: "2.0.0" },
+      capabilities: {
+        tools: { listChanged: true },
+        resources: { subscribe: true },
+      },
+    },
+    clientCapabilities: fullClientCaps,
+    transport: "streamable-http",
+    protocolEra: "modern",
+    discoverResult: {
+      supportedVersions: ["2026-07-28", "2025-11-25"],
+      serverInfo: { name: "Modern Server", version: "2.0.0" },
+      capabilities: {
+        tools: { listChanged: true },
+        resources: { subscribe: true },
+        extensions: {
+          "io.modelcontextprotocol/tasks": {},
+        },
+      },
+    },
+  },
+};
+
 export const MinimalCapabilities: Story = {
   args: {
     initializeResult: {

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
@@ -99,7 +99,7 @@ describe("ConnectionInfoContent", () => {
     expect(screen.queryByText("Server Instructions")).not.toBeInTheDocument();
   });
 
-  it("defaults to the Legacy era and session-based when no protocolEra is given", () => {
+  it("defaults to the Legacy era, and marks the session N/A for stdio", () => {
     renderWithMantine(
       <ConnectionInfoContent
         initializeResult={fullResult}
@@ -109,9 +109,23 @@ describe("ConnectionInfoContent", () => {
     );
     expect(screen.getByText("Era")).toBeInTheDocument();
     expect(screen.getByText("Legacy")).toBeInTheDocument();
-    expect(screen.getByText("Session-based")).toBeInTheDocument();
+    // stdio has no HTTP session concept.
+    expect(screen.getByText("N/A (stdio)")).toBeInTheDocument();
     // No discover result → no Discovery section.
     expect(screen.queryByText("Discovery")).not.toBeInTheDocument();
+  });
+
+  it("marks a legacy HTTP connection as session-based", () => {
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={fullResult}
+        clientCapabilities={fullClientCaps}
+        transport="streamable-http"
+        protocolEra="legacy"
+      />,
+    );
+    expect(screen.getByText("Legacy")).toBeInTheDocument();
+    expect(screen.getByText("Session-based")).toBeInTheDocument();
   });
 
   it("shows the Modern era as sessionless and renders the discovery section", () => {

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
@@ -99,6 +99,69 @@ describe("ConnectionInfoContent", () => {
     expect(screen.queryByText("Server Instructions")).not.toBeInTheDocument();
   });
 
+  it("defaults to the Legacy era and session-based when no protocolEra is given", () => {
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={fullResult}
+        clientCapabilities={fullClientCaps}
+        transport="stdio"
+      />,
+    );
+    expect(screen.getByText("Era")).toBeInTheDocument();
+    expect(screen.getByText("Legacy")).toBeInTheDocument();
+    expect(screen.getByText("Session-based")).toBeInTheDocument();
+    // No discover result → no Discovery section.
+    expect(screen.queryByText("Discovery")).not.toBeInTheDocument();
+  });
+
+  it("shows the Modern era as sessionless and renders the discovery section", () => {
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={fullResult}
+        clientCapabilities={fullClientCaps}
+        transport="streamable-http"
+        protocolEra="modern"
+        discoverResult={{
+          supportedVersions: ["2026-07-28", "2025-11-25"],
+          serverInfo: { name: "Everything Server", version: "2.1.0" },
+          capabilities: {
+            tools: {},
+            extensions: {
+              "io.modelcontextprotocol/tasks": {},
+            },
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("Modern")).toBeInTheDocument();
+    expect(screen.getByText("Sessionless")).toBeInTheDocument();
+    expect(screen.getByText("Discovery")).toBeInTheDocument();
+    expect(screen.getByText("2026-07-28, 2025-11-25")).toBeInTheDocument();
+    expect(
+      screen.getByText("io.modelcontextprotocol/tasks"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders em-dashes for empty supported versions and absent extensions", () => {
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={fullResult}
+        clientCapabilities={fullClientCaps}
+        transport="streamable-http"
+        protocolEra="modern"
+        discoverResult={{
+          supportedVersions: [],
+          serverInfo: { name: "Everything Server", version: "2.1.0" },
+          capabilities: { tools: {} },
+        }}
+      />,
+    );
+    expect(screen.getByText("Supported versions")).toBeInTheDocument();
+    expect(screen.getByText("Extensions")).toBeInTheDocument();
+    // Both the empty-versions and no-extensions values render as an em dash.
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+  });
+
   it("renders client registration kind when provided", () => {
     renderWithMantine(
       <ConnectionInfoContent

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
@@ -11,7 +11,9 @@ import {
 } from "@mantine/core";
 import type {
   ClientCapabilities,
+  DiscoverResult,
   InitializeResult,
+  ProtocolEra,
 } from "@modelcontextprotocol/client";
 import type { ServerType } from "@inspector/core/mcp/types.js";
 import type { OAuthClientRegistrationKind } from "@inspector/core/auth/types.js";
@@ -38,6 +40,18 @@ export interface ConnectionInfoContentProps {
   initializeResult: InitializeResult;
   clientCapabilities: ClientCapabilities;
   transport: ServerType;
+  /**
+   * Protocol era negotiated with the server (SEP §7.8). `"modern"` connections
+   * are sessionless and learn capabilities from `server/discover`; `"legacy"`
+   * (or undefined, on a plain legacy connect) use the initialize handshake.
+   * (#1626)
+   */
+  protocolEra?: ProtocolEra;
+  /**
+   * The `server/discover` result on a modern connection — supported versions,
+   * capabilities, and extensions learned up front. Undefined on legacy. (#1626)
+   */
+  discoverResult?: DiscoverResult;
   oauth?: OAuthDetails;
   onClearOAuth?: () => void;
 }
@@ -97,6 +111,33 @@ function formatClientRegistrationKind(
   }
 }
 
+// A plain legacy connect (versionNegotiation "legacy") leaves the SDK's
+// `getProtocolEra()` undefined — the client never ran negotiation. Treat that
+// as the legacy era for display, since the connection used the 2025-11-25
+// initialize handshake.
+function isModernEra(era: ProtocolEra | undefined): boolean {
+  return era === "modern";
+}
+
+function formatEra(era: ProtocolEra | undefined): string {
+  return isModernEra(era) ? "Modern" : "Legacy";
+}
+
+// Modern connections are sessionless (no `Mcp-Session-Id`, nothing to DELETE on
+// disconnect); legacy connections may carry a server session.
+function formatSession(era: ProtocolEra | undefined): string {
+  return isModernEra(era) ? "Sessionless" : "Session-based";
+}
+
+// The `extensions` map the server advertised in its `server/discover`
+// capabilities (SEP-2133). Render the extension identifiers, or an em dash when
+// none were advertised.
+function formatExtensions(discoverResult: DiscoverResult): string {
+  const extensions = discoverResult.capabilities.extensions;
+  const keys = extensions ? Object.keys(extensions) : [];
+  return keys.length > 0 ? keys.join(", ") : "—";
+}
+
 const SERVER_CAPABILITY_KEYS: CapabilityKey[] = [
   "tools",
   "resources",
@@ -131,6 +172,8 @@ export function ConnectionInfoContent({
   initializeResult,
   clientCapabilities,
   transport,
+  protocolEra,
+  discoverResult,
   oauth,
   onClearOAuth,
 }: ConnectionInfoContentProps) {
@@ -159,8 +202,36 @@ export function ConnectionInfoContent({
 
           <Text size="sm">Transport</Text>
           <Badge variant="outline">{transport}</Badge>
+
+          <Text size="sm">Era</Text>
+          <Badge
+            variant="outline"
+            color={isModernEra(protocolEra) ? "blue" : "gray"}
+          >
+            {formatEra(protocolEra)}
+          </Badge>
+
+          <Text size="sm">Session</Text>
+          <ValueText>{formatSession(protocolEra)}</ValueText>
         </SimpleGrid>
       </Stack>
+
+      {discoverResult && (
+        <Stack gap="xs">
+          <SectionHeading>Discovery</SectionHeading>
+          <SimpleGrid cols={2}>
+            <Text size="sm">Supported versions</Text>
+            <ValueText>
+              {discoverResult.supportedVersions.length > 0
+                ? discoverResult.supportedVersions.join(", ")
+                : "—"}
+            </ValueText>
+
+            <Text size="sm">Extensions</Text>
+            <ValueText>{formatExtensions(discoverResult)}</ValueText>
+          </SimpleGrid>
+        </Stack>
+      )}
 
       <SimpleGrid cols={2}>
         <Stack gap="xs">

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
@@ -111,10 +111,9 @@ function formatClientRegistrationKind(
   }
 }
 
-// A plain legacy connect (versionNegotiation "legacy") leaves the SDK's
-// `getProtocolEra()` undefined — the client never ran negotiation. Treat that
-// as the legacy era for display, since the connection used the 2025-11-25
-// initialize handshake.
+// The SDK reports the era for every connected era, including a plain legacy
+// connect (`"legacy"`); it's undefined only when not connected. Anything other
+// than `"modern"` renders as the legacy era.
 function isModernEra(era: ProtocolEra | undefined): boolean {
   return era === "modern";
 }
@@ -123,9 +122,15 @@ function formatEra(era: ProtocolEra | undefined): string {
   return isModernEra(era) ? "Modern" : "Legacy";
 }
 
-// Modern connections are sessionless (no `Mcp-Session-Id`, nothing to DELETE on
-// disconnect); legacy connections may carry a server session.
-function formatSession(era: ProtocolEra | undefined): string {
+// The session concept is HTTP-only: modern HTTP connections are sessionless (no
+// `Mcp-Session-Id`, nothing to DELETE on disconnect) while a legacy HTTP
+// connection may carry a server session. stdio has no HTTP session at all, so
+// the row is not applicable there.
+function formatSession(
+  era: ProtocolEra | undefined,
+  transport: ServerType,
+): string {
+  if (transport === "stdio") return "N/A (stdio)";
   return isModernEra(era) ? "Sessionless" : "Session-based";
 }
 
@@ -212,7 +217,7 @@ export function ConnectionInfoContent({
           </Badge>
 
           <Text size="sm">Session</Text>
-          <ValueText>{formatSession(protocolEra)}</ValueText>
+          <ValueText>{formatSession(protocolEra, transport)}</ValueText>
         </SimpleGrid>
       </Stack>
 

--- a/clients/web/src/components/groups/ConnectionInfoModal/ConnectionInfoModal.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoModal/ConnectionInfoModal.tsx
@@ -1,7 +1,9 @@
 import { CloseButton, Group, Modal, Stack } from "@mantine/core";
 import type {
   ClientCapabilities,
+  DiscoverResult,
   InitializeResult,
+  ProtocolEra,
 } from "@modelcontextprotocol/client";
 import type { ServerType } from "@inspector/core/mcp/types.js";
 import {
@@ -15,6 +17,8 @@ export interface ConnectionInfoModalProps {
   initializeResult: InitializeResult;
   clientCapabilities: ClientCapabilities;
   transport: ServerType;
+  protocolEra?: ProtocolEra;
+  discoverResult?: DiscoverResult;
   oauth?: OAuthDetails;
   onClearOAuth?: () => void;
 }
@@ -25,6 +29,8 @@ export function ConnectionInfoModal({
   initializeResult,
   clientCapabilities,
   transport,
+  protocolEra,
+  discoverResult,
   oauth,
   onClearOAuth,
 }: ConnectionInfoModalProps) {
@@ -47,6 +53,8 @@ export function ConnectionInfoModal({
           initializeResult={initializeResult}
           clientCapabilities={clientCapabilities}
           transport={transport}
+          protocolEra={protocolEra}
+          discoverResult={discoverResult}
           oauth={oauth}
           onClearOAuth={onClearOAuth}
         />

--- a/clients/web/src/components/groups/ServerSettingsForm/ServerSettingsForm.stories.tsx
+++ b/clients/web/src/components/groups/ServerSettingsForm/ServerSettingsForm.stories.tsx
@@ -137,6 +137,12 @@ function InteractiveRender(args: ServerSettingsFormProps) {
           settings: { ...args.settings, maxFetchRequests: value },
         });
       }}
+      onProtocolEraChange={(value) => {
+        args.onProtocolEraChange(value);
+        updateArgs({
+          settings: { ...args.settings, protocolEra: value },
+        });
+      }}
       onOAuthChange={(oauth) => {
         args.onOAuthChange(oauth);
         updateArgs({
@@ -173,6 +179,7 @@ const meta: Meta<typeof ServerSettingsForm> = {
     onTimeoutChange: fn(),
     onAutoRefreshChange: fn(),
     onMaxFetchRequestsChange: fn(),
+    onProtocolEraChange: fn(),
     onOAuthChange: fn(),
   },
 };

--- a/clients/web/src/components/groups/ServerSettingsForm/ServerSettingsForm.test.tsx
+++ b/clients/web/src/components/groups/ServerSettingsForm/ServerSettingsForm.test.tsx
@@ -66,6 +66,7 @@ const baseHandlers = {
   onTimeoutChange: vi.fn(),
   onAutoRefreshChange: vi.fn(),
   onMaxFetchRequestsChange: vi.fn(),
+  onProtocolEraChange: vi.fn(),
   onOAuthChange: vi.fn(),
   onAddRoot: vi.fn(),
   onRemoveRoot: vi.fn(),
@@ -86,6 +87,46 @@ describe("ServerSettingsForm", () => {
     expect(screen.getByText("Timeouts")).toBeInTheDocument();
     expect(screen.getByText("OAuth Settings")).toBeInTheDocument();
     expect(screen.getByText("Roots")).toBeInTheDocument();
+  });
+
+  it("defaults the Protocol Era select to Legacy when unset", () => {
+    renderWithMantine(
+      <ServerSettingsForm
+        {...baseHandlers}
+        settings={emptySettings}
+        expandedSections={["options"]}
+      />,
+    );
+    expect(
+      screen.getByDisplayValue("Legacy (2025-11-25 handshake)"),
+    ).toBeInTheDocument();
+  });
+
+  it("invokes onProtocolEraChange with the selected era", async () => {
+    const user = userEvent.setup();
+    renderWithMantine(
+      <ServerSettingsForm
+        {...baseHandlers}
+        settings={emptySettings}
+        expandedSections={["options"]}
+      />,
+    );
+    await user.click(screen.getByDisplayValue("Legacy (2025-11-25 handshake)"));
+    await user.click(screen.getByText("Modern (2026-07-28, sessionless)"));
+    expect(baseHandlers.onProtocolEraChange).toHaveBeenCalledWith("modern");
+  });
+
+  it("reflects the configured protocolEra in the select value", () => {
+    renderWithMantine(
+      <ServerSettingsForm
+        {...baseHandlers}
+        settings={{ ...emptySettings, protocolEra: "auto" }}
+        expandedSections={["options"]}
+      />,
+    );
+    expect(
+      screen.getByDisplayValue("Auto (probe, fall back to legacy)"),
+    ).toBeInTheDocument();
   });
 
   it("shows empty hints for headers and metadata when no entries exist", () => {

--- a/clients/web/src/components/groups/ServerSettingsForm/ServerSettingsForm.tsx
+++ b/clients/web/src/components/groups/ServerSettingsForm/ServerSettingsForm.tsx
@@ -15,8 +15,10 @@ import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type {
   InspectorServerSettings,
   OAuthSettings,
+  ServerProtocolEra,
   ServerType,
 } from "@inspector/core/mcp/types.js";
+import { DEFAULT_PROTOCOL_ERA } from "@inspector/core/mcp/types.js";
 import { isOAuthCapableServerType } from "@inspector/core/mcp/config.js";
 import type { Root } from "@modelcontextprotocol/client";
 
@@ -57,11 +59,29 @@ export interface ServerSettingsFormProps {
   ) => void;
   onAutoRefreshChange: (value: boolean) => void;
   onMaxFetchRequestsChange: (value: number) => void;
+  onProtocolEraChange: (value: ServerProtocolEra) => void;
   onOAuthChange: (oauth: OAuthSettings) => void;
   onClearStoredOAuth?: () => void;
   onAddRoot: () => void;
   onRemoveRoot: (index: number) => void;
   onRootChange: (index: number, uri: string, name: string) => void;
+}
+
+// Protocol-era options (SEP §7.8). Values are `ServerProtocolEra`; the pinned
+// modern revision is an internal detail (MODERN_PROTOCOL_VERSION), so the label
+// stays version-free.
+const PROTOCOL_ERA_OPTIONS: { value: ServerProtocolEra; label: string }[] = [
+  { value: "legacy", label: "Legacy (2025-11-25 handshake)" },
+  { value: "auto", label: "Auto (probe, fall back to legacy)" },
+  { value: "modern", label: "Modern (2026-07-28, sessionless)" },
+];
+
+const PROTOCOL_ERA_VALUES: ReadonlySet<ServerProtocolEra> = new Set(
+  PROTOCOL_ERA_OPTIONS.map((o) => o.value),
+);
+
+function isProtocolEra(value: string | null): value is ServerProtocolEra {
+  return value !== null && PROTOCOL_ERA_VALUES.has(value as ServerProtocolEra);
 }
 
 const RemoveIcon = ActionIcon.withProps({
@@ -220,6 +240,7 @@ export function ServerSettingsForm({
   onTimeoutChange,
   onAutoRefreshChange,
   onMaxFetchRequestsChange,
+  onProtocolEraChange,
   onOAuthChange,
   onClearStoredOAuth,
   onAddRoot,
@@ -273,6 +294,20 @@ export function ServerSettingsForm({
         <Accordion.Control>Options</Accordion.Control>
         <Accordion.Panel>
           <Stack gap="md">
+            <Select
+              label="Protocol Era"
+              description="Which MCP protocol era to negotiate with this server (independent of the transport). Legacy uses the 2025-11-25 initialize handshake; Auto probes server/discover and falls back to legacy; Modern pins the 2026-07-28 sessionless protocol. Defaults to Legacy — debugging tools should not auto-probe."
+              data={PROTOCOL_ERA_OPTIONS}
+              value={settings.protocolEra ?? DEFAULT_PROTOCOL_ERA}
+              onChange={(value) => {
+                // Select emits `string | null`; the null (cleared) case is
+                // unreachable here — the field is not clearable and the value
+                // always resolves to a known era.
+                /* v8 ignore next -- Select never emits an out-of-range value */
+                if (isProtocolEra(value)) onProtocolEraChange(value);
+              }}
+              allowDeselect={false}
+            />
             <Checkbox
               label="Auto Refresh on List Changed Notifications"
               description="When checked, tool/prompt/resource lists refresh automatically when the server sends a */list_changed notification. When unchecked, the list-changed indicator appears and you refresh on demand."

--- a/clients/web/src/components/groups/ServerSettingsModal/ServerSettingsModal.test.tsx
+++ b/clients/web/src/components/groups/ServerSettingsModal/ServerSettingsModal.test.tsx
@@ -118,6 +118,27 @@ describe("ServerSettingsModal", () => {
     );
   });
 
+  it("maps the selected protocol era into settings (#1626)", async () => {
+    const user = userEvent.setup();
+    const onSettingsChange = vi.fn();
+    renderWithMantine(
+      <ServerSettingsModal
+        opened
+        settings={emptySettings}
+        serverType="streamable-http"
+        isStdio={false}
+        onClose={vi.fn()}
+        onSettingsChange={onSettingsChange}
+      />,
+    );
+    // The Options section (with Protocol Era) is expanded by default.
+    await user.click(screen.getByDisplayValue("Legacy (2025-11-25 handshake)"));
+    await user.click(screen.getByText("Modern (2026-07-28, sessionless)"));
+    expect(onSettingsChange).toHaveBeenCalledWith(
+      expect.objectContaining({ protocolEra: "modern" }),
+    );
+  });
+
   it("calls onSettingsChange when adding a header after expanding the section", async () => {
     const user = userEvent.setup();
     const onSettingsChange = vi.fn();

--- a/clients/web/src/components/groups/ServerSettingsModal/ServerSettingsModal.tsx
+++ b/clients/web/src/components/groups/ServerSettingsModal/ServerSettingsModal.tsx
@@ -3,6 +3,7 @@ import { CloseButton, Group, Modal, Stack } from "@mantine/core";
 import type {
   InspectorServerSettings,
   OAuthSettings,
+  ServerProtocolEra,
   ServerType,
 } from "@inspector/core/mcp/types.js";
 import { isOAuthCapableServerType } from "@inspector/core/mcp/config.js";
@@ -165,6 +166,10 @@ export function ServerSettingsModal({
     onSettingsChange({ ...settings, maxFetchRequests: value });
   }
 
+  function handleProtocolEraChange(value: ServerProtocolEra) {
+    onSettingsChange({ ...settings, protocolEra: value });
+  }
+
   function handleAddRoot() {
     onSettingsChange({
       ...settings,
@@ -228,6 +233,7 @@ export function ServerSettingsModal({
           onTimeoutChange={handleTimeoutChange}
           onAutoRefreshChange={handleAutoRefreshChange}
           onMaxFetchRequestsChange={handleMaxFetchRequestsChange}
+          onProtocolEraChange={handleProtocolEraChange}
           onOAuthChange={handleOAuthChange}
           onClearStoredOAuth={onClearStoredOAuth}
           onAddRoot={handleAddRoot}

--- a/clients/web/src/test/core/mcp/protocolEra.test.ts
+++ b/clients/web/src/test/core/mcp/protocolEra.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_PROTOCOL_ERA,
+  MODERN_PROTOCOL_VERSION,
+  eraToVersionNegotiation,
+} from "@inspector/core/mcp/types.js";
+
+describe("eraToVersionNegotiation", () => {
+  it("maps legacy to the legacy mode", () => {
+    expect(eraToVersionNegotiation("legacy")).toEqual({ mode: "legacy" });
+  });
+
+  it("maps auto to the probing mode", () => {
+    expect(eraToVersionNegotiation("auto")).toEqual({ mode: "auto" });
+  });
+
+  it("maps modern to a pin at the modern protocol version", () => {
+    expect(eraToVersionNegotiation("modern")).toEqual({
+      mode: { pin: MODERN_PROTOCOL_VERSION },
+    });
+  });
+
+  it("defaults to the legacy era", () => {
+    expect(DEFAULT_PROTOCOL_ERA).toBe("legacy");
+    expect(eraToVersionNegotiation(DEFAULT_PROTOCOL_ERA)).toEqual({
+      mode: "legacy",
+    });
+  });
+});

--- a/clients/web/src/test/core/mcp/serverList.test.ts
+++ b/clients/web/src/test/core/mcp/serverList.test.ts
@@ -303,6 +303,57 @@ describe("serverEntriesToMcpConfig", () => {
     expect(round).toEqual(original);
   });
 
+  it("round-trips protocolEra: lifts a non-default value to settings and back to disk", () => {
+    const original: MCPConfig = {
+      mcpServers: {
+        "era-modern": {
+          type: "streamable-http",
+          url: "https://x.test/mcp",
+          protocolEra: "modern",
+        },
+      },
+    };
+    const [entry] = mcpConfigToServerEntries(original);
+    expect(entry?.settings?.protocolEra).toBe("modern");
+    const round = serverEntriesToMcpConfig(mcpConfigToServerEntries(original));
+    expect(round).toEqual(original);
+  });
+
+  it("round-trips protocolEra: auto is a non-default value", () => {
+    const original: MCPConfig = {
+      mcpServers: {
+        "era-auto": {
+          type: "streamable-http",
+          url: "https://x.test/mcp",
+          protocolEra: "auto",
+        },
+      },
+    };
+    const [entry] = mcpConfigToServerEntries(original);
+    expect(entry?.settings?.protocolEra).toBe("auto");
+    const round = serverEntriesToMcpConfig(mcpConfigToServerEntries(original));
+    expect(round).toEqual(original);
+  });
+
+  it("omits protocolEra from disk when it equals the default (legacy)", () => {
+    // A legacy era is the default — writing it back must NOT inject the field.
+    // A benign inspector field keeps `settings` materialized.
+    const original: MCPConfig = {
+      mcpServers: {
+        "era-legacy": {
+          type: "streamable-http",
+          url: "https://x.test/mcp",
+          protocolEra: "legacy",
+          connectionTimeout: 5000,
+        },
+      },
+    };
+    const [entry] = mcpConfigToServerEntries(original);
+    expect(entry?.settings?.protocolEra).toBe("legacy");
+    const round = serverEntriesToMcpConfig(mcpConfigToServerEntries(original));
+    expect("protocolEra" in (round.mcpServers["era-legacy"] ?? {})).toBe(false);
+  });
+
   it("lifts top-level Inspector-extension fields onto ServerEntry.settings (form shape)", () => {
     const cfg: MCPConfig = {
       mcpServers: {

--- a/clients/web/src/test/core/mcp/serverList.test.ts
+++ b/clients/web/src/test/core/mcp/serverList.test.ts
@@ -335,6 +335,25 @@ describe("serverEntriesToMcpConfig", () => {
     expect(round).toEqual(original);
   });
 
+  it("drops an unknown protocolEra literal on read (hand-edited file)", () => {
+    // The CLI/TUI read mcp.json directly (no /api/servers validators), so a
+    // garbage era must be dropped here rather than reaching versionNegotiation.
+    // Spread the invalid field through an `object`-typed literal so the garbage
+    // value models a hand-edited file without needing an `as unknown as` cast.
+    const badEra: object = { protocolEra: "future" };
+    const original: MCPConfig = {
+      mcpServers: {
+        "era-bad": {
+          type: "streamable-http",
+          url: "https://x.test/mcp",
+          ...badEra,
+        },
+      },
+    };
+    const [entry] = mcpConfigToServerEntries(original);
+    expect(entry?.settings?.protocolEra).toBeUndefined();
+  });
+
   it("omits protocolEra from disk when it equals the default (legacy)", () => {
     // A legacy era is the default — writing it back must NOT inject the field.
     // A benign inspector field keeps `settings` materialized.

--- a/clients/web/src/test/core/react/useInspectorClient.test.tsx
+++ b/clients/web/src/test/core/react/useInspectorClient.test.tsx
@@ -77,6 +77,59 @@ describe("useInspectorClient", () => {
     expect(result.current.protocolVersion).toBe("2025-06-18");
   });
 
+  it("returns initial protocolEra / discoverResult from the client", () => {
+    const discoverResult = {
+      supportedVersions: ["2026-07-28"],
+      serverInfo: SERVER_INFO,
+      capabilities: {},
+    };
+    const client = new FakeInspectorClient({
+      status: "connected",
+      protocolEra: "modern",
+      discoverResult,
+    });
+    const { result } = renderHook(() => useInspectorClient(client));
+    expect(result.current.protocolEra).toBe("modern");
+    expect(result.current.discoverResult).toEqual(discoverResult);
+  });
+
+  it("subscribes to protocolEraChange and discoverResultChange", () => {
+    const client = new FakeInspectorClient();
+    const { result } = renderHook(() => useInspectorClient(client));
+    expect(result.current.protocolEra).toBeUndefined();
+    expect(result.current.discoverResult).toBeUndefined();
+    const discoverResult = {
+      supportedVersions: ["2026-07-28"],
+      serverInfo: SERVER_INFO,
+      capabilities: {},
+    };
+    act(() => {
+      client.setProtocolEra("modern");
+      client.setDiscoverResult(discoverResult);
+    });
+    expect(result.current.protocolEra).toBe("modern");
+    expect(result.current.discoverResult).toEqual(discoverResult);
+  });
+
+  it("resets protocolEra / discoverResult to defaults when client becomes null", () => {
+    const client = new FakeInspectorClient({
+      status: "connected",
+      protocolEra: "modern",
+      discoverResult: {
+        supportedVersions: ["2026-07-28"],
+        serverInfo: SERVER_INFO,
+        capabilities: {},
+      },
+    });
+    const { result, rerender } = renderHook(({ c }) => useInspectorClient(c), {
+      initialProps: { c: client as FakeInspectorClient | null },
+    });
+    expect(result.current.protocolEra).toBe("modern");
+    rerender({ c: null });
+    expect(result.current.protocolEra).toBeUndefined();
+    expect(result.current.discoverResult).toBeUndefined();
+  });
+
   it("connect() and disconnect() proxy to the client and update status", async () => {
     const client = new FakeInspectorClient();
     const { result } = renderHook(() => useInspectorClient(client));

--- a/clients/web/src/test/integration/mcp/inspectorClient.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient.test.ts
@@ -746,12 +746,44 @@ describe("InspectorClient", () => {
 
       expect(client.getProtocolVersion()).toBeUndefined();
       await client.connect();
-      // stdio transports don't store the version themselves; the capture
-      // happens in MessageTrackingTransport, so this also guards that path.
+      // The SDK Client's getNegotiatedProtocolVersion() supplies the version
+      // for both eras.
       expect(client.getProtocolVersion()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      // A legacy connect reports the legacy era; there is no server/discover
+      // result without a probe.
+      expect(client.getProtocolEra()).toBe("legacy");
+      expect(client.getDiscoverResult()).toBeUndefined();
 
       await client.disconnect();
       expect(client.getProtocolVersion()).toBeUndefined();
+      expect(client.getProtocolEra()).toBeUndefined();
+      expect(client.getDiscoverResult()).toBeUndefined();
+    });
+
+    it("negotiates the legacy era under versionNegotiation 'auto' against a legacy server (stdio)", async () => {
+      client = new InspectorClient(
+        {
+          type: "stdio",
+          command: serverCommand.command,
+          args: serverCommand.args,
+        },
+        {
+          environment: { transport: createTransportNode },
+          // Auto probes server/discover, then falls back to the initialize
+          // handshake on this legacy test server — so the negotiated era is
+          // legacy and getProtocolEra() reports it (vs. undefined on a plain
+          // legacy connect).
+          versionNegotiation: { mode: "auto" },
+        },
+      );
+
+      await client.connect();
+      expect(client.getProtocolEra()).toBe("legacy");
+      expect(client.getProtocolVersion()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      // A legacy server has no server/discover result even when probed.
+      expect(client.getDiscoverResult()).toBeUndefined();
+
+      await client.disconnect();
     });
 
     it("should not auto-fetch server contents when disabled", async () => {

--- a/clients/web/src/test/integration/mcp/remote/server-extra-coverage.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/server-extra-coverage.test.ts
@@ -424,6 +424,11 @@ describe("server.ts supplemental coverage", () => {
       expect((await res.json()).error).toMatch(/roots/);
     });
 
+    it("rejects an unknown protocolEra", async () => {
+      const res = await postSettings({ ...base, protocolEra: "future" });
+      expect((await res.json()).error).toMatch(/protocolEra/);
+    });
+
     it("accepts a fully-populated valid settings payload", async () => {
       const res = await postSettings({
         ...base,
@@ -432,6 +437,7 @@ describe("server.ts supplemental coverage", () => {
         taskTtl: 1000,
         autoRefreshOnListChanged: true,
         maxFetchRequests: 5,
+        protocolEra: "modern",
         oauthClientId: "cid",
         oauthScopes: "a b",
         enterpriseManaged: true,
@@ -467,6 +473,8 @@ describe("server.ts supplemental coverage", () => {
               requestTimeout: -1,
               taskTtl: "x",
               maxFetchRequests: -1,
+              // unknown era literal → isProtocolEra branch
+              protocolEra: "future",
               // enterpriseManaged non-boolean → isOauthObject inner branch
               oauth: { enterpriseManaged: "yes" },
               // a non-string `name` → isRootArray inner branch
@@ -494,6 +502,7 @@ describe("server.ts supplemental coverage", () => {
           "requestTimeout",
           "taskTtl",
           "maxFetchRequests",
+          "protocolEra",
           "oauth",
           "roots",
         ]) {

--- a/clients/web/src/test/integration/mcp/remote/servers-route.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/servers-route.test.ts
@@ -1045,6 +1045,8 @@ describe("/api/servers routes", () => {
               connectionTimeout: "30s",
               // Good: valid number
               requestTimeout: 60000,
+              // Good: valid era literal → round-trips
+              protocolEra: "modern",
               // Bad: array instead of object → drop
               oauth: ["not", "an", "object"],
               // Bad: entry missing a string `uri` → drop the whole roots field
@@ -1063,6 +1065,7 @@ describe("/api/servers routes", () => {
       // Good fields survive.
       expect(fetched.headers).toEqual({ "X-Keep": "yes" });
       expect(fetched.requestTimeout).toBe(60000);
+      expect(fetched.protocolEra).toBe("modern");
       // Bad fields are dropped.
       expect(fetched).not.toHaveProperty("metadata");
       expect(fetched).not.toHaveProperty("connectionTimeout");

--- a/core/mcp/__tests__/fakeInspectorClient.ts
+++ b/core/mcp/__tests__/fakeInspectorClient.ts
@@ -8,9 +8,11 @@
 import { vi } from "vitest";
 import type {
   ClientCapabilities,
+  DiscoverResult,
   Implementation,
   LoggingLevel,
   Prompt,
+  ProtocolEra,
   Resource,
   ResourceTemplateType as ResourceTemplate,
   ServerCapabilities,
@@ -45,6 +47,8 @@ export interface FakeInspectorClientOptions {
   serverInfo?: Implementation;
   instructions?: string;
   protocolVersion?: string;
+  protocolEra?: ProtocolEra;
+  discoverResult?: DiscoverResult;
   serverSettings?: InspectorServerSettings;
 }
 
@@ -58,6 +62,8 @@ export class FakeInspectorClient
   private serverInfo: Implementation | undefined;
   private instructions: string | undefined;
   private protocolVersion: string | undefined;
+  private protocolEra: ProtocolEra | undefined;
+  private discoverResult: DiscoverResult | undefined;
   private serverSettings: InspectorServerSettings | undefined;
   private appRendererClient: AppRendererClient | null = null;
   private sessionId: string | undefined;
@@ -153,6 +159,8 @@ export class FakeInspectorClient
     this.serverInfo = options.serverInfo;
     this.instructions = options.instructions;
     this.protocolVersion = options.protocolVersion;
+    this.protocolEra = options.protocolEra;
+    this.discoverResult = options.discoverResult;
     this.serverSettings = options.serverSettings;
   }
 
@@ -178,6 +186,14 @@ export class FakeInspectorClient
 
   getProtocolVersion(): string | undefined {
     return this.protocolVersion;
+  }
+
+  getProtocolEra(): ProtocolEra | undefined {
+    return this.protocolEra;
+  }
+
+  getDiscoverResult(): DiscoverResult | undefined {
+    return this.discoverResult;
   }
 
   getServerSettings(): InspectorServerSettings | undefined {
@@ -257,6 +273,16 @@ export class FakeInspectorClient
   setProtocolVersion(protocolVersion: string | undefined): void {
     this.protocolVersion = protocolVersion;
     this.dispatchTypedEvent("protocolVersionChange", protocolVersion);
+  }
+
+  setProtocolEra(protocolEra: ProtocolEra | undefined): void {
+    this.protocolEra = protocolEra;
+    this.dispatchTypedEvent("protocolEraChange", protocolEra);
+  }
+
+  setDiscoverResult(discoverResult: DiscoverResult | undefined): void {
+    this.discoverResult = discoverResult;
+    this.dispatchTypedEvent("discoverResultChange", discoverResult);
   }
 
   setAppRendererClient(client: AppRendererClient | null): void {

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -1786,8 +1786,9 @@ export class InspectorClient extends InspectorClientEventTarget {
   /**
    * The protocol era negotiated with the server (SEP §7.8): `"legacy"` for the
    * 2025-11-25 initialize handshake, `"modern"` for the 2026-era sessionless
-   * model. Undefined when not connected, or on a plain legacy connect where the
-   * SDK doesn't run negotiation (mode "legacy"). (#1626)
+   * model. Populated for every era once connected — including a plain legacy
+   * (`mode: "legacy"`) connect, which the SDK reports as `"legacy"`. Undefined
+   * only when not connected (before connect / after disconnect). (#1626)
    */
   getProtocolEra(): ProtocolEra | undefined {
     return this.protocolEra;
@@ -2956,9 +2957,9 @@ export class InspectorClient extends InspectorClientEventTarget {
       }
 
       // Era model (SEP §7.8): the SDK Client owns negotiation and exposes the
-      // outcome. `getProtocolEra()` / `getDiscoverResult()` are undefined on a
-      // plain legacy connect (mode "legacy"); populated once "auto"/"modern"
-      // negotiates.
+      // outcome. `getProtocolEra()` is populated for every era once connected —
+      // a plain legacy connect reports `"legacy"`. `getDiscoverResult()` is
+      // populated only when "auto"/"modern" actually probed server/discover.
       this.protocolEra = this.client.getProtocolEra();
       this.dispatchTypedEvent("protocolEraChange", this.protocolEra);
       this.discoverResult = this.client.getDiscoverResult();

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -84,6 +84,8 @@ import type {
   RequestOptions,
   ProgressCallback,
   VersionNegotiationOptions,
+  ProtocolEra,
+  DiscoverResult,
 } from "@modelcontextprotocol/client";
 import { ProtocolError, ProtocolErrorCode } from "@modelcontextprotocol/client";
 import {
@@ -247,6 +249,7 @@ export class InspectorClient extends InspectorClientEventTarget {
   private requestTimeout: number | undefined;
   private defaultMetadata: Record<string, string> | undefined;
   private serverSettings: InspectorServerSettings | undefined;
+  private versionNegotiation: VersionNegotiationOptions;
   private status: ConnectionStatus = "disconnected";
   // True only while an explicit disconnect() owns the teardown. close() can
   // trigger the transport's onclose synchronously, so this lets onclose defer
@@ -258,6 +261,12 @@ export class InspectorClient extends InspectorClientEventTarget {
   private serverInfo?: Implementation;
   private instructions?: string;
   private protocolVersion?: string;
+  // Era model (SEP §7.8). Populated after connect from the SDK Client's
+  // negotiation accessors. `protocolEra` is the negotiated era ("legacy" |
+  // "modern"); `discoverResult` is the `server/discover` payload on a
+  // probed/pinned connection (undefined on a plain legacy connect).
+  private protocolEra?: ProtocolEra;
+  private discoverResult?: DiscoverResult;
   // The capabilities this Inspector client advertises to the server during the
   // initialize handshake. Built once in setupClient() and snapshotted here so
   // UI surfaces (Server Info modal) can display them without poking at the
@@ -341,6 +350,9 @@ export class InspectorClient extends InspectorClientEventTarget {
         ? options.defaultMetadata
         : undefined;
     this.serverSettings = options.serverSettings;
+    // Default to the legacy 2025-11-25 era when the caller doesn't pin one, per
+    // the SDK guidance that a debugging tool must not auto-probe (#1626).
+    this.versionNegotiation = options.versionNegotiation ?? { mode: "legacy" };
     this.directAuthRecovery = options.directAuthRecovery ?? false;
     // Only set roots if explicitly provided (even if empty array) - this enables roots capability
     this.roots = options.roots;
@@ -392,10 +404,11 @@ export class InspectorClient extends InspectorClientEventTarget {
       capabilities?: ClientCapabilities;
       versionNegotiation?: VersionNegotiationOptions;
     } = {
-      // Pin to the legacy (2025-11-25) protocol so this migration stays
-      // behavior-neutral: nothing 2026-era goes on the wire. Era/version
-      // selection becomes per-server configuration in a later card.
-      versionNegotiation: { mode: "legacy" },
+      // Per-server protocol era (SEP §7.8), threaded from config via
+      // `eraToVersionNegotiation` and defaulted to `{ mode: "legacy" }` in the
+      // constructor. "legacy" keeps the wire byte-identical to a 2025 client;
+      // "auto"/"modern" opt into 2026-era negotiation (#1626).
+      versionNegotiation: this.versionNegotiation,
     };
     const capabilities: ClientCapabilities = {};
     if (this.sample) {
@@ -1450,6 +1463,8 @@ export class InspectorClient extends InspectorClientEventTarget {
     this.serverInfo = undefined;
     this.instructions = undefined;
     this.protocolVersion = undefined;
+    this.protocolEra = undefined;
+    this.discoverResult = undefined;
     this.dispatchTypedEvent("pendingSamplesChange", this.pendingSamples);
     this.dispatchTypedEvent(
       "pendingElicitationsChange",
@@ -1459,6 +1474,8 @@ export class InspectorClient extends InspectorClientEventTarget {
     this.dispatchTypedEvent("serverInfoChange", this.serverInfo);
     this.dispatchTypedEvent("instructionsChange", this.instructions);
     this.dispatchTypedEvent("protocolVersionChange", this.protocolVersion);
+    this.dispatchTypedEvent("protocolEraChange", this.protocolEra);
+    this.dispatchTypedEvent("discoverResultChange", this.discoverResult);
   }
 
   /**
@@ -1757,11 +1774,35 @@ export class InspectorClient extends InspectorClientEventTarget {
   }
 
   /**
-   * Get the MCP protocol version negotiated with the server during the
-   * initialize handshake (e.g. "2025-06-18"). Undefined when not connected.
+   * Get the MCP protocol version negotiated with the server. On a legacy
+   * connect this is the version from the initialize handshake (e.g.
+   * "2025-06-18"); on a modern connect it's the negotiated modern revision.
+   * Undefined when not connected.
    */
   getProtocolVersion(): string | undefined {
     return this.protocolVersion;
+  }
+
+  /**
+   * The protocol era negotiated with the server (SEP §7.8): `"legacy"` for the
+   * 2025-11-25 initialize handshake, `"modern"` for the 2026-era sessionless
+   * model. Undefined when not connected, or on a plain legacy connect where the
+   * SDK doesn't run negotiation (mode "legacy"). (#1626)
+   */
+  getProtocolEra(): ProtocolEra | undefined {
+    return this.protocolEra;
+  }
+
+  /**
+   * The `server/discover` result captured on a probed (`"auto"`) or pinned
+   * (`"modern"`) connect — server identity, capabilities, and supported
+   * versions learned up front without an initialize handshake. Undefined when
+   * not connected or on a plain legacy connect. Persistable and feedable back
+   * to the SDK as `connect(transport, { prior })` for a zero-round-trip
+   * reconnect. (#1626)
+   */
+  getDiscoverResult(): DiscoverResult | undefined {
+    return this.discoverResult;
   }
 
   /**
@@ -2914,13 +2955,20 @@ export class InspectorClient extends InspectorClientEventTarget {
         this.dispatchTypedEvent("instructionsChange", this.instructions);
       }
 
-      // The negotiated protocol version isn't exposed by the SDK Client; it's
-      // stamped onto the transport during initialize. MessageTrackingTransport
-      // captures it (see its setProtocolVersion) so we can surface it here.
-      if (this.transport instanceof MessageTrackingTransport) {
-        this.protocolVersion = this.transport.protocolVersion;
-        this.dispatchTypedEvent("protocolVersionChange", this.protocolVersion);
-      }
+      // Era model (SEP §7.8): the SDK Client owns negotiation and exposes the
+      // outcome. `getProtocolEra()` / `getDiscoverResult()` are undefined on a
+      // plain legacy connect (mode "legacy"); populated once "auto"/"modern"
+      // negotiates.
+      this.protocolEra = this.client.getProtocolEra();
+      this.dispatchTypedEvent("protocolEraChange", this.protocolEra);
+      this.discoverResult = this.client.getDiscoverResult();
+      this.dispatchTypedEvent("discoverResultChange", this.discoverResult);
+
+      // The SDK's negotiated-version accessor works for both eras (the
+      // initialize handshake on legacy, the discover/pin on modern), so it
+      // supersedes the older MessageTrackingTransport capture.
+      this.protocolVersion = this.client.getNegotiatedProtocolVersion();
+      this.dispatchTypedEvent("protocolVersionChange", this.protocolVersion);
     } catch {
       // Ignore errors in fetching server info
     }

--- a/core/mcp/inspectorClientEventTarget.ts
+++ b/core/mcp/inspectorClientEventTarget.ts
@@ -58,7 +58,7 @@ export interface InspectorClientEventMap {
   serverInfoChange: Implementation | undefined;
   instructionsChange: string | undefined;
   protocolVersionChange: string | undefined;
-  /** Protocol era negotiated after connect (SEP §7.8). Undefined on legacy. */
+  /** Protocol era negotiated after connect (SEP §7.8); `"legacy"` on a legacy connect, undefined when not connected. */
   protocolEraChange: ProtocolEra | undefined;
   /** `server/discover` result on a probed/pinned connect; undefined on legacy. */
   discoverResultChange: DiscoverResult | undefined;

--- a/core/mcp/inspectorClientEventTarget.ts
+++ b/core/mcp/inspectorClientEventTarget.ts
@@ -34,6 +34,8 @@ import type {
   Task,
   CallToolResult,
   ProtocolError,
+  ProtocolEra,
+  DiscoverResult,
 } from "@modelcontextprotocol/client";
 import type { SamplingCreateMessage } from "./samplingCreateMessage.js";
 import type { ElicitationCreateMessage } from "./elicitationCreateMessage.js";
@@ -56,6 +58,10 @@ export interface InspectorClientEventMap {
   serverInfoChange: Implementation | undefined;
   instructionsChange: string | undefined;
   protocolVersionChange: string | undefined;
+  /** Protocol era negotiated after connect (SEP §7.8). Undefined on legacy. */
+  protocolEraChange: ProtocolEra | undefined;
+  /** `server/discover` result on a probed/pinned connect; undefined on legacy. */
+  discoverResultChange: DiscoverResult | undefined;
   message: MessageEntry;
   stderrLog: StderrLogEntry;
   fetchRequest: FetchRequestEntry;

--- a/core/mcp/inspectorClientProtocol.ts
+++ b/core/mcp/inspectorClientProtocol.ts
@@ -22,9 +22,11 @@ import type {
 } from "./types.js";
 import type {
   ClientCapabilities,
+  DiscoverResult,
   Implementation,
   LoggingLevel,
   Prompt,
+  ProtocolEra,
   Resource,
   ResourceTemplateType as ResourceTemplate,
   ServerCapabilities,
@@ -56,6 +58,8 @@ export interface InspectorClientProtocol extends InspectorClientEventTarget {
   getServerInfo(): Implementation | undefined;
   getInstructions(): string | undefined;
   getProtocolVersion(): string | undefined;
+  getProtocolEra(): ProtocolEra | undefined;
+  getDiscoverResult(): DiscoverResult | undefined;
   getServerSettings(): InspectorServerSettings | undefined;
   setServerSettings(settings: InspectorServerSettings): void;
   getAppRendererClient(): AppRendererClient | null;

--- a/core/mcp/remote/node/server.ts
+++ b/core/mcp/remote/node/server.ts
@@ -41,6 +41,7 @@ import type {
   InspectorServerSettings,
   MCPConfig,
   MCPServerConfig,
+  ServerProtocolEra,
   StdioServerConfig,
   StoredMCPServer,
 } from "../../types.js";
@@ -1077,6 +1078,8 @@ export function createRemoteApp(
       return true;
     });
   };
+  const isProtocolEra = (v: unknown): v is ServerProtocolEra =>
+    v === "legacy" || v === "auto" || v === "modern";
   // `Number.isFinite` rejects `Infinity` and `NaN` as well as non-numbers,
   // matching the write-side semantics in `validateSettings`. A hand-edited
   // file with `connectionTimeout: Infinity` would otherwise pass the guard
@@ -1177,6 +1180,13 @@ export function createRemoteApp(
           "Dropping malformed `roots` field — expected `Array<{ uri: string, name?: string }>`.",
         );
         delete valObj.roots;
+      }
+      if ("protocolEra" in valObj && !isProtocolEra(valObj.protocolEra)) {
+        logWarn(
+          { route: "/api/servers", id, droppedKey: "protocolEra" },
+          "Dropping malformed `protocolEra` field — expected 'legacy', 'auto', or 'modern'.",
+        );
+        delete valObj.protocolEra;
       }
 
       out[id] = normalizeServerType(
@@ -1436,6 +1446,15 @@ export function createRemoteApp(
         error: "settings.roots must be an array of { uri, name? }",
       };
     }
+    // protocolEra is optional on the wire (older clients won't send it); when
+    // present it must be one of the three era literals, otherwise it defaults
+    // to absent (→ legacy) below.
+    if (obj.protocolEra !== undefined && !isProtocolEra(obj.protocolEra)) {
+      return {
+        ok: false,
+        error: "settings.protocolEra must be 'legacy', 'auto', or 'modern'",
+      };
+    }
     // Build the validated value from explicitly named fields rather than
     // casting the raw object through. Unknown keys silently drop so a
     // misconfigured client can't smuggle stowaways onto disk, and consumers
@@ -1493,6 +1512,11 @@ export function createRemoteApp(
       obj.oauthOnInsufficientScope === "throw"
     ) {
       value.oauthOnInsufficientScope = obj.oauthOnInsufficientScope;
+    }
+    // Optional; when a valid era is present, carry it. Absence reads back as the
+    // default era downstream (eraToVersionNegotiation is not called for absent).
+    if (isProtocolEra(obj.protocolEra)) {
+      value.protocolEra = obj.protocolEra;
     }
     // Empty cwd coerces to absent on the value (matching the read side); the
     // write-through distinguishes "sent cwd: '' " (clear) from "cwd omitted"

--- a/core/mcp/remote/node/server.ts
+++ b/core/mcp/remote/node/server.ts
@@ -41,7 +41,6 @@ import type {
   InspectorServerSettings,
   MCPConfig,
   MCPServerConfig,
-  ServerProtocolEra,
   StdioServerConfig,
   StoredMCPServer,
 } from "../../types.js";
@@ -52,6 +51,7 @@ import {
   extractSecretsFromStored,
   INSPECTOR_FIELD_KEYS,
   inspectorSettingsToStoredFields,
+  isProtocolEra,
   mergeSecretsIntoStored,
   normalizeServerType,
   storedFieldsToInspectorSettings,
@@ -1078,8 +1078,6 @@ export function createRemoteApp(
       return true;
     });
   };
-  const isProtocolEra = (v: unknown): v is ServerProtocolEra =>
-    v === "legacy" || v === "auto" || v === "modern";
   // `Number.isFinite` rejects `Infinity` and `NaN` as well as non-numbers,
   // matching the write-side semantics in `validateSettings`. A hand-edited
   // file with `connectionTimeout: Infinity` would otherwise pass the guard

--- a/core/mcp/serverList.ts
+++ b/core/mcp/serverList.ts
@@ -5,7 +5,11 @@
  * remote-server route handlers.
  */
 
-import { DEFAULT_MAX_FETCH_REQUESTS, DEFAULT_TASK_TTL_MS } from "./types.js";
+import {
+  DEFAULT_MAX_FETCH_REQUESTS,
+  DEFAULT_PROTOCOL_ERA,
+  DEFAULT_TASK_TTL_MS,
+} from "./types.js";
 import type { Root } from "@modelcontextprotocol/client";
 import type {
   InspectorServerSettings,
@@ -89,6 +93,7 @@ type StoredInspectorFields = Pick<
   StoredMCPServer,
   | "headers"
   | "metadata"
+  | "protocolEra"
   | "connectionTimeout"
   | "requestTimeout"
   | "taskTtl"
@@ -162,6 +167,7 @@ export function storedFieldsToInspectorSettings(
     stored.maxFetchRequests !== undefined ||
     stored.oauth !== undefined ||
     stored.roots !== undefined ||
+    stored.protocolEra !== undefined ||
     stored.env !== undefined ||
     stored.cwd !== undefined;
   if (!hasAny) return undefined;
@@ -189,6 +195,12 @@ export function storedFieldsToInspectorSettings(
     // `[]`, which `inspectorSettingsToStoredFields` then omits on write.
     roots: stored.roots ?? [],
   };
+  // Absent on disk reads back as the default era; the write side then omits the
+  // default so a byte-stable round-trip never injects `protocolEra` into files
+  // that never set it.
+  if (stored.protocolEra !== undefined) {
+    settings.protocolEra = stored.protocolEra;
+  }
   // Truthiness drops empty-string OAuth fields — mirrors the write-side
   // coercion in `validateSettings` (server.ts) so a round-trip can't
   // accidentally surface `oauthClientId: ""` to the form, where the
@@ -258,6 +270,16 @@ export function inspectorSettingsToStoredFields(
     out.autoRefreshOnListChanged = true;
   }
 
+  // Persist only when it differs from the default era. Absent reads back as
+  // DEFAULT_PROTOCOL_ERA, so writing the default would inject the field into
+  // hand-edited files that never had it and break byte-stable round-trips.
+  if (
+    settings.protocolEra !== undefined &&
+    settings.protocolEra !== DEFAULT_PROTOCOL_ERA
+  ) {
+    out.protocolEra = settings.protocolEra;
+  }
+
   // Persist only when it differs from the default. Unlike the timeouts, 0 is a
   // meaningful value here (unlimited), so the omit-sentinel is the default
   // itself rather than 0 — writing the default would inject the field into
@@ -309,6 +331,7 @@ export function inspectorSettingsToStoredFields(
 const INSPECTOR_FIELD_KEY_MAP = {
   headers: true,
   metadata: true,
+  protocolEra: true,
   connectionTimeout: true,
   requestTimeout: true,
   taskTtl: true,

--- a/core/mcp/serverList.ts
+++ b/core/mcp/serverList.ts
@@ -16,6 +16,7 @@ import type {
   MCPConfig,
   MCPServerConfig,
   ServerEntry,
+  ServerProtocolEra,
   ServerType,
   StdioServerConfig,
   StoredMCPServer,
@@ -32,6 +33,27 @@ const VALID_SERVER_TYPES: ReadonlySet<ServerType> = new Set([
   "sse",
   "streamable-http",
 ]);
+
+const VALID_PROTOCOL_ERAS: ReadonlySet<ServerProtocolEra> = new Set([
+  "legacy",
+  "auto",
+  "modern",
+]);
+
+/**
+ * Runtime guard for the `protocolEra` literal. `StoredMCPServer` types the
+ * field as `ServerProtocolEra`, but a hand-edited `mcp.json` read directly by
+ * the CLI/TUI (which don't pass through the `/api/servers` route validators)
+ * can carry any string. Dropping unknowns here keeps a garbage value from
+ * reaching `eraToVersionNegotiation` — matching the read-side check the
+ * `/api/servers` route already applies.
+ */
+export function isProtocolEra(value: unknown): value is ServerProtocolEra {
+  return (
+    typeof value === "string" &&
+    VALID_PROTOCOL_ERAS.has(value as ServerProtocolEra)
+  );
+}
 
 /**
  * Normalizes server type:
@@ -197,8 +219,9 @@ export function storedFieldsToInspectorSettings(
   };
   // Absent on disk reads back as the default era; the write side then omits the
   // default so a byte-stable round-trip never injects `protocolEra` into files
-  // that never set it.
-  if (stored.protocolEra !== undefined) {
+  // that never set it. An unknown literal from a hand-edited file is dropped
+  // (→ default legacy) rather than passed through to `eraToVersionNegotiation`.
+  if (isProtocolEra(stored.protocolEra)) {
     settings.protocolEra = stored.protocolEra;
   }
   // Truthiness drops empty-string OAuth fields — mirrors the write-side

--- a/core/mcp/types.ts
+++ b/core/mcp/types.ts
@@ -17,6 +17,7 @@ import type {
   ServerNotification,
   ServerRequest,
   Tool,
+  VersionNegotiationOptions,
 } from "@modelcontextprotocol/client";
 import type { Client } from "@modelcontextprotocol/client";
 import type { OAuthClientProvider } from "@modelcontextprotocol/client";
@@ -102,6 +103,13 @@ export type StoredMCPServer = MCPServerConfig & {
    * shape is preserved on disk and in memory.
    */
   metadata?: { key: string; value: string }[];
+  /**
+   * Protocol era to negotiate with this server (`"legacy" | "auto" | "modern"`),
+   * orthogonal to the transport `type`. Inspector-specific (no analog in the
+   * broader mcp.json ecosystem). Omitted on disk when it equals the default
+   * (`"legacy"`). (#1626)
+   */
+  protocolEra?: ServerProtocolEra;
   /** Inspector-specific connect-time timeout (ms). */
   connectionTimeout?: number;
   /** Inspector-specific request timeout (ms). */
@@ -435,6 +443,50 @@ export const DEFAULT_TASK_TTL_MS = 60000;
 export const DEFAULT_MAX_FETCH_REQUESTS = 1000;
 
 /**
+ * Per-server protocol era (SEP §7.8 backward-compat model), an orthogonal
+ * dimension to the transport `type`. Drives the SDK Client's
+ * `versionNegotiation`:
+ *
+ * - `"legacy"` — the plain 2025-11-25 `initialize` handshake, byte-identical to
+ *   a client without negotiation. **This is the default** per the SDK's
+ *   guidance that a debugging tool must not auto-probe (a probe stalls on
+ *   silent stdio legacy servers and pollutes recorded transcripts).
+ * - `"auto"` — probe `server/discover` at connect and fall back to `initialize`
+ *   on any non-modern outcome.
+ * - `"modern"` — pin the modern era at exactly `MODERN_PROTOCOL_VERSION`; no
+ *   fallback (a non-modern server fails loudly).
+ */
+export type ServerProtocolEra = "legacy" | "auto" | "modern";
+
+/** The default per-server protocol era when none is configured. */
+export const DEFAULT_PROTOCOL_ERA: ServerProtocolEra = "legacy";
+
+/**
+ * The modern protocol revision `"modern"` era pins to. The successor to
+ * 2025-11-25; the first revision with the per-request-metadata / sessionless
+ * model (SEP §7.1).
+ */
+export const MODERN_PROTOCOL_VERSION = "2026-07-28";
+
+/**
+ * Map a per-server {@link ServerProtocolEra} onto the SDK Client's
+ * `versionNegotiation` option. `"modern"` pins {@link MODERN_PROTOCOL_VERSION};
+ * `"legacy"`/`"auto"` pass their mode straight through.
+ */
+export function eraToVersionNegotiation(
+  era: ServerProtocolEra,
+): VersionNegotiationOptions {
+  switch (era) {
+    case "auto":
+      return { mode: "auto" };
+    case "modern":
+      return { mode: { pin: MODERN_PROTOCOL_VERSION } };
+    case "legacy":
+      return { mode: "legacy" };
+  }
+}
+
+/**
  * Runtime settings for a configured server. A subset of
  * InspectorClientOptions (v1.5) relevant to the settings form:
  * headers, metadata, timeouts, and OAuth credentials.
@@ -497,6 +549,14 @@ export interface InspectorServerSettings {
    * persist (see `inspectorSettingsToStoredFields`).
    */
   roots: Root[];
+  /**
+   * Protocol era to negotiate with this server (orthogonal to the transport
+   * `type`). Drives the SDK Client's `versionNegotiation`. Optional so a bare
+   * settings node reads back without one; absence means {@link
+   * DEFAULT_PROTOCOL_ERA} (`"legacy"`). Persisted on disk as `protocolEra` and
+   * omitted when it equals the default, keeping the file diff minimal.
+   */
+  protocolEra?: ServerProtocolEra;
 }
 
 /**
@@ -741,6 +801,15 @@ export interface InspectorClientOptions {
    * `serverSettings` itself is only consumed by the transport.
    */
   serverSettings?: InspectorServerSettings;
+
+  /**
+   * Protocol version negotiation for the SDK Client (SEP §7.8 era model).
+   * When omitted, the client pins the legacy 2025-11-25 era
+   * (`{ mode: "legacy" }`), byte-identical to a client without negotiation.
+   * Callers derive this from the per-server {@link ServerProtocolEra} via
+   * {@link eraToVersionNegotiation}. (#1626)
+   */
+  versionNegotiation?: VersionNegotiationOptions;
 
   /**
    * OAuth configuration (client credentials, scope, etc.)

--- a/core/react/useInspectorClient.ts
+++ b/core/react/useInspectorClient.ts
@@ -7,6 +7,8 @@ import type {
   ClientCapabilities,
   ServerCapabilities,
   Implementation,
+  ProtocolEra,
+  DiscoverResult,
 } from "@modelcontextprotocol/client";
 
 // Module-scope frozen object so the `?? EMPTY_CLIENT_CAPABILITIES`
@@ -22,6 +24,18 @@ export interface UseInspectorClientResult {
   serverInfo?: Implementation;
   instructions?: string;
   protocolVersion?: string;
+  /**
+   * Protocol era negotiated with the server (SEP §7.8): `"legacy"` for the
+   * 2025-11-25 initialize handshake, `"modern"` for the 2026-era sessionless
+   * model. Undefined when not connected or on a plain legacy connect. (#1626)
+   */
+  protocolEra?: ProtocolEra;
+  /**
+   * The `server/discover` result on a probed/pinned connect — server identity,
+   * capabilities, and supported versions learned without an initialize
+   * handshake. Undefined on a legacy connect. (#1626)
+   */
+  discoverResult?: DiscoverResult;
   /**
    * Message from the most recent mid-session transport failure (the client's
    * `error` event — stdio crash, SSE drop, HTTP 5xx). Stays set until the next
@@ -66,6 +80,12 @@ export function useInspectorClient(
   const [protocolVersion, setProtocolVersion] = useState<string | undefined>(
     inspectorClient?.getProtocolVersion(),
   );
+  const [protocolEra, setProtocolEra] = useState<ProtocolEra | undefined>(
+    inspectorClient?.getProtocolEra(),
+  );
+  const [discoverResult, setDiscoverResult] = useState<
+    DiscoverResult | undefined
+  >(inspectorClient?.getDiscoverResult());
   const [lastError, setLastError] = useState<string | undefined>(undefined);
 
   useEffect(() => {
@@ -75,6 +95,8 @@ export function useInspectorClient(
       setServerInfo(undefined);
       setInstructions(undefined);
       setProtocolVersion(undefined);
+      setProtocolEra(undefined);
+      setDiscoverResult(undefined);
       setLastError(undefined);
       return;
     }
@@ -84,6 +106,8 @@ export function useInspectorClient(
     setServerInfo(inspectorClient.getServerInfo());
     setInstructions(inspectorClient.getInstructions());
     setProtocolVersion(inspectorClient.getProtocolVersion());
+    setProtocolEra(inspectorClient.getProtocolEra());
+    setDiscoverResult(inspectorClient.getDiscoverResult());
     setLastError(undefined);
 
     const onStatusChange = (event: TypedEvent<"statusChange">) => {
@@ -111,6 +135,14 @@ export function useInspectorClient(
     ) => {
       setProtocolVersion(event.detail);
     };
+    const onProtocolEraChange = (event: TypedEvent<"protocolEraChange">) => {
+      setProtocolEra(event.detail);
+    };
+    const onDiscoverResultChange = (
+      event: TypedEvent<"discoverResultChange">,
+    ) => {
+      setDiscoverResult(event.detail);
+    };
 
     inspectorClient.addEventListener("statusChange", onStatusChange);
     inspectorClient.addEventListener("error", onError);
@@ -126,6 +158,11 @@ export function useInspectorClient(
     inspectorClient.addEventListener(
       "protocolVersionChange",
       onProtocolVersionChange,
+    );
+    inspectorClient.addEventListener("protocolEraChange", onProtocolEraChange);
+    inspectorClient.addEventListener(
+      "discoverResultChange",
+      onDiscoverResultChange,
     );
 
     return () => {
@@ -146,6 +183,14 @@ export function useInspectorClient(
       inspectorClient.removeEventListener(
         "protocolVersionChange",
         onProtocolVersionChange,
+      );
+      inspectorClient.removeEventListener(
+        "protocolEraChange",
+        onProtocolEraChange,
+      );
+      inspectorClient.removeEventListener(
+        "discoverResultChange",
+        onDiscoverResultChange,
       );
     };
   }, [inspectorClient]);
@@ -173,6 +218,8 @@ export function useInspectorClient(
     serverInfo,
     instructions,
     protocolVersion,
+    protocolEra,
+    discoverResult,
     lastError,
     appRendererClient: inspectorClient?.getAppRendererClient() ?? null,
     connect,

--- a/core/react/useInspectorClient.ts
+++ b/core/react/useInspectorClient.ts
@@ -27,7 +27,8 @@ export interface UseInspectorClientResult {
   /**
    * Protocol era negotiated with the server (SEP §7.8): `"legacy"` for the
    * 2025-11-25 initialize handshake, `"modern"` for the 2026-era sessionless
-   * model. Undefined when not connected or on a plain legacy connect. (#1626)
+   * model. Populated for every era once connected (a plain legacy connect
+   * reports `"legacy"`); undefined only when not connected. (#1626)
    */
   protocolEra?: ProtocolEra;
   /**


### PR DESCRIPTION
Closes #1626

**Stack:** SDK V2 + New Spec — 3 of 10 (the era-aware connection model).

Makes **protocol era** (SEP §7.8) a first-class, per-server connection dimension, orthogonal to the transport type, and drives the SDK Client's `versionNegotiation` from it.

### What changed

**Config (`core/mcp/types.ts`, `serverList.ts`, `remote/node/server.ts`)**
- New `ServerProtocolEra` = `"legacy" | "auto" | "modern"`, plus `DEFAULT_PROTOCOL_ERA` (`legacy`, per the SDK's guidance that debugging tools must not auto-probe), `MODERN_PROTOCOL_VERSION` (`2026-07-28`), and `eraToVersionNegotiation()`.
- `protocolEra` persists on `StoredMCPServer` / `InspectorServerSettings`, round-trips through the disk↔memory converters (default omitted on disk) and the `/api/servers` read + write validators.

**InspectorClient / state (`inspectorClient.ts`, event map, `useInspectorClient`)**
- `versionNegotiation` is threaded through `InspectorClientOptions` (default `legacy`), replacing the hardcoded pin from the SDK-migration card.
- After connect, the client reads `getProtocolEra()` / `getDiscoverResult()` / `getNegotiatedProtocolVersion()`, exposes them via getters, dispatches `protocolEraChange` / `discoverResultChange`, and clears them on disconnect. `useInspectorClient` surfaces `protocolEra` / `discoverResult`.

**Web UI**
- `ServerSettingsForm`: a **Protocol Era** selector bound to the per-server setting.
- `ConnectionInfoContent`: era-aware — an **Era** badge, a **Session** row that reads **"Sessionless"** on modern, and a **Discovery** section (supported versions + advertised extensions) from the `server/discover` result.

**CLI/TUI** also map the `mcp.json` `protocolEra` into `versionNegotiation`, so the field applies uniformly across all three clients.

### Scope notes
- Version negotiation is fully **client-side** (the SDK Client). The `server/discover` probe and `_meta` envelope travel as JSON-RPC bodies over the existing remote tunnel, so **modern connect works with no backend header work**, and **disconnect is sessionless** (the SDK skips the upstream `DELETE` when there is no session id). On a modern connect the SDK populates `getServerCapabilities()`/`getServerVersion()` from `server/discover`, so tab-gating keeps working unchanged.
- HTTP-header fidelity (`Mcp-Method` / `Mcp-Param-*`) and the new message vocabulary are deliberately left to the **History/Network** card (#4 in the sequencing), as are the tab-by-tab era forks (#5).

### Testing
`npm run ci` green locally: validate (4 clients), the per-file ≥90 coverage gate (4 clients), smoke, and Storybook. New coverage includes the era→negotiation mapper, config round-trip, read/write validators, an integration test that negotiates the legacy era under `auto` against the stdio test server, the hook subscriptions, and the era-aware Connection Info + settings selector (plus a Storybook `ModernEra` story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNdjEPKLG637X8YmhDiEk5