### PR TITLE
chore(deps): override js-yaml (3.15.0 / 4.2.0) (DoS fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1633,9 +1633,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9523,9 +9523,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,9 @@
     "typescript": "^5.4.2"
   },
   "overrides": {
-    "get-intrinsic": "1.3.0"
+    "get-intrinsic": "1.3.0",
+    "js-yaml@<4": "3.15.0",
+    "js-yaml@>=4": "4.2.0"
   },
   "engines": {
     "node": ">=22.7.5"


### PR DESCRIPTION
## Summary

Two js-yaml lines exist in the dependency tree, each affected by the quadratic-DoS advisories. This PR adds **version-targeted npm overrides** so each major stays on its own line and gets its respective patched release:

- **js-yaml 3.x** — pulled by `@istanbuljs/load-nyc-config` (used by jest coverage tooling), currently 3.14.2 → **3.15.0** (first 3.x release with the fix).
- **js-yaml 4.x** — pulled by `@eslint/eslintrc`, currently 4.1.1 → **4.2.0**.

```json
"overrides": {
  "get-intrinsic": "1.3.0",
  "js-yaml@<4": "3.15.0",
  "js-yaml@>=4": "4.2.0"
}
```

## Why keep the majors separate

The js-yaml 3 → 4 API changed (e.g. `safeLoad`/`safeDump` were removed, default schema behavior differs). Forcing the 3.x consumer onto the 4.x line would break jest coverage tooling, so the two lines are pinned independently using version-targeted override keys rather than a single blanket override.

## Verification

`npm ls js-yaml --all` after install:

```
├─┬ @eslint/eslintrc@3.3.3
│ └── js-yaml@4.2.0
└─┬ @istanbuljs/load-nyc-config@1.1.0
  └── js-yaml@3.15.0
```

No 3.x below 3.15.0, no 4.x below 4.2.0.

Checks run and passing: `prettier --check .`, `npm run check-version`, client `eslint`, client `jest` (535 tests, coverage exercises the 3.x line), CLI tests (85 tests), and `npm run build`. E2e (Playwright) skipped — requires browser downloads.

Resolves Dependabot alerts #134, #133
Part of #1706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiccCEh9mwCfVzE8qYcop1