### PR TITLE
chore(deps): override form-data to ^4.0.6 (CVE fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7223,17 +7223,17 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -7576,9 +7576,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
   "overrides": {
     "get-intrinsic": "1.3.0",
     "shell-quote": "^1.8.4",
-    "hono": "^4.12.25"
+    "hono": "^4.12.25",
+    "form-data": "^4.0.6"
   },
   "engines": {
     "node": ">=22.7.5"


### PR DESCRIPTION
## Summary

Adds a `form-data` override to the root `package.json` so the transitive dev dependency resolves to `>= 4.0.6`, which contains the fix for the CRLF-injection vulnerability.

Before this change, `form-data` resolved to `4.0.5` via `vitest -> jsdom`. After the override, `npm ls form-data --all` shows only `form-data@4.0.6`:

```
@modelcontextprotocol/inspector-cli -> ./cli
  vitest@4.0.17
    jsdom@20.0.3
      form-data@4.0.6
```

The existing `get-intrinsic` override is preserved. No inspector version numbers were changed.

Resolves Dependabot alert 130

Part of #1706

## Verification

All CI checks (mirroring `.github/workflows/main.yml` and `cli_tests.yml`) pass locally:

- `npx prettier --check .` — pass
- `npm run check-version` — pass
- `cd client && npm run lint` — pass
- `cd client && npm test` — pass (535 tests)
- `cd cli && npm test` — pass (85 tests)
- `npm run build` — pass

E2e tests were not run (require Playwright browser downloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiccCEh9mwCfVzE8qYcop1