### PR TITLE
chore(deps): override hono to ^4.12.25 (CVE fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7588,9 +7588,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
   },
   "overrides": {
     "get-intrinsic": "1.3.0",
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "hono": "^4.12.25"
   },
   "engines": {
     "node": ">=22.7.5"


### PR DESCRIPTION
## Summary

`hono` is a transitive runtime dependency pulled in via `@modelcontextprotocol/sdk` (and `@hono/node-server`), previously resolving to `hono@4.12.23`. Five Dependabot security advisories affecting hono are patched in `hono >= 4.12.25`.

This PR adds an `overrides` entry pinning `hono` to `^4.12.25`, so the entire dependency tree resolves to a patched version. After `npm install`, `npm ls hono --all` shows all hono at `4.12.30` (>= 4.12.25).

The only source change is the `overrides` block in the root `package.json` (the existing `get-intrinsic` override is preserved); `package-lock.json` is refreshed accordingly. No inspector version numbers were changed.

## Verification

- `npx prettier --check .` — pass
- `npm run check-version` — pass
- `client` lint — pass
- `client` tests — 535 passed
- `cli` tests — 85 passed
- `npm run build` (server + client + cli) — pass

Resolves Dependabot alerts 126, 128, 127, 125, 124

Part of #1706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiccCEh9mwCfVzE8qYcop1