### PR TITLE
chore(deps): bump vite to ^7.3.5 (CVE fixes)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -85,6 +85,6 @@
     "ts-jest": "^29.4.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.38.0",
-    "vite": "^7.1.11"
+    "vite": "^7.3.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,7 +136,7 @@
         "ts-jest": "^29.4.0",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.38.0",
-        "vite": "^7.1.11"
+        "vite": "^7.3.5"
       }
     },
     "client/node_modules/jest-environment-jsdom": {
@@ -12957,13 +12957,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",


### PR DESCRIPTION
## Summary

Bumps the client's `vite` dev dependency from `^7.1.11` to `^7.3.5` to resolve two Dependabot security alerts.

- **123 (HIGH)** — `vite` `server.fs.deny` bypass, patched in 7.3.5.
- **129 (MEDIUM)** — vulnerability in `launch-editor`, a transitive dependency of `vite`. The newer vite no longer pulls in `launch-editor` at all, so the vulnerable package is removed from the tree.

After the bump, `npm ls vite` resolves to **vite 7.3.6** (>= 7.3.5) and `launch-editor` is no longer present in the dependency tree.

Resolves Dependabot alerts 123, 129.

Part of #1706.

### Note on esbuild (121)

`esbuild` is also a transitive dependency of vite. After this bump it resolves to **0.27.7**, which is still below the patched 0.28.1, so this PR does **not** clear alert 121. No esbuild override was added here.

### Verification

- `npx prettier --check .` — pass
- `npm run check-version` — pass
- `client` lint — pass
- `client` tests — pass (535/535)
- `cli` tests — pass (85/85)
- `npm run build` — pass (client vite build succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiccCEh9mwCfVzE8qYcop1