### PR TITLE
fix: resolve sandbox_proxy.html path in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN npm ci --omit=dev --ignore-scripts
 COPY --from=builder /app/client/dist ./client/dist
 COPY --from=builder /app/client/bin ./client/bin
 COPY --from=builder /app/server/build ./server/build
+COPY --from=builder /app/server/static ./server/static
 COPY --from=builder /app/cli/build ./cli/build
 
 # Set default port values as environment variables

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1066,7 +1066,7 @@ app.get(
   (req, res) => {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
-    const filePath = join(__dirname, "..", "static", "sandbox_proxy.html");
+    const filePath = join(__dirname, "static", "sandbox_proxy.html");
     let sandboxHtml;
 
     try {


### PR DESCRIPTION

## Summary

<!-- Provide a brief description of what this PR does -->

> **Note:** Inspector V2 is under development to address architectural and UX improvements. During this time, V1 contributions should focus on **bug fixes and MCP spec compliance**. See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.

The compiled server looks for sandbox_proxy.html at join(__dirname, '..', 'static', ...) which resolves to /app/server/static/ in Docker. However, the Dockerfile only copies server/build/ to the production image, not server/static/.

reference static files relative to the build output (join(__dirname, 'static', ...)) since the build process already copies static/ into build/static/. Also add explicit COPY of server/static/ in the Dockerfile for insurance

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

<!-- Describe the changes in detail. Include screenshots/recordings if applicable -->

## Related Issues

<!-- Link to related issues using #issue_number or "Fixes #issue_number" -->

## Testing

<!-- Describe how you tested these changes, where applicable -->

- [x] Tested in UI mode
- [x] Tested in CLI mode
- [x] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [ ] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

use curl -v http://localhost:6277/sandbox when you started docker container with network host,normally it return html

Screenshots are encouraged to share your testing results for this change.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->
None

## Additional Context

<!-- Add any other context, screenshots, or information about the PR here -->
None