### PR TITLE
chore(deps): override esbuild to ^0.28.1 (CVE fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "get-intrinsic": "1.3.0",
     "shell-quote": "^1.8.4",
     "hono": "^4.12.25",
-    "form-data": "^4.0.6"
+    "form-data": "^4.0.6",
+    "esbuild": "^0.28.1"
   },
   "engines": {
     "node": ">=22.7.5"


### PR DESCRIPTION
## Summary

Adds an npm `overrides` entry forcing **esbuild** to `^0.28.1`, which resolves the moderate-severity dev-server arbitrary file read advisory affecting `esbuild < 0.28.1` (on Windows). esbuild is a transitive **dev** dependency pulled in by `vite` and `vitest`; it previously resolved to `0.27.7`. The existing `get-intrinsic` override is preserved.

```json
"overrides": {
  "get-intrinsic": "1.3.0",
  "esbuild": "^0.28.1"
}
```

## Verification

- `npm ls esbuild --all` → esbuild resolves to `0.28.1` everywhere (under vite 7.3.6 and tsx/vitest).
- `npm audit` → **0 vulnerabilities**.
- `npm run check-version` → pass.
- `cd client && npm run lint` → pass.
- `cd client && npm test` → **535 passed**.
- `cd cli && npm test` → **85 passed**.
- `npm run build` → pass (client + cli).

Forcing esbuild `0.28.1` does **not** break the client build or tests — no vite bump was required for this fix.

> Note: repo-wide `prettier --check` currently flags 5 pre-existing client files unrelated to this change. This is caused by `prettier` floating to `3.9.5` (package.json allows `^3.7.1`) whose formatting rules differ from the `3.7.4` the files were formatted with. It is a separate, pre-existing drift and is intentionally out of scope for this security fix.

Resolves Dependabot alert #121
Part of #1706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiccCEh9mwCfVzE8qYcop1