### PR TITLE
test: deterministic remote-server teardown to kill #1667 afterEach hang

### DIFF
--- a/clients/web/src/test/integration/mcp/remote/connect-crash.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/connect-crash.test.ts
@@ -10,6 +10,7 @@ import { serve } from "@hono/node-server";
 import type { ServerType } from "@hono/node-server";
 import { createRemoteApp } from "@inspector/core/mcp/remote/node/server.js";
 import type { MCPServerConfig } from "@inspector/core/mcp/types.js";
+import { closeHarnessServer } from "./harnessTeardown.js";
 
 interface Harness {
   baseUrl: string;
@@ -37,16 +38,7 @@ async function startServer(): Promise<Harness> {
 }
 
 async function teardown(h: Harness): Promise<void> {
-  await new Promise<void>((resolve) => {
-    h.server.close(() => resolve());
-    // Force keep-alive sockets closed so close()'s callback fires
-    // deterministically under parallel/instrumented ci load, instead of
-    // blocking on undici's idle connection pool (the #1667 teardown hang).
-    // This suite's crash-on-startup sessions never disconnect either.
-    // `serve` returns http1's Server here; closeAllConnections is http1-only
-    // (absent on the Http2Server arm of ServerType), so guard the narrow.
-    if ("closeAllConnections" in h.server) h.server.closeAllConnections();
-  });
+  await closeHarnessServer(h.server);
 }
 
 interface ParsedSseEvent {

--- a/clients/web/src/test/integration/mcp/remote/connect-crash.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/connect-crash.test.ts
@@ -43,7 +43,9 @@ async function teardown(h: Harness): Promise<void> {
     // deterministically under parallel/instrumented ci load, instead of
     // blocking on undici's idle connection pool (the #1667 teardown hang).
     // This suite's crash-on-startup sessions never disconnect either.
-    h.server.closeAllConnections();
+    // `serve` returns http1's Server here; closeAllConnections is http1-only
+    // (absent on the Http2Server arm of ServerType), so guard the narrow.
+    if ("closeAllConnections" in h.server) h.server.closeAllConnections();
   });
 }
 

--- a/clients/web/src/test/integration/mcp/remote/connect-crash.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/connect-crash.test.ts
@@ -37,7 +37,14 @@ async function startServer(): Promise<Harness> {
 }
 
 async function teardown(h: Harness): Promise<void> {
-  await new Promise<void>((resolve) => h.server.close(() => resolve()));
+  await new Promise<void>((resolve) => {
+    h.server.close(() => resolve());
+    // Force keep-alive sockets closed so close()'s callback fires
+    // deterministically under parallel/instrumented ci load, instead of
+    // blocking on undici's idle connection pool (the #1667 teardown hang).
+    // This suite's crash-on-startup sessions never disconnect either.
+    h.server.closeAllConnections();
+  });
 }
 
 interface ParsedSseEvent {

--- a/clients/web/src/test/integration/mcp/remote/harnessTeardown.ts
+++ b/clients/web/src/test/integration/mcp/remote/harnessTeardown.ts
@@ -1,0 +1,25 @@
+import type { ServerType } from "@hono/node-server";
+
+/**
+ * Deterministically close a Hono-served HTTP server in test teardown.
+ *
+ * Node's `server.close(cb)` stops accepting new connections and then waits for
+ * every existing keep-alive socket to go idle before firing its callback.
+ * undici's global-`fetch` connection pool holds sockets open, and under the
+ * full parallel/instrumented `npm run coverage` load they may not go idle
+ * before the 30s `afterEach` timeout — the #1667 teardown hang. Some of these
+ * suites' sessions (crash-on-startup / dead-transport) never disconnect, so the
+ * session and its dead subprocess transport also linger at close time.
+ *
+ * Force the pooled sockets closed with `closeAllConnections()` alongside
+ * `close()` so the callback fires regardless of load. `closeAllConnections` is
+ * declared only on http1's `Server` (absent on the `Http2Server` arm of
+ * `ServerType`); `serve()` returns an http1 server here, so the `in` narrow is
+ * always taken at runtime while keeping the union type-safe without a cast.
+ */
+export async function closeHarnessServer(server: ServerType): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+    if ("closeAllConnections" in server) server.closeAllConnections();
+  });
+}

--- a/clients/web/src/test/integration/mcp/remote/remote-auth-branches.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/remote-auth-branches.test.ts
@@ -45,7 +45,16 @@ async function start(): Promise<Harness> {
 }
 
 async function stop(h: Harness): Promise<void> {
-  await new Promise<void>((resolve) => h.server.close(() => resolve()));
+  await new Promise<void>((resolve) => {
+    h.server.close(() => resolve());
+    // Force keep-alive sockets closed so close()'s callback fires
+    // deterministically. undici's global-fetch connection pool holds sockets
+    // open, and under the full parallel/instrumented ci load they may not go
+    // idle before the 30s afterEach timeout — the #1667 teardown hang. The
+    // dead-transport tests are the worst case: they never disconnect, so the
+    // session (and its crashed subprocess transport) lingers when we close.
+    h.server.closeAllConnections();
+  });
 }
 
 async function connect(

--- a/clients/web/src/test/integration/mcp/remote/remote-auth-branches.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/remote-auth-branches.test.ts
@@ -18,6 +18,7 @@ import type { ServerType } from "@hono/node-server";
 import { createRemoteApp } from "@inspector/core/mcp/remote/node/server.js";
 import { getTestMcpServerCommand } from "@modelcontextprotocol/inspector-test-server";
 import type { MCPServerConfig } from "@inspector/core/mcp/types.js";
+import { closeHarnessServer } from "./harnessTeardown.js";
 
 interface Harness {
   baseUrl: string;
@@ -45,18 +46,7 @@ async function start(): Promise<Harness> {
 }
 
 async function stop(h: Harness): Promise<void> {
-  await new Promise<void>((resolve) => {
-    h.server.close(() => resolve());
-    // Force keep-alive sockets closed so close()'s callback fires
-    // deterministically. undici's global-fetch connection pool holds sockets
-    // open, and under the full parallel/instrumented ci load they may not go
-    // idle before the 30s afterEach timeout — the #1667 teardown hang. The
-    // dead-transport tests are the worst case: they never disconnect, so the
-    // session (and its crashed subprocess transport) lingers when we close.
-    // `serve` returns http1's Server here; closeAllConnections is http1-only
-    // (absent on the Http2Server arm of ServerType), so guard the narrow.
-    if ("closeAllConnections" in h.server) h.server.closeAllConnections();
-  });
+  await closeHarnessServer(h.server);
 }
 
 async function connect(

--- a/clients/web/src/test/integration/mcp/remote/remote-auth-branches.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/remote-auth-branches.test.ts
@@ -53,7 +53,9 @@ async function stop(h: Harness): Promise<void> {
     // idle before the 30s afterEach timeout — the #1667 teardown hang. The
     // dead-transport tests are the worst case: they never disconnect, so the
     // session (and its crashed subprocess transport) lingers when we close.
-    h.server.closeAllConnections();
+    // `serve` returns http1's Server here; closeAllConnections is http1-only
+    // (absent on the Http2Server arm of ServerType), so guard the narrow.
+    if ("closeAllConnections" in h.server) h.server.closeAllConnections();
   });
 }
 

--- a/core/mcp/remote/node/server.ts
+++ b/core/mcp/remote/node/server.ts
@@ -633,12 +633,16 @@ export function createRemoteApp(
         // the user. The endpoint cleans up on stream close; this TTL
         // sweeps sessions whose client never connects at all.
         if (!session.hasEventConsumer()) {
+          // This sweep is a best-effort GC of an abandoned session, not work
+          // the process must stay alive for — unref it so a pending timer
+          // can't keep the event loop (or a test worker) alive for 30s after
+          // everything else has finished.
           setTimeout(() => {
             const stale = sessions.get(sessionId);
             if (stale && !stale.hasEventConsumer()) {
               sessions.delete(sessionId);
             }
-          }, 30_000);
+          }, 30_000).unref();
         }
       } else {
         // Session not created yet - failed during start


### PR DESCRIPTION
Closes #1667

## Problem

The remote integration test `remote-auth-branches.test.ts` → **"short-circuits with a transport_error when the session's transport is already dead"** intermittently timed out in its 30s `afterEach` under the full `npm run coverage` / `npm run ci` gate (v8 instrumentation + all projects under parallel load), while passing reliably in isolation.

## Root cause (issue option 2)

The `afterEach` closes the Hono HTTP server with `server.close(cb)`. Node's `close()` only stops accepting new connections and then waits for **all existing keep-alive sockets to go idle** before firing its callback. The global `fetch` (undici) keeps its connection pool sockets open, and under heavy parallel/instrumented load they don't reliably go idle before the 30s hook timeout — so `close()`'s callback never fires and the hook times out.

The dead-transport tests are the worst case: they connect a session whose stdio subprocess crashes and then **never disconnect** it, so the session (and its dead transport) lingers on the server at teardown.

## Fix

1. **Deterministic teardown.** Call `server.closeAllConnections()` alongside `close()` in the teardown helpers, forcibly destroying the pooled keep-alive sockets so the `close()` callback fires **regardless of parallel load**. Applied to both `remote-auth-branches.test.ts` and its sibling `connect-crash.test.ts` (same crash-on-startup / never-disconnect pattern). Guarded behind an `in` narrow because `ServerType` is `Server | Http2Server` and `closeAllConnections` is http1-only. Available since Node 18.2; the repo requires Node ≥22.

2. **Unref the abandoned-session sweep timer** (`core/mcp/remote/node/server.ts`). The transport-onclose path arms a 30s `setTimeout` to GC a session whose client never opens the events stream. That sweep is best-effort cleanup, not work the process must stay alive for — `unref()` it so a pending timer can't keep the event loop (or a test worker) alive for 30s after everything else finishes.

## Verification

- Affected tests: green in isolation.
- Full `integration` project: green (49 files / 969 tests).
- Full web `test:coverage` gate (unit + integration under v8 instrumentation — the exact context the flake appeared in): green (298 files / 4426 tests); `server.ts` at 97.9/92.6/97.9/98.4, above the ≥90 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNdjEPKLG637X8YmhDiEk5