### PR TITLE
chore: pin prettier to 3.9.5 and run format check after install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check formatting
-        run: npx prettier --check .
-
       - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
@@ -25,6 +22,9 @@ jobs:
       # Working around https://github.com/npm/cli/issues/4828
       # - run: npm ci
       - run: npm install --no-package-lock
+
+      - name: Check formatting
+        run: npm run prettier-check
 
       - name: Check version consistency
         run: npm run check-version

--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -347,8 +347,7 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
           // Titled single-select using oneOf/anyOf with const/title pairs
           const titledOptions = (
             (propSchema.oneOf ?? propSchema.anyOf) as
-              | (JsonSchemaType | JsonSchemaConst)[]
-              | undefined
+              (JsonSchemaType | JsonSchemaConst)[] | undefined
           )?.filter((opt): opt is JsonSchemaConst => "const" in opt);
 
           if (titledOptions && titledOptions.length > 0) {
@@ -606,8 +605,7 @@ const DynamicJsonForm = forwardRef<DynamicJsonFormRef, DynamicJsonFormProps>(
 
           const titledMulti = (
             (itemSchema.anyOf ?? itemSchema.oneOf) as
-              | (JsonSchemaType | JsonSchemaConst)[]
-              | undefined
+              (JsonSchemaType | JsonSchemaConst)[] | undefined
           )?.filter((opt): opt is JsonSchemaConst => "const" in opt);
 
           if (titledMulti && titledMulti.length > 0) {

--- a/client/src/components/ElicitationTab.tsx
+++ b/client/src/components/ElicitationTab.tsx
@@ -20,8 +20,7 @@ export interface ElicitationUrlRequestData extends ElicitationRequestBase {
 }
 
 export type ElicitationRequestData =
-  | ElicitationFormRequestData
-  | ElicitationUrlRequestData;
+  ElicitationFormRequestData | ElicitationUrlRequestData;
 
 export interface ElicitationResponse {
   action: "accept" | "decline" | "cancel";

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -30,10 +30,7 @@ export const getServerSpecificKey = (
 };
 
 export type ConnectionStatus =
-  | "disconnected"
-  | "connected"
-  | "error"
-  | "error-connecting-to-proxy";
+  "disconnected" | "connected" | "error" | "error-connecting-to-proxy";
 
 export const DEFAULT_MCP_PROXY_LISTEN_PORT = "6277";
 

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -564,8 +564,7 @@ export function useConnection({
 
       // Create appropriate transport
       let transportOptions:
-        | StreamableHTTPClientTransportOptions
-        | SSEClientTransportOptions;
+        StreamableHTTPClientTransportOptions | SSEClientTransportOptions;
 
       let serverUrl: URL;
 
@@ -843,8 +842,7 @@ export function useConnection({
       const makeTaskId = () => {
         // Prefer UUID when available; otherwise fall back to a reasonably unique id.
         const cryptoAny = globalThis.crypto as unknown as
-          | { randomUUID?: () => string }
-          | undefined;
+          { randomUUID?: () => string } | undefined;
         return (
           cryptoAny?.randomUUID?.() ??
           `task_${Date.now()}_${Math.random().toString(16).slice(2)}`

--- a/client/src/utils/configUtils.ts
+++ b/client/src/utils/configUtils.ts
@@ -59,18 +59,14 @@ export const getMCPTaskTtl = (config: InspectorConfig): number => {
 };
 
 export const getInitialTransportType = ():
-  | "stdio"
-  | "sse"
-  | "streamable-http" => {
+  "stdio" | "sse" | "streamable-http" => {
   const param = getSearchParam("transport");
   if (param === "stdio" || param === "sse" || param === "streamable-http") {
     return param;
   }
   return (
     (localStorage.getItem("lastTransportType") as
-      | "stdio"
-      | "sse"
-      | "streamable-http") || "stdio"
+      "stdio" | "sse" | "streamable-http") || "stdio"
   );
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "jest-fixed-jsdom": "^0.0.9",
         "lint-staged": "^16.1.5",
         "playwright": "^1.56.1",
-        "prettier": "^3.7.1",
+        "prettier": "3.9.5",
         "rimraf": "^6.0.1",
         "typescript": "^5.4.2"
       },
@@ -10908,9 +10908,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jest-fixed-jsdom": "^0.0.9",
     "lint-staged": "^16.1.5",
     "playwright": "^1.56.1",
-    "prettier": "^3.7.1",
+    "prettier": "3.9.5",
     "rimraf": "^6.0.1",
     "typescript": "^5.4.2"
   },


### PR DESCRIPTION
## Problem

The `main.yml` CI workflow's **Check formatting** step ran `npx prettier --check .` **before** `npm install`. Because prettier was not yet installed locally, npx downloaded the **latest** published prettier (currently 3.9.5) instead of the version pinned in `package-lock.json` (3.7.4). Meanwhile the caret range `"prettier": "^3.7.1"` allowed the locally-resolved version to drift from whatever npx fetched.

The result: the format check was non-deterministic and turned **red on every open PR** whenever the latest published prettier's formatting differed from the pinned one. Five client source files were already flagged as "not formatted" under 3.9.5 even though they were correctly formatted under the pinned 3.7.x.

## Fix

1. **Pin prettier to an exact version** — `"prettier": "3.9.5"` in root `devDependencies`, and update `package-lock.json` accordingly. No more caret-range drift.
2. **Reformat the repo** with the now-pinned prettier (`npm run prettier-fix`). This reformats the 5 drifted files to 3.9.5 style — this source churn is the point of the PR.
3. **Make CI use the pinned prettier** — in `.github/workflows/main.yml`, move the *Check formatting* step to run **after** `npm install --no-package-lock`, and change its command to `npm run prettier-check` (which invokes the locally-installed pinned prettier rather than npx-latest).

`cli_tests.yml` and `e2e_tests.yml` had no pre-install `npx prettier` step, so they were left unchanged.

## Reformatted files

- `client/src/components/DynamicJsonForm.tsx`
- `client/src/components/ElicitationTab.tsx`
- `client/src/lib/constants.ts`
- `client/src/lib/hooks/useConnection.ts`
- `client/src/utils/configUtils.ts`

## Impact

This makes the format check deterministic and unblocks the **Check formatting** CI step on the open #1706 security PRs (and all other open PRs), which were failing purely because of this npx-latest vs pinned-version mismatch.

## Verification

- `npx prettier --check .` — passes
- `npm run prettier-check` — passes
- `npm run check-version` — passes
- `(cd client && npm run lint)` — passes
- `(cd client && npm test)` — 535 passed
- `(cd cli && npm test)` — 85 passed
- `npm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiccCEh9mwCfVzE8qYcop1