### PR TITLE
chore(deps): override @babel/core to ^7.29.6 (CVE fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "get-intrinsic": "1.3.0",
     "shell-quote": "^1.8.4",
     "hono": "^4.12.25",
-    "form-data": "^4.0.6"
+    "form-data": "^4.0.6",
+    "@babel/core@<=7.29.0": "^7.29.6"
   },
   "engines": {
     "node": ">=22.7.5"


### PR DESCRIPTION
## Summary

Adds an npm `override` forcing `@babel/core` to `^7.29.6` to remediate a transitive dev-dependency vulnerability.

`@babel/core` is pulled in transitively (via the client toolchain / babel plugins) and previously resolved to **7.28.5**, which is affected by an arbitrary file read via a crafted `sourceMappingURL` (fixed in `>= 7.29.6`). With this override it now resolves to **7.29.7**, and `npm ls @babel/core --all` shows no instances below `7.29.6`.

The change is intentionally minimal:
- Root `package.json`: add `"@babel/core": "^7.29.6"` to `overrides` (the existing `get-intrinsic` override is preserved).
- `package-lock.json`: refreshed with a targeted update of only the `@babel/*` subtree (no unrelated dependency bumps).

## Verification

- `npx prettier --check .` — pass
- `npm run check-version` — pass
- `cd client && npm run lint` — pass
- `cd client && npm test` — pass (535 tests)
- `cd cli && npm test` — pass (85 tests)
- `npm run build` — pass
- E2e tests skipped (require Playwright browser downloads unavailable in this environment)

Resolves Dependabot alert 132

Part of #1706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiccCEh9mwCfVzE8qYcop1