### PR TITLE
chore(deps): override vulnerable minimatch 3.x to 3.1.5 (ReDoS fixes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
   "overrides": {
     "get-intrinsic": "1.3.0",
     "shell-quote": "^1.8.4",
-    "hono": "^4.12.25"
+    "hono": "^4.12.25",
+    "minimatch@<3.1.4": "3.1.5"
   },
   "engines": {
     "node": ">=22.7.5"


### PR DESCRIPTION
## Summary

Adds a **version-targeted** npm override in the root `package.json` so that **only the vulnerable minimatch 3.x line** is bumped, resolving the HIGH-severity ReDoS advisories.

```json
"overrides": {
  "get-intrinsic": "1.3.0",
  "minimatch@<3.1.4": "3.1.5"
}
```

The `minimatch@<3.1.4` selector scopes the override to the old 3.x line only. The healthy **minimatch 9.x and 10.x** instances elsewhere in the tree are left completely untouched (never forced down).

## Verification

`npm ls minimatch --all` after the change:

- 6x `minimatch@3.1.5` (all former 3.1.2 consumers now deduped to 3.1.5)
- 1x `minimatch@9.0.9` — untouched
- 1x `minimatch@10.2.5` — untouched
- **No** minimatch `< 3.1.4` remains

The lockfile change is minimal — only the single hoisted `node_modules/minimatch` entry moves from 3.1.2 to 3.1.5. `npm ci` installs cleanly against the committed lockfile.

## Checks

- `npx prettier --check .` — pass
- `npm run check-version` — pass
- `cd client && npm run lint` — pass
- `cd client && npm test` — pass (535 tests)
- `cd cli && npm test` — pass (85 tests)
- `npm run build` — pass
- e2e (`e2e_tests.yml`) — skipped (requires Playwright browser download)

Resolves Dependabot alerts #69, #66, #61
Part of #1706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiccCEh9mwCfVzE8qYcop1