### PR TITLE
test: de-flake ViewHeader connect/disconnect animation assertion (#1699)

### DIFF
--- a/clients/web/src/components/groups/ViewHeader/ViewHeader.test.tsx
+++ b/clients/web/src/components/groups/ViewHeader/ViewHeader.test.tsx
@@ -355,12 +355,18 @@ describe("ViewHeader", () => {
           ?.getAttribute("data-anim"),
       ).toBe("out");
 
+      // The server name and the Disconnect button are removed by two
+      // independent Transition exits; on a slow runner the button's exit can
+      // lag the name's, so each "removed" assertion gets its own waitFor rather
+      // than assuming the two transitions complete in lockstep (#1699).
       await waitFor(() =>
         expect(screen.queryByText("my-mcp-server")).not.toBeInTheDocument(),
       );
-      expect(
-        screen.queryByRole("button", { name: "Disconnect from server" }),
-      ).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("button", { name: "Disconnect from server" }),
+        ).not.toBeInTheDocument(),
+      );
     });
 
     it("renders the dark-scheme icon/logo branch under a dark color scheme", () => {


### PR DESCRIPTION
Closes #1699

Fixes the flaky `ViewHeader.test.tsx` assertion described in #1699.

## Part 1 — ViewHeader animation (fixed here)
The test `waitFor`'d that the server-*name* text was removed after its exit `Transition`, then did a **synchronous** `queryByRole("button", { name: "Disconnect from server" })` check. The server name and the Disconnect button are removed by two *independent* Mantine `Transition` exits; on a slow runner the button's exit can lag the name's, so it could still be in the DOM at the synchronous check — the `expect(element).not.toBeInTheDocument()` CI failure.

Fix: wrap the Disconnect-button "removed" assertion in its own `waitFor`, so it no longer assumes the two transitions complete in lockstep.

## Part 2 — TUI OAuth step-up (already fixed)
Already resolved in PR #1742 by raising the Ink poll ceiling to `POLL_TRIES = 100` (~2.5s). Verified the current `clients/tui/__tests__/App.test.tsx` still carries that fix — no change needed.

## Retry knob
Kept zero-retry (the issue offered `retry: 1` as an alternative). Both flakes are addressed at the assertion level, so no vitest retry was added.

## Verification
- `ViewHeader.test.tsx` green across repeated runs (20/20 each).
- Full `npm run ci` passes (validate → coverage → smoke → Storybook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNdjEPKLG637X8YmhDiEk5