### PR TITLE
fix(test): use non-base36 secret fixtures to prevent flaky redaction assertion

### DIFF
--- a/clients/web/src/test/core/mcp/fetchTracking.test.ts
+++ b/clients/web/src/test/core/mcp/fetchTracking.test.ts
@@ -375,7 +375,7 @@ describe("createFetchTracker", () => {
       trackRequest: (entry) => tracked.push(entry),
     });
     const liveBody =
-      "grant_type=authorization_code&code=secret-auth-code&client_secret=shh&code_verifier=pkce123&client_id=public";
+      "grant_type=authorization_code&code=Secret-Auth-Code&client_secret=SHH&code_verifier=PKCE123&client_id=public";
     await fetcher("https://auth.example.com/token", {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
@@ -387,9 +387,9 @@ describe("createFetchTracker", () => {
     expect(recorded.get("code_verifier")).toBe(REDACTED_VALUE);
     expect(recorded.get("grant_type")).toBe("authorization_code");
     expect(recorded.get("client_id")).toBe("public");
-    expect(JSON.stringify(tracked[0])).not.toContain("secret-auth-code");
-    expect(JSON.stringify(tracked[0])).not.toContain("shh");
-    expect(JSON.stringify(tracked[0])).not.toContain("pkce123");
+    expect(JSON.stringify(tracked[0])).not.toContain("Secret-Auth-Code");
+    expect(JSON.stringify(tracked[0])).not.toContain("SHH");
+    expect(JSON.stringify(tracked[0])).not.toContain("PKCE123");
     // The live outbound request body is byte-identical.
     expect(outboundInit?.body).toBe(liveBody);
   });


### PR DESCRIPTION
## Summary

Fixes a flaky test in `fetchTracking.test.ts` where the substring redaction assertion can spuriously fail when a short secret value collides with the randomly-generated base36 request ID.

## Problem

The request ID is generated as:
```ts
const id = \`${timestamp.getTime()}-${Math.random().toString(36).slice(2, 11)}\`;
```

The test asserts:
```ts
expect(JSON.stringify(tracked[0])).not.toContain("shh");
```

Since base36 uses `[0-9a-z]`, the 3-character string `"shh"` can randomly appear as a substring of the ID (e.g., `sw7kshhf0`), causing a false failure.

## Fix

Uppercase the secret fixture values (`"SHH"`, `"Secret-Auth-Code"`, `"PKCE123"`). Since `Math.random().toString(36)` only produces lowercase letters and digits, uppercase characters can never appear in the request ID, making the assertions deterministic by construction.

This is option 3 from the issue's suggested fixes — the smallest change that eliminates the collision without modifying production code or test infrastructure.

Closes #1757

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.