### PR TITLE
fix(cli): publish cli/package.json so --cli metadata lookup works from the installed package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "client/dist",
     "server/build",
     "server/static",
-    "cli/build"
+    "cli/build",
+    "cli/package.json"
   ],
   "workspaces": [
     "client",


### PR DESCRIPTION
## Summary

The CLI (`--cli` mode) is broken from v0.17.0 through v0.22.0: invocations can fail immediately with `ERR_MODULE_NOT_FOUND` for `cli/package.json`.

`cli/build/index.js` reads `../package.json` to get the CLI name and version for the client identity. The root package `files` allowlist ships `cli/build` but not `cli/package.json`, so that file is absent from the published npm tarball. The current cwd-relative `fs.existsSync("../package.json")` probe selects the module-relative `../package.json` (which resolves to `cli/package.json`) whenever the process working directory happens to have a sibling `package.json`, and the dynamic import then fails because the file was never published.

Adding `cli/package.json` to `files` makes both resolution targets present in the tarball, so the metadata import always resolves.

This is the packaging half of the problem; #1337 separately hardens the runtime resolution to be module-relative. The two are complementary and touch different files (`package.json` here vs `cli/src/index.ts` there).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How verified

`npm pack --dry-run` at the repo root (lifecycle scripts skipped for the file listing):

- Before: `cli/package.json` is absent from the packed file list
- After: `cli/package.json` is present in the packed file list

## Related

Fixes #1503
