### PR TITLE
Add cancel control for task polling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -111,6 +111,13 @@ type PrefilledAppsToolCall = {
   result: CompatibilityCallToolResult;
 };
 
+type ActivePollingTask = {
+  taskId: string;
+  runId: number;
+  cancelled: boolean;
+  wakePollingDelay?: () => void;
+};
+
 const hasAppResourceUri = (tool: Tool): boolean => {
   return Boolean(getToolUiResourceUri(tool));
 };
@@ -308,6 +315,7 @@ const App = () => {
   const [selectedTool, setSelectedTool] = useState<Tool | null>(null);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [isPollingTask, setIsPollingTask] = useState(false);
+  const [pollingTaskId, setPollingTaskId] = useState<string | null>(null);
   const [nextResourceCursor, setNextResourceCursor] = useState<
     string | undefined
   >();
@@ -321,6 +329,8 @@ const App = () => {
   const [nextTaskCursor, setNextTaskCursor] = useState<string | undefined>();
   const progressTokenRef = useRef(0);
   const prefilledAppsToolCallIdRef = useRef(0);
+  const activePollingTaskRef = useRef<ActivePollingTask | null>(null);
+  const pollingRunIdRef = useRef(0);
 
   const [activeTab, setActiveTab] = useState<string>(() => {
     const hash = window.location.hash.slice(1);
@@ -1107,8 +1117,15 @@ const App = () => {
       if (runAsTask && isTaskResult(response)) {
         const taskId = response.task.taskId;
         const pollInterval = response.task.pollInterval;
+        const pollingRunId = ++pollingRunIdRef.current;
+        activePollingTaskRef.current = {
+          taskId,
+          runId: pollingRunId,
+          cancelled: false,
+        };
         // Set polling state BEFORE setting tool result for proper UI update
         setIsPollingTask(true);
+        setPollingTaskId(taskId);
         // Safely extract any _meta from the original response (if present)
         const initialResponseMeta =
           response &&
@@ -1130,12 +1147,41 @@ const App = () => {
         };
         setToolResult(latestToolResult);
 
+        const isPollingCancelled = () =>
+          activePollingTaskRef.current?.runId !== pollingRunId ||
+          activePollingTaskRef.current.cancelled;
+
+        const waitForNextPoll = () =>
+          new Promise<void>((resolve) => {
+            const timeoutId = setTimeout(() => {
+              const activePollingTask = activePollingTaskRef.current;
+              if (activePollingTask?.runId === pollingRunId) {
+                activePollingTask.wakePollingDelay = undefined;
+              }
+              resolve();
+            }, pollInterval);
+
+            const activePollingTask = activePollingTaskRef.current;
+            if (activePollingTask?.runId === pollingRunId) {
+              activePollingTask.wakePollingDelay = () => {
+                clearTimeout(timeoutId);
+                activePollingTask.wakePollingDelay = undefined;
+                resolve();
+              };
+            }
+          });
+
         // Polling loop
         let taskCompleted = false;
         while (!taskCompleted) {
           try {
-            // Wait for 1 second before polling
-            await new Promise((resolve) => setTimeout(resolve, pollInterval));
+            // Wait for the server-provided poll interval before polling.
+            await waitForNextPoll();
+
+            if (isPollingCancelled()) {
+              taskCompleted = true;
+              break;
+            }
 
             const taskStatus = await sendMCPRequest(
               {
@@ -1144,6 +1190,11 @@ const App = () => {
               },
               GetTaskResultSchema,
             );
+
+            if (isPollingCancelled()) {
+              taskCompleted = true;
+              break;
+            }
 
             if (
               taskStatus.status === "completed" ||
@@ -1164,6 +1215,10 @@ const App = () => {
                   },
                   CompatibilityCallToolResultSchema,
                 );
+                if (isPollingCancelled()) {
+                  taskCompleted = true;
+                  break;
+                }
                 console.log(`Result received for task ${taskId}:`, result);
                 latestToolResult = result as CompatibilityCallToolResult;
                 setToolResult(latestToolResult);
@@ -1220,6 +1275,10 @@ const App = () => {
                   },
                   CompatibilityCallToolResultSchema,
                 );
+                if (isPollingCancelled()) {
+                  taskCompleted = true;
+                  break;
+                }
                 void listTasks();
               } else {
                 latestToolResult = {
@@ -1240,6 +1299,10 @@ const App = () => {
               }
             }
           } catch (pollingError) {
+            if (isPollingCancelled()) {
+              taskCompleted = true;
+              break;
+            }
             console.error("Error polling task status:", pollingError);
             latestToolResult = {
               content: [
@@ -1254,9 +1317,13 @@ const App = () => {
             taskCompleted = true;
           }
         }
-        setIsPollingTask(false);
-        // Clear any validation errors since tool execution completed
-        setErrors((prev) => ({ ...prev, tools: null }));
+        if (activePollingTaskRef.current?.runId === pollingRunId) {
+          activePollingTaskRef.current = null;
+          setIsPollingTask(false);
+          setPollingTaskId(null);
+          // Clear any validation errors since tool execution completed
+          setErrors((prev) => ({ ...prev, tools: null }));
+        }
         return latestToolResult;
       } else {
         const directResult = response as CompatibilityCallToolResult;
@@ -1312,6 +1379,70 @@ const App = () => {
       }));
     }
   };
+
+  const cancelTaskPolling = useCallback(async () => {
+    const activePollingTask = activePollingTaskRef.current;
+    if (!activePollingTask) return;
+
+    try {
+      const response = await cancelMcpTask(activePollingTask.taskId);
+      const currentActivePollingTask = activePollingTaskRef.current;
+      if (currentActivePollingTask?.runId !== activePollingTask.runId) {
+        return;
+      }
+
+      currentActivePollingTask.cancelled = true;
+      currentActivePollingTask.wakePollingDelay?.();
+      activePollingTaskRef.current = null;
+      setIsPollingTask(false);
+      setPollingTaskId(null);
+      setTasks((prev) => {
+        const exists = prev.some((t) => t.taskId === response.taskId);
+        return exists
+          ? prev.map((t) => (t.taskId === response.taskId ? response : t))
+          : [response, ...prev];
+      });
+      if (selectedTaskRef.current?.taskId === response.taskId) {
+        setSelectedTask(response);
+      }
+      setToolResult({
+        content: [
+          {
+            type: "text",
+            text: `Task cancelled: ${response.statusMessage || response.taskId}`,
+          },
+        ],
+        isError: true,
+        _meta: {
+          "io.modelcontextprotocol/related-task": {
+            taskId: response.taskId,
+          },
+        },
+      });
+      setErrors((prev) => ({ ...prev, tools: null }));
+      void listTasks();
+    } catch (e) {
+      const message = (e as Error).message ?? String(e);
+      setErrors((prev) => ({
+        ...prev,
+        tools: message,
+      }));
+      setToolResult({
+        content: [
+          {
+            type: "text",
+            text: `Error cancelling task: ${message}`,
+          },
+        ],
+        isError: true,
+        _meta: {
+          "io.modelcontextprotocol/related-task": {
+            taskId: activePollingTask.taskId,
+          },
+        },
+      });
+    }
+  }, [cancelMcpTask, listTasks]);
 
   const handleRootsChange = async () => {
     await sendNotification({ method: "notifications/roots/list_changed" });
@@ -1657,6 +1788,8 @@ const App = () => {
                         }}
                         toolResult={toolResult}
                         isPollingTask={isPollingTask}
+                        pollingTaskId={pollingTaskId}
+                        cancelTaskPolling={cancelTaskPolling}
                         nextCursor={nextToolCursor}
                         error={errors.tools}
                         resourceContent={resourceContentMap}

--- a/client/src/__tests__/App.taskPolling.test.tsx
+++ b/client/src/__tests__/App.taskPolling.test.tsx
@@ -119,6 +119,9 @@ jest.mock("../components/ToolsTab", () => ({
   default: ({
     callTool,
     toolResult,
+    isPollingTask,
+    pollingTaskId,
+    cancelTaskPolling,
   }: {
     callTool: (
       name: string,
@@ -127,6 +130,9 @@ jest.mock("../components/ToolsTab", () => ({
       runAsTask?: boolean,
     ) => Promise<unknown>;
     toolResult: { content: Array<{ type: string; text: string }> } | null;
+    isPollingTask?: boolean;
+    pollingTaskId?: string | null;
+    cancelTaskPolling?: () => Promise<void>;
   }) => (
     <div data-testid="tools-tab">
       <button
@@ -137,6 +143,16 @@ jest.mock("../components/ToolsTab", () => ({
       >
         run task tool
       </button>
+      {isPollingTask && pollingTaskId && cancelTaskPolling && (
+        <button
+          type="button"
+          onClick={() => {
+            void cancelTaskPolling();
+          }}
+        >
+          cancel polling task
+        </button>
+      )}
       {toolResult && (
         <div data-testid="tool-result">
           {toolResult.content.map((c, i) => (
@@ -332,5 +348,191 @@ describe("App - task polling with input_required status", () => {
       ([req]) => (req as { method: string }).method === "tasks/result",
     );
     expect(resultCalls).toHaveLength(1);
+  });
+
+  it("lets users cancel the active polling task from the Tools tab", async () => {
+    const POLL_INTERVAL_MS = 1000;
+    const taskId = "task-cancel-789";
+    const cancelTask = jest.fn(async () => ({
+      taskId,
+      status: "cancelled",
+      statusMessage: "Cancelled by user",
+    }));
+    const makeRequest = jest.fn(async (request: { method: string }) => {
+      if (request.method === "tools/list") {
+        return {
+          tools: [
+            {
+              name: "myTool",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+          nextCursor: undefined,
+        };
+      }
+
+      if (request.method === "tools/call") {
+        // The interval has to outlast the render and click below, otherwise the
+        // polling loop reaches tasks/get before the cancel button is pressed.
+        return {
+          task: { taskId, status: "working", pollInterval: POLL_INTERVAL_MS },
+        };
+      }
+
+      if (request.method === "tasks/list") {
+        return { tasks: [] };
+      }
+
+      throw new Error(
+        `Unexpected method after cancellation: ${request.method}`,
+      );
+    });
+
+    mockUseConnection.mockReturnValue({
+      connectionStatus: "connected",
+      serverCapabilities: { tools: { listChanged: true } },
+      serverImplementation: null,
+      mcpClient: {
+        request: jest.fn(),
+        notification: jest.fn(),
+        close: jest.fn(),
+      } as unknown as Client,
+      requestHistory: [],
+      clearRequestHistory: jest.fn(),
+      makeRequest,
+      cancelTask,
+      listTasks: jest.fn(),
+      sendNotification: jest.fn(),
+      handleCompletion: jest.fn(),
+      completionsSupported: false,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+    } as ReturnType<typeof useConnection>);
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: /run task tool/i }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /cancel polling task/i }),
+    );
+
+    await waitFor(() => {
+      expect(cancelTask).toHaveBeenCalledWith(taskId);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("tool-result")).toHaveTextContent(
+        "Task cancelled: Cancelled by user",
+      );
+    });
+
+    // Wait past a full poll interval to prove the loop stopped for good.
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS * 1.5));
+    const taskGetCalls = makeRequest.mock.calls.filter(
+      ([req]) => (req as { method: string }).method === "tasks/get",
+    );
+    expect(taskGetCalls).toHaveLength(0);
+  });
+
+  it("does not let an in-flight polling response overwrite a cancelled task", async () => {
+    const taskId = "task-cancel-in-flight";
+    let resolveTaskGet:
+      ((value: { taskId: string; status: string }) => void) | undefined;
+    const taskGetResponse = new Promise<{ taskId: string; status: string }>(
+      (resolve) => {
+        resolveTaskGet = resolve;
+      },
+    );
+    const cancelTask = jest.fn(async () => ({
+      taskId,
+      status: "cancelled",
+      statusMessage: "Cancelled by user",
+    }));
+    const makeRequest = jest.fn(async (request: { method: string }) => {
+      if (request.method === "tools/list") {
+        return {
+          tools: [
+            {
+              name: "myTool",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+          nextCursor: undefined,
+        };
+      }
+
+      if (request.method === "tools/call") {
+        return {
+          task: { taskId, status: "working", pollInterval: 0 },
+        };
+      }
+
+      if (request.method === "tasks/get") {
+        return taskGetResponse;
+      }
+
+      if (request.method === "tasks/result") {
+        return {
+          content: [{ type: "text", text: "late final result" }],
+        };
+      }
+
+      if (request.method === "tasks/list") {
+        return { tasks: [] };
+      }
+
+      throw new Error(`Unexpected method: ${request.method}`);
+    });
+
+    mockUseConnection.mockReturnValue({
+      connectionStatus: "connected",
+      serverCapabilities: { tools: { listChanged: true } },
+      serverImplementation: null,
+      mcpClient: {
+        request: jest.fn(),
+        notification: jest.fn(),
+        close: jest.fn(),
+      } as unknown as Client,
+      requestHistory: [],
+      clearRequestHistory: jest.fn(),
+      makeRequest,
+      cancelTask,
+      listTasks: jest.fn(),
+      sendNotification: jest.fn(),
+      handleCompletion: jest.fn(),
+      completionsSupported: false,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+    } as ReturnType<typeof useConnection>);
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: /run task tool/i }));
+    const cancelButton = await screen.findByRole("button", {
+      name: /cancel polling task/i,
+    });
+    await waitFor(() => {
+      const taskGetCalls = makeRequest.mock.calls.filter(
+        ([req]) => (req as { method: string }).method === "tasks/get",
+      );
+      expect(taskGetCalls).toHaveLength(1);
+    });
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tool-result")).toHaveTextContent(
+        "Task cancelled: Cancelled by user",
+      );
+    });
+
+    resolveTaskGet?.({ taskId, status: "completed" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(screen.getByTestId("tool-result")).toHaveTextContent(
+      "Task cancelled: Cancelled by user",
+    );
+    const resultCalls = makeRequest.mock.calls.filter(
+      ([req]) => (req as { method: string }).method === "tasks/result",
+    );
+    expect(resultCalls).toHaveLength(0);
   });
 });

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -173,6 +173,8 @@ const ToolsTab = ({
   setSelectedTool,
   toolResult,
   isPollingTask,
+  pollingTaskId,
+  cancelTaskPolling,
   nextCursor,
   error,
   resourceContent,
@@ -193,6 +195,8 @@ const ToolsTab = ({
   setSelectedTool: (tool: Tool | null) => void;
   toolResult: CompatibilityCallToolResult | null;
   isPollingTask?: boolean;
+  pollingTaskId?: string | null;
+  cancelTaskPolling?: () => Promise<void>;
   nextCursor: ListToolsResult["nextCursor"];
   error: string | null;
   resourceContent: Record<string, string>;
@@ -203,6 +207,7 @@ const ToolsTab = ({
   const [params, setParams] = useState<Record<string, unknown>>({});
   const [runAsTask, setRunAsTask] = useState(false);
   const [isToolRunning, setIsToolRunning] = useState(false);
+  const [isCancellingPollingTask, setIsCancellingPollingTask] = useState(false);
   const [isOutputSchemaExpanded, setIsOutputSchemaExpanded] = useState(false);
   const [isMetadataExpanded, setIsMetadataExpanded] = useState(false);
   const [metadataEntries, setMetadataEntries] = useState<
@@ -805,58 +810,85 @@ const ToolsTab = ({
                     </Label>
                   </div>
                 )}
-                <Button
-                  onClick={async () => {
-                    // Validate JSON inputs before calling tool
-                    if (checkValidationErrors(true)) return;
+                <div className="flex gap-2">
+                  <Button
+                    onClick={async () => {
+                      // Validate JSON inputs before calling tool
+                      if (checkValidationErrors(true)) return;
 
-                    try {
-                      setIsToolRunning(true);
-                      const metadata = metadataEntries.reduce<
-                        Record<string, unknown>
-                      >((acc, { key, value }) => {
-                        const trimmedKey = key.trim();
-                        if (
-                          trimmedKey !== "" &&
-                          hasValidMetaPrefix(trimmedKey) &&
-                          !isReservedMetaKey(trimmedKey) &&
-                          hasValidMetaName(trimmedKey)
-                        ) {
-                          acc[trimmedKey] = value;
-                        }
-                        return acc;
-                      }, {});
-                      await callTool(
-                        selectedTool.name,
-                        params,
-                        Object.keys(metadata).length ? metadata : undefined,
-                        runAsTask,
-                      );
-                    } finally {
-                      setIsToolRunning(false);
+                      try {
+                        setIsToolRunning(true);
+                        const metadata = metadataEntries.reduce<
+                          Record<string, unknown>
+                        >((acc, { key, value }) => {
+                          const trimmedKey = key.trim();
+                          if (
+                            trimmedKey !== "" &&
+                            hasValidMetaPrefix(trimmedKey) &&
+                            !isReservedMetaKey(trimmedKey) &&
+                            hasValidMetaName(trimmedKey)
+                          ) {
+                            acc[trimmedKey] = value;
+                          }
+                          return acc;
+                        }, {});
+                        await callTool(
+                          selectedTool.name,
+                          params,
+                          Object.keys(metadata).length ? metadata : undefined,
+                          runAsTask,
+                        );
+                      } finally {
+                        setIsToolRunning(false);
+                      }
+                    }}
+                    disabled={
+                      isToolRunning ||
+                      isPollingTask ||
+                      hasValidationErrors ||
+                      hasReservedMetadataEntry ||
+                      hasInvalidMetaPrefixEntry ||
+                      hasInvalidMetaNameEntry
                     }
-                  }}
-                  disabled={
-                    isToolRunning ||
-                    isPollingTask ||
-                    hasValidationErrors ||
-                    hasReservedMetadataEntry ||
-                    hasInvalidMetaPrefixEntry ||
-                    hasInvalidMetaNameEntry
-                  }
-                >
-                  {isToolRunning || isPollingTask ? (
-                    <>
-                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                      {isPollingTask ? "Polling Task..." : "Running..."}
-                    </>
-                  ) : (
-                    <>
-                      <Send className="w-4 h-4 mr-2" />
-                      Run Tool
-                    </>
+                  >
+                    {isToolRunning || isPollingTask ? (
+                      <>
+                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        {isPollingTask ? "Polling Task..." : "Running..."}
+                      </>
+                    ) : (
+                      <>
+                        <Send className="w-4 h-4 mr-2" />
+                        Run Tool
+                      </>
+                    )}
+                  </Button>
+                  {isPollingTask && pollingTaskId && cancelTaskPolling && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      aria-label={`Cancel polling task ${pollingTaskId}`}
+                      disabled={isCancellingPollingTask}
+                      onClick={async () => {
+                        try {
+                          setIsCancellingPollingTask(true);
+                          await cancelTaskPolling();
+                        } finally {
+                          setIsCancellingPollingTask(false);
+                        }
+                      }}
+                    >
+                      {isCancellingPollingTask ? (
+                        <>
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                          Cancelling...
+                        </>
+                      ) : (
+                        "Cancel Task"
+                      )}
+                    </Button>
                   )}
-                </Button>
+                </div>
                 <div className="flex gap-2">
                   <Button
                     onClick={async () => {


### PR DESCRIPTION
## Summary

Adds a cancel control for tool calls that are running as MCP tasks and currently being polled from the Tools tab.

## Root cause

The app already exposed `tasks/cancel` through the Tasks tab, but a user who launched a tool as a task from the Tools tab only saw the disabled `Polling Task...` button. The active polling task ID was not stored in a way that Tools could cancel, and the polling loop could continue into `tasks/get` after a user wanted to stop it.

## Changes

- Track the active polling task ID/run in `App`.
- Pass `pollingTaskId` and `cancelTaskPolling` into `ToolsTab`.
- Render a scoped `Cancel Task` button while a tool task is actively polling.
- Wake and stop the local polling delay after successful cancellation.
- Guard against late `tasks/get` / `tasks/result` responses overwriting the cancelled state.
- Add regression coverage for direct cancellation and an in-flight polling response race.

Closes #1039.

## Validation

- `npm.cmd test -- --runTestsByPath src/__tests__/App.taskPolling.test.tsx --runInBand`
- `npm.cmd run build-client`
- `npm.cmd run lint`
- `npx.cmd prettier --check client/src/App.tsx client/src/components/ToolsTab.tsx client/src/__tests__/App.taskPolling.test.tsx`
- `git diff --check`
