### PR TITLE
fix(cli): align --log-level with MCP LoggingLevel specification

### DIFF
--- a/cli/__tests__/cli.test.ts
+++ b/cli/__tests__/cli.test.ts
@@ -410,6 +410,31 @@ describe("CLI Tests", () => {
 
       expectCliFailure(result);
     });
+
+    it("should reject non-spec log levels trace and warn", async () => {
+      const { command, args } = getTestMcpServerCommand();
+      const resultTrace = await runCli([
+        command,
+        ...args,
+        "--cli",
+        "--method",
+        "logging/setLevel",
+        "--log-level",
+        "trace",
+      ]);
+      expectCliFailure(resultTrace);
+
+      const resultWarn = await runCli([
+        command,
+        ...args,
+        "--cli",
+        "--method",
+        "logging/setLevel",
+        "--log-level",
+        "warn",
+      ]);
+      expectCliFailure(resultWarn);
+    });
   });
 
   describe("Combined Options", () => {

--- a/cli/src/client/connection.ts
+++ b/cli/src/client/connection.ts
@@ -3,11 +3,14 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { McpResponse } from "./types.js";
 
 export const validLogLevels = [
-  "trace",
   "debug",
   "info",
-  "warn",
+  "notice",
+  "warning",
   "error",
+  "critical",
+  "alert",
+  "emergency",
 ] as const;
 
 export type LogLevel = (typeof validLogLevels)[number];


### PR DESCRIPTION
﻿## Summary
- Update CLI `validLogLevels` to include all 8 spec-defined log levels (`debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`).
- Remove non-spec log level aliases (`trace`, `warn`) from CLI option validation.
- Add CLI tests validating rejection of non-spec log level strings.

## Root cause
`validLogLevels` in `cli/src/client/connection.ts` diverged from `@modelcontextprotocol/sdk`'s `LoggingLevelSchema` by including `trace`/`warn` while rejecting standard MCP levels like `notice`, `critical`, `alert`, and `emergency`.

Fixes #1734.

## Validation
- `cd cli && npx vitest run __tests__/cli.test.ts -t "reject"`
- `npm run build-cli`
