### PR TITLE
fix: handle SSE transport send errors after SSE disconnects

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -674,22 +674,28 @@ app.get(
         if (chunk.toString().includes("MODULE_NOT_FOUND")) {
           // Server command not found, remove transports
           const message = "Command not found, transports removed";
-          webAppTransport.send({
-            jsonrpc: "2.0",
-            method: "notifications/message",
-            params: {
-              level: "emergency",
-              logger: "proxy",
-              data: {
-                message,
+          webAppTransport
+            .send({
+              jsonrpc: "2.0",
+              method: "notifications/message",
+              params: {
+                level: "emergency",
+                logger: "proxy",
+                data: {
+                  message,
+                },
               },
-            },
-          });
-          webAppTransport.close();
-          serverTransport.close();
-          webAppTransports.delete(webAppTransport.sessionId);
-          serverTransports.delete(webAppTransport.sessionId);
-          sessionHeaderHolders.delete(webAppTransport.sessionId);
+            })
+            .catch(() => {
+              // SSE connection already closed, ignore
+            })
+            .finally(() => {
+              webAppTransport.close();
+              serverTransport.close();
+              webAppTransports.delete(webAppTransport.sessionId);
+              serverTransports.delete(webAppTransport.sessionId);
+              sessionHeaderHolders.delete(webAppTransport.sessionId);
+            });
           console.error(message);
         } else {
           // Inspect message and attempt to assign a RFC 5424 Syslog Protocol level
@@ -724,17 +730,21 @@ app.get(
           } else {
             level = "info";
           }
-          webAppTransport.send({
-            jsonrpc: "2.0",
-            method: "notifications/message",
-            params: {
-              level,
-              logger: "stdio",
-              data: {
-                message,
+          webAppTransport
+            .send({
+              jsonrpc: "2.0",
+              method: "notifications/message",
+              params: {
+                level,
+                logger: "stdio",
+                data: {
+                  message,
+                },
               },
-            },
-          });
+            })
+            .catch(() => {
+              // SSE connection already closed, ignore
+            });
         }
       });
 


### PR DESCRIPTION
## Summary
- catch rejected `webAppTransport.send()` promises in the stdio stderr handler
- keep transport cleanup in `.finally()` for the `MODULE_NOT_FOUND` path so cleanup still runs if the SSE client already disconnected
- avoid unhandled `Not connected` rejections when multiple SSE connections race and one closes before stderr forwarding completes

## Testing
- `npm ci`
- `npm run build-server`

Fixes #1014.

Supersedes the earlier stale attempt in #1129.