### PR TITLE
Fix number input silently changing value during page scroll

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -1,7 +1,7 @@
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
+import { Input, InputProps } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { TabsContent } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
@@ -162,6 +162,53 @@ const AnnotationBadges = ({
       ))}
     </div>
   );
+};
+
+/**
+ * Number input whose wheel behaviour depends on focus: while unfocused the
+ * event is left alone so the pane scrolls normally, and while focused the pane
+ * is pinned and the wheel steps the value instead.
+ *
+ * React registers its `wheel` listener on the root container as passive, so
+ * `preventDefault()` from an `onWheel` prop is silently dropped. Binding the
+ * listener on the element itself with `{ passive: false }` makes the event
+ * cancellable, which is what lets the focused case suppress the scroll. The
+ * step is applied through the native value setter plus a synthetic `input`
+ * event so the controlled `onChange` upstream still fires.
+ */
+const NumberInput = (props: InputProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+
+    const onWheel = (e: WheelEvent) => {
+      if (document.activeElement !== input || e.deltaY === 0) return;
+
+      // Focused: keep the pane still and step the value ourselves.
+      e.preventDefault();
+
+      const before = input.value;
+      if (e.deltaY < 0) {
+        input.stepUp();
+      } else {
+        input.stepDown();
+      }
+      const after = input.value;
+      if (after === before) return;
+
+      // `stepUp`/`stepDown` mutate the DOM value without going through React's
+      // instance-level value setter, so its change tracker still holds the old
+      // value and the dispatched event reaches the controlled `onChange`.
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    };
+
+    input.addEventListener("wheel", onWheel, { passive: false });
+    return () => input.removeEventListener("wheel", onWheel);
+  }, []);
+
+  return <Input {...props} type="number" ref={inputRef} />;
 };
 
 const ToolsTab = ({
@@ -517,8 +564,7 @@ const ToolsTab = ({
                             </div>
                           ) : prop.type === "number" ||
                             prop.type === "integer" ? (
-                            <Input
-                              type="number"
+                            <NumberInput
                               id={key}
                               name={key}
                               placeholder={prop.description}


### PR DESCRIPTION
While a number/integer input field was focused, scrolling the mouse wheel over it would both step the field's value (the browser's native stepper behavior on <input type="number">) and continue scrolling the page at the same time. Because these fields are short and easy to leave focused right after typing into them, a normal scroll-away gesture would silently change the value without the scroll itself giving any visual indication that a field was still active.

React's root-level wheel listener is passive, which makes preventDefault() from an onWheel prop a no-op, so this couldn't be fixed with a plain event handler.

Add a NumberInput wrapper that binds a non-passive wheel listener directly to the input element. When unfocused, the event is left alone entirely (page scrolls normally, as before). When focused, the listener prevents the page from scrolling and steps the value itself via stepUp()/stepDown(), dispatching a synthetic input event so the existing controlled onChange still fires.

## Summary

Fixes a bug where number/integer input fields in the tool call form would
silently change value while the page was being scrolled, due to native
browser behavior on `<input type="number">` combined with React's passive
root-level wheel listener.

> **Note:** Inspector V2 is under development to address architectural and UX improvements. During this time, V1 contributions should focus on **bug fixes and MCP spec compliance**. See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test updates
- [ ] Build/CI improvements

## Changes Made

While a number/integer input field was focused, scrolling the mouse wheel
over it would both step the field's value (the browser's native stepper
behavior on `<input type="number">`) and continue scrolling the page at
the same time. Because these fields are short and easy to leave focused
right after typing into them, a normal scroll-away gesture would silently
change the value without the scroll itself giving any visual indication
that a field was still active.

React's root-level wheel listener is passive, which makes
`preventDefault()` from an `onWheel` prop a no-op, so this couldn't be
fixed with a plain event handler.

This PR adds a `NumberInput` wrapper that binds a non-passive wheel
listener directly to the input element:
- **Unfocused:** the event is left alone entirely — the page scrolls
  normally, as before.
- **Focused:** the listener prevents the page from scrolling and steps
  the value itself via `stepUp()`/`stepDown()`, dispatching a synthetic
  `input` event so the existing controlled `onChange` still fires.

**Before:**

https://github.com/user-attachments/assets/69bbdfb0-8af3-4b24-8694-8e79a68964dd

**After:**

https://github.com/user-attachments/assets/bf279189-ab02-4a06-97b9-381cac769ecd

## Related Issues

N/A — found and fixed during local testing, not tied to an existing issue.

## Testing

<!-- Describe how you tested these changes, where applicable -->

- [x] Tested in UI mode
- [ ] Tested in CLI mode
- [x] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [ ] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

1. Connect any server with a tool that has a `number`/`integer` argument.
2. Click into the number field and type a value.
3. Without clicking away, scroll the mouse wheel down over the field.
4. **Before this fix:** the field's value silently decrements and the
   page scrolls at the same time.
5. **After this fix:** while the field is focused, scrolling steps the
   value via the native stepper and the page does not scroll; clicking
   away and scrolling again behaves like a normal page scroll.

Screenshots are encouraged to share your testing results for this change.

## Checklist

- [x] Code follows the style guidelines (ran `npm run prettier-fix`)
- [x] Self-review completed
- [x] Code is commented where necessary
- [x] Documentation updated (README, comments, etc.)

## Breaking Changes

None. Existing `onChange` behavior for number inputs is unchanged; this
only affects wheel-scroll interaction with a focused number field.

## Additional Context

Found while testing a custom MCP server locally in Inspector — noticed
number arguments were being silently altered during normal page
scrolling.