### PR TITLE
fix(web): render the connected header when a modern server omits serverInfo (#1772)

### DIFF
--- a/clients/web/src/App.test.tsx
+++ b/clients/web/src/App.test.tsx
@@ -358,6 +358,7 @@ vi.mock("./components/views/InspectorView/InspectorView", () => ({
     currentLogLevel?: string;
     activeTab?: string;
     erroredServerId?: string;
+    initializeResult?: { serverInfo: { name: string; version: string } };
     onActiveTabChange: (tab: string) => void;
     onToggleConnection: (id: string) => void;
     onToolsUiChange: (next: {
@@ -425,6 +426,11 @@ vi.mock("./components/views/InspectorView/InspectorView", () => ({
       </span>
       <span data-testid="log-level">{props.currentLogLevel}</span>
       <span data-testid="active-tab">{props.activeTab ?? "none"}</span>
+      <span data-testid="init-result">
+        {props.initializeResult
+          ? `name:${props.initializeResult.serverInfo.name || "(empty)"}`
+          : "none"}
+      </span>
       <span data-testid="errored-server">
         {props.erroredServerId ?? "none"}
       </span>
@@ -621,6 +627,43 @@ describe("App failed-connection card border (#1621)", () => {
     await user.click(screen.getByText("connect"));
     await waitFor(() =>
       expect(screen.getByTestId("errored-server")).toHaveTextContent("none"),
+    );
+  });
+});
+
+describe("App initializeResult when connected without serverInfo (#1772)", () => {
+  beforeEach(() => {
+    clientInstances.length = 0;
+    vi.mocked(useInspectorClient).mockReturnValue(DEFAULT_USE_INSPECTOR_CLIENT);
+  });
+
+  // A modern-era `server/discover` makes `serverInfo` optional, so a conforming
+  // modern server can be `connected` with `serverInfo === undefined`. The header
+  // (and its whole tab bar) is gated on `initializeResult` downstream, so it must
+  // still be built in that case — otherwise the connected server shows no menu.
+  it("builds initializeResult when connected even though serverInfo is undefined", () => {
+    // DEFAULT_USE_INSPECTOR_CLIENT is exactly this case: connected + no serverInfo.
+    renderWithMantine(<App />);
+    expect(screen.getByTestId("init-result")).not.toHaveTextContent("none");
+  });
+
+  it("does not build initializeResult while disconnected", () => {
+    vi.mocked(useInspectorClient).mockReturnValue({
+      ...DEFAULT_USE_INSPECTOR_CLIENT,
+      status: "disconnected",
+    });
+    renderWithMantine(<App />);
+    expect(screen.getByTestId("init-result")).toHaveTextContent("none");
+  });
+
+  it("uses the reported serverInfo name when present (legacy / stamped modern)", () => {
+    vi.mocked(useInspectorClient).mockReturnValue({
+      ...DEFAULT_USE_INSPECTOR_CLIENT,
+      serverInfo: { name: "real-server", version: "2.0.0" },
+    });
+    renderWithMantine(<App />);
+    expect(screen.getByTestId("init-result")).toHaveTextContent(
+      "name:real-server",
     );
   });
 });

--- a/clients/web/src/App.test.tsx
+++ b/clients/web/src/App.test.tsx
@@ -549,6 +549,7 @@ vi.mock("./components/views/InspectorView/InspectorView", () => ({
 }));
 
 import App from "./App";
+import { NOT_REPORTED } from "./components/groups/ConnectionInfoContent/ConnectionInfoContent";
 import { OAUTH_CALLBACK_PATH } from "./utils/oauthFlow.js";
 import { INSPECTOR_SERVERS_TAB } from "./utils/inspectorTabs.js";
 import {
@@ -696,7 +697,7 @@ describe("App initializeResult when connected without serverInfo (#1772)", () =>
     await user.click(screen.getByText("connect")); // active server = A
     await user.click(screen.getByText("open-connection-info"));
     await waitFor(() =>
-      expect(screen.getAllByText("— (not reported by server)")).toHaveLength(2),
+      expect(screen.getAllByText(NOT_REPORTED)).toHaveLength(2),
     );
     // The synthesized catalog name is not presented as the server's report.
     expect(screen.queryByText("PlotRocket")).not.toBeInTheDocument();
@@ -714,9 +715,7 @@ describe("App initializeResult when connected without serverInfo (#1772)", () =>
     await waitFor(() =>
       expect(screen.getByText("real-server")).toBeInTheDocument(),
     );
-    expect(
-      screen.queryByText("— (not reported by server)"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(NOT_REPORTED)).not.toBeInTheDocument();
   });
 });
 

--- a/clients/web/src/App.test.tsx
+++ b/clients/web/src/App.test.tsx
@@ -549,7 +549,7 @@ vi.mock("./components/views/InspectorView/InspectorView", () => ({
 }));
 
 import App from "./App";
-import { NOT_REPORTED } from "./components/groups/ConnectionInfoContent/ConnectionInfoContent";
+import { SERVER_INFO_NOT_REPORTED_LABEL } from "./components/groups/ConnectionInfoContent/ConnectionInfoContent";
 import { OAUTH_CALLBACK_PATH } from "./utils/oauthFlow.js";
 import { INSPECTOR_SERVERS_TAB } from "./utils/inspectorTabs.js";
 import {
@@ -697,9 +697,14 @@ describe("App initializeResult when connected without serverInfo (#1772)", () =>
     await user.click(screen.getByText("connect")); // active server = A
     await user.click(screen.getByText("open-connection-info"));
     await waitFor(() =>
-      expect(screen.getAllByText(NOT_REPORTED)).toHaveLength(2),
+      expect(screen.getAllByText(SERVER_INFO_NOT_REPORTED_LABEL)).toHaveLength(
+        2,
+      ),
     );
     // The synthesized catalog name is not presented as the server's report.
+    // Exact-match query on purpose: the mocked InspectorView's `init-result` span
+    // prints "name:PlotRocket" (prefixed), so this only matches a bare "PlotRocket"
+    // — i.e. the modal's Name cell — not the harness span.
     expect(screen.queryByText("PlotRocket")).not.toBeInTheDocument();
   });
 
@@ -715,7 +720,9 @@ describe("App initializeResult when connected without serverInfo (#1772)", () =>
     await waitFor(() =>
       expect(screen.getByText("real-server")).toBeInTheDocument(),
     );
-    expect(screen.queryByText(NOT_REPORTED)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(SERVER_INFO_NOT_REPORTED_LABEL),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/clients/web/src/App.test.tsx
+++ b/clients/web/src/App.test.tsx
@@ -220,8 +220,10 @@ vi.mock("@inspector/core/react/useInspectorClient.js", () => ({
     status: "connected",
     capabilities: {},
     clientCapabilities: {},
-    // Left undefined so `initializeResult` stays undefined and the
-    // ConnectionInfoModal (gated on it) never mounts during the test.
+    // Undefined models a modern server that omitted the optional serverInfo. As
+    // of #1772 `initializeResult` is still built when connected (with a
+    // catalog-name fallback), so this exercises that path — see the "#1772"
+    // describe block.
     serverInfo: undefined,
     instructions: undefined,
   })),
@@ -645,6 +647,20 @@ describe("App initializeResult when connected without serverInfo (#1772)", () =>
     // DEFAULT_USE_INSPECTOR_CLIENT is exactly this case: connected + no serverInfo.
     renderWithMantine(<App />);
     expect(screen.getByTestId("init-result")).not.toHaveTextContent("none");
+  });
+
+  it("falls back to the active server's catalog name when serverInfo is undefined", async () => {
+    const user = userEvent.setup();
+    renderWithMantine(<App />);
+    // Connect server "A" (PlotRocket) via the mocked InspectorView control so it
+    // becomes the active server; serverInfo is still undefined (default mock), so
+    // the synthesized name must come from the catalog entry.
+    await user.click(screen.getByText("connect"));
+    await waitFor(() =>
+      expect(screen.getByTestId("init-result")).toHaveTextContent(
+        "name:PlotRocket",
+      ),
+    );
   });
 
   it("does not build initializeResult while disconnected", () => {

--- a/clients/web/src/App.test.tsx
+++ b/clients/web/src/App.test.tsx
@@ -362,6 +362,7 @@ vi.mock("./components/views/InspectorView/InspectorView", () => ({
     erroredServerId?: string;
     initializeResult?: { serverInfo: { name: string; version: string } };
     onActiveTabChange: (tab: string) => void;
+    onConnectionInfo: () => void;
     onToggleConnection: (id: string) => void;
     onToolsUiChange: (next: {
       selectedToolName?: string;
@@ -440,6 +441,9 @@ vi.mock("./components/views/InspectorView/InspectorView", () => ({
         switch-servers-tab
       </button>
       <button onClick={() => props.onToggleConnection("A")}>connect</button>
+      <button onClick={() => props.onConnectionInfo()}>
+        open-connection-info
+      </button>
       <button
         onClick={() =>
           props.onToolsUiChange({
@@ -681,6 +685,38 @@ describe("App initializeResult when connected without serverInfo (#1772)", () =>
     expect(screen.getByTestId("init-result")).toHaveTextContent(
       "name:real-server",
     );
+  });
+
+  // Pins the App → ConnectionInfoModal wiring of `serverInfoReported`: without
+  // this, hard-coding it to `true` would keep the suite green and silently
+  // reintroduce the fidelity bug.
+  it("passes serverInfoReported=false to the modal, which shows 'not reported' (serverInfo omitted)", async () => {
+    const user = userEvent.setup();
+    renderWithMantine(<App />);
+    await user.click(screen.getByText("connect")); // active server = A
+    await user.click(screen.getByText("open-connection-info"));
+    await waitFor(() =>
+      expect(screen.getAllByText("— (not reported by server)")).toHaveLength(2),
+    );
+    // The synthesized catalog name is not presented as the server's report.
+    expect(screen.queryByText("PlotRocket")).not.toBeInTheDocument();
+  });
+
+  it("passes serverInfoReported=true to the modal, which shows the reported name", async () => {
+    vi.mocked(useInspectorClient).mockReturnValue({
+      ...DEFAULT_USE_INSPECTOR_CLIENT,
+      serverInfo: { name: "real-server", version: "2.0.0" },
+    });
+    const user = userEvent.setup();
+    renderWithMantine(<App />);
+    await user.click(screen.getByText("connect"));
+    await user.click(screen.getByText("open-connection-info"));
+    await waitFor(() =>
+      expect(screen.getByText("real-server")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText("— (not reported by server)"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -1446,17 +1446,28 @@ function App() {
   // modal expect from the hook's split fields. `protocolVersion` is the value
   // the InspectorClient negotiated during initialize (#1324); it's dispatched
   // alongside serverInfo, so in practice it's present whenever we're connected.
-  // We deliberately gate only on serverInfo (not protocolVersion): this object
-  // also drives the connected header and Connection Info modal, so a
-  // missing/edge-case version must not hide those. It flows through as the
-  // optional field it is everywhere downstream (the ServerCard label and the
-  // modal value both tolerate an empty string), so "" reads as "unknown".
+  // We gate only on `connectionStatus`, never on serverInfo or protocolVersion:
+  // this object also drives the connected header (and its whole tab bar) and the
+  // Connection Info modal, so a missing field must not hide those.
+  //
+  // A modern-era server's `server/discover` makes `serverInfo` OPTIONAL (SHOULD,
+  // not MUST — it's stamped in `_meta["io.modelcontextprotocol/serverInfo"]`), so
+  // a conforming modern server may omit it and `serverInfo` stays undefined even
+  // while connected. Falling back to the catalog name (rather than returning
+  // `undefined`) keeps the header + tabs rendered for those servers (#1772);
+  // everything downstream already tolerates an empty version, and now an
+  // inferred name. Legacy `initialize` always carries serverInfo, so this
+  // fallback only ever fires for a modern server that skipped it.
   const initializeResult = useMemo<InitializeResult | undefined>(() => {
-    if (connectionStatus !== "connected" || !serverInfo) return undefined;
+    if (connectionStatus !== "connected") return undefined;
+    const resolvedServerInfo = serverInfo ?? {
+      name: servers.find((s) => s.id === activeServerId)?.name ?? "",
+      version: "",
+    };
     return {
       protocolVersion: protocolVersion ?? "",
       capabilities: capabilities ?? {},
-      serverInfo,
+      serverInfo: resolvedServerInfo,
       ...(instructions ? { instructions } : {}),
     };
   }, [
@@ -1465,6 +1476,8 @@ function App() {
     serverInfo,
     instructions,
     protocolVersion,
+    servers,
+    activeServerId,
   ]);
 
   // The Server Info modal needs the active server's transport and (optional)

--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -1442,6 +1442,20 @@ function App() {
     };
   }, [inspectorClient]);
 
+  // The Server Info modal needs the active server's transport and (optional)
+  // OAuth details — both are co-located here so the modal opens against the
+  // same connection snapshot the header is reading. Also feeds the
+  // `initializeResult` serverInfo fallback below.
+  const activeServer = useMemo<ServerEntry | undefined>(
+    () => servers.find((s) => s.id === activeServerId),
+    [servers, activeServerId],
+  );
+
+  // Whether the server actually reported `serverInfo`, vs. the catalog-name
+  // fallback synthesized below. Threaded to the Connection Info modal so it can
+  // show "not reported" instead of an inferred name that looks server-sent.
+  const serverInfoReported = serverInfo !== undefined;
+
   // Build the InitializeResult the connected ViewHeader / Connection Info
   // modal expect from the hook's split fields. `protocolVersion` is the value
   // the InspectorClient negotiated during initialize (#1324); it's dispatched
@@ -1454,14 +1468,15 @@ function App() {
   // not MUST — it's stamped in `_meta["io.modelcontextprotocol/serverInfo"]`), so
   // a conforming modern server may omit it and `serverInfo` stays undefined even
   // while connected. Falling back to the catalog name (rather than returning
-  // `undefined`) keeps the header + tabs rendered for those servers (#1772);
-  // everything downstream already tolerates an empty version, and now an
-  // inferred name. Legacy `initialize` always carries serverInfo, so this
-  // fallback only ever fires for a modern server that skipped it.
+  // `undefined`) keeps the header + tabs rendered for those servers (#1772). It
+  // fires for such a modern server — and, harmlessly, in the batched instant on
+  // any connect (legacy included) between the `connected` status dispatch and the
+  // `serverInfo` dispatch, which land in a single React render. The modal uses
+  // `serverInfoReported` (above), not this name, to stay faithful.
   const initializeResult = useMemo<InitializeResult | undefined>(() => {
     if (connectionStatus !== "connected") return undefined;
     const resolvedServerInfo = serverInfo ?? {
-      name: servers.find((s) => s.id === activeServerId)?.name ?? "",
+      name: activeServer?.name ?? "",
       version: "",
     };
     return {
@@ -1476,17 +1491,8 @@ function App() {
     serverInfo,
     instructions,
     protocolVersion,
-    servers,
-    activeServerId,
+    activeServer,
   ]);
-
-  // The Server Info modal needs the active server's transport and (optional)
-  // OAuth details — both are co-located here so the modal opens against the
-  // same connection snapshot the header is reading.
-  const activeServer = useMemo<ServerEntry | undefined>(
-    () => servers.find((s) => s.id === activeServerId),
-    [servers, activeServerId],
-  );
 
   // Mirror the active server's name into a ref so a mid-session failure toast
   // can still name the server: a transport crash dispatches `disconnect`,
@@ -4437,6 +4443,7 @@ function App() {
           opened={connectionInfoModalOpen}
           onClose={() => setConnectionInfoModalOpen(false)}
           initializeResult={initializeResult}
+          serverInfoReported={serverInfoReported}
           clientCapabilities={clientCapabilities}
           transport={connectionInfoTransport}
           protocolEra={protocolEra}

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
@@ -3,6 +3,7 @@ import type {
   InitializeResult,
 } from "@modelcontextprotocol/client";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import { ConnectionInfoContent } from "./ConnectionInfoContent";
 
 const fullResult: InitializeResult = {
@@ -72,6 +73,30 @@ export const ModernEra: Story = {
         },
       },
     },
+  },
+};
+
+// A modern server that omitted the optional `_meta` serverInfo stamp (#1772).
+// `initializeResult.serverInfo` here is App's client-side catalog fallback, and
+// `serverInfoReported: false` tells the modal not to present it as server-sent —
+// Name and Version read "— (not reported by server)".
+export const ServerInfoNotReported: Story = {
+  args: {
+    initializeResult: {
+      protocolVersion: "2026-07-28",
+      // The catalog name App synthesizes; must NOT surface as the reported name.
+      serverInfo: { name: "my-catalog-name", version: "" },
+      capabilities: { tools: { listChanged: true } },
+    },
+    serverInfoReported: false,
+    clientCapabilities: { roots: { listChanged: true } },
+    transport: "streamable-http",
+    protocolEra: "modern",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.queryByText("my-catalog-name")).not.toBeInTheDocument();
+    expect(canvas.getAllByText("— (not reported by server)")).toHaveLength(2);
   },
 };
 

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
@@ -4,7 +4,10 @@ import type {
 } from "@modelcontextprotocol/client";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, within } from "storybook/test";
-import { ConnectionInfoContent, NOT_REPORTED } from "./ConnectionInfoContent";
+import {
+  ConnectionInfoContent,
+  SERVER_INFO_NOT_REPORTED_LABEL,
+} from "./ConnectionInfoContent";
 
 const fullResult: InitializeResult = {
   protocolVersion: "2025-03-26",
@@ -104,7 +107,7 @@ export const ServerInfoNotReported: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     expect(canvas.queryByText("my-catalog-name")).not.toBeInTheDocument();
-    expect(canvas.getAllByText(NOT_REPORTED)).toHaveLength(2);
+    expect(canvas.getAllByText(SERVER_INFO_NOT_REPORTED_LABEL)).toHaveLength(2);
   },
 };
 

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
@@ -4,7 +4,7 @@ import type {
 } from "@modelcontextprotocol/client";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, within } from "storybook/test";
-import { ConnectionInfoContent } from "./ConnectionInfoContent";
+import { ConnectionInfoContent, NOT_REPORTED } from "./ConnectionInfoContent";
 
 const fullResult: InitializeResult = {
   protocolVersion: "2025-03-26",
@@ -92,11 +92,19 @@ export const ServerInfoNotReported: Story = {
     clientCapabilities: { roots: { listChanged: true } },
     transport: "streamable-http",
     protocolEra: "modern",
+    // A real modern connection that skipped the `_meta` serverInfo stamp still
+    // has a discover result — with `supportedVersions` + capabilities, just no
+    // `serverInfo`. Including it makes the story accurate and shows the Discovery
+    // section doesn't leak a name either.
+    discoverResult: {
+      supportedVersions: ["2026-07-28", "2025-11-25"],
+      capabilities: { tools: { listChanged: true } },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     expect(canvas.queryByText("my-catalog-name")).not.toBeInTheDocument();
-    expect(canvas.getAllByText("— (not reported by server)")).toHaveLength(2);
+    expect(canvas.getAllByText(NOT_REPORTED)).toHaveLength(2);
   },
 };
 

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
@@ -62,6 +62,42 @@ describe("ConnectionInfoContent", () => {
     expect(screen.getAllByText("—")).toHaveLength(3);
   });
 
+  it("renders an em-dash when the reported version is an empty string", () => {
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={{
+          ...fullResult,
+          serverInfo: { name: "Empty Version Server", version: "" },
+        }}
+        clientCapabilities={fullClientCaps}
+        transport="stdio"
+      />,
+    );
+    // An empty version reads as unknown ("—"), not a blank row (#1772).
+    expect(screen.getByText("Empty Version Server")).toBeInTheDocument();
+    expect(screen.getAllByText("—")).toHaveLength(3);
+  });
+
+  it("shows 'not reported' for name and version when serverInfo was not reported", () => {
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={{
+          ...fullResult,
+          // App synthesizes a catalog-name fallback here when a modern server
+          // omits serverInfo; the modal must not present it as server-reported.
+          serverInfo: { name: "my-catalog-name", version: "" },
+        }}
+        serverInfoReported={false}
+        clientCapabilities={fullClientCaps}
+        transport="streamable-http"
+      />,
+    );
+    // The inferred catalog name is NOT shown as the server's reported name...
+    expect(screen.queryByText("my-catalog-name")).not.toBeInTheDocument();
+    // ...both Name and Version read as not reported instead.
+    expect(screen.getAllByText("— (not reported by server)")).toHaveLength(2);
+  });
+
   it("renders server and client capability sections", () => {
     renderWithMantine(
       <ConnectionInfoContent

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
@@ -8,6 +8,7 @@ import { renderWithMantine, screen } from "../../../test/renderWithMantine";
 import {
   CLEAR_OAUTH_STATE_AND_DISCONNECT_LABEL,
   ConnectionInfoContent,
+  NOT_REPORTED,
 } from "./ConnectionInfoContent";
 
 const fullResult: InitializeResult = {
@@ -112,7 +113,20 @@ describe("ConnectionInfoContent", () => {
     // The inferred catalog name is NOT shown as the server's reported name...
     expect(screen.queryByText("my-catalog-name")).not.toBeInTheDocument();
     // ...both Name and Version read as not reported instead.
-    expect(screen.getAllByText("— (not reported by server)")).toHaveLength(2);
+    expect(screen.getAllByText(NOT_REPORTED)).toHaveLength(2);
+  });
+
+  it("renders an em-dash when the protocol version is empty", () => {
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={{ ...fullResult, protocolVersion: "" }}
+        clientCapabilities={fullClientCaps}
+        transport="stdio"
+      />,
+    );
+    // App supplies `protocolVersion ?? ""`; an empty one reads as unknown ("—"),
+    // symmetric with Name/Version (#1772).
+    expect(screen.getAllByText("—")).toHaveLength(3);
   });
 
   it("renders server and client capability sections", () => {

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
@@ -78,6 +78,23 @@ describe("ConnectionInfoContent", () => {
     expect(screen.getAllByText("—")).toHaveLength(3);
   });
 
+  it("renders an em-dash when the reported name is an empty string", () => {
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={{
+          ...fullResult,
+          serverInfo: { name: "", version: "1.0.0" },
+        }}
+        clientCapabilities={fullClientCaps}
+        transport="stdio"
+      />,
+    );
+    // `initialize` mandates the name field, not a non-empty value, so an empty
+    // reported name also reads as unknown ("—") — symmetric with version.
+    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+    expect(screen.getAllByText("—")).toHaveLength(3);
+  });
+
   it("shows 'not reported' for name and version when serverInfo was not reported", () => {
     renderWithMantine(
       <ConnectionInfoContent

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
@@ -8,7 +8,7 @@ import { renderWithMantine, screen } from "../../../test/renderWithMantine";
 import {
   CLEAR_OAUTH_STATE_AND_DISCONNECT_LABEL,
   ConnectionInfoContent,
-  NOT_REPORTED,
+  SERVER_INFO_NOT_REPORTED_LABEL,
 } from "./ConnectionInfoContent";
 
 const fullResult: InitializeResult = {
@@ -113,7 +113,7 @@ describe("ConnectionInfoContent", () => {
     // The inferred catalog name is NOT shown as the server's reported name...
     expect(screen.queryByText("my-catalog-name")).not.toBeInTheDocument();
     // ...both Name and Version read as not reported instead.
-    expect(screen.getAllByText(NOT_REPORTED)).toHaveLength(2);
+    expect(screen.getAllByText(SERVER_INFO_NOT_REPORTED_LABEL)).toHaveLength(2);
   });
 
   it("renders an em-dash when the protocol version is empty", () => {

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
@@ -40,6 +40,16 @@ export interface OAuthDetails {
 
 export interface ConnectionInfoContentProps {
   initializeResult: InitializeResult;
+  /**
+   * Whether the server actually reported `serverInfo`. When false (a modern
+   * server that omitted the optional `_meta` stamp), `initializeResult`'s name is
+   * a client-side catalog fallback, so the Server Implementation section renders
+   * "not reported" rather than presenting the inferred name as server-sent — the
+   * exact fact a user opens this modal to check (#1772). Defaults to `true`
+   * (server-reported), which is the norm and what fixtures with a real
+   * `serverInfo` want.
+   */
+  serverInfoReported?: boolean;
   clientCapabilities: ClientCapabilities;
   transport: ServerType;
   /**
@@ -62,6 +72,11 @@ const ValueText = Text.withProps({
   size: "sm",
   fw: 600,
 });
+
+// Shown for Name/Version when the server didn't report `serverInfo` — an em dash
+// plus an explicit note so the client-side catalog fallback is never mistaken
+// for a value the server sent.
+const NOT_REPORTED = "— (not reported by server)";
 
 const SectionHeading = Title.withProps({
   // `order: 3` (not 5) keeps the heading level one below the modal's `h2`
@@ -172,6 +187,7 @@ function getCapabilityEntries(
 
 export function ConnectionInfoContent({
   initializeResult,
+  serverInfoReported = true,
   clientCapabilities,
   transport,
   protocolEra,
@@ -181,6 +197,14 @@ export function ConnectionInfoContent({
 }: ConnectionInfoContentProps) {
   const { serverInfo, protocolVersion, capabilities, instructions } =
     initializeResult;
+
+  // Only trust `serverInfo` when the server actually reported it; otherwise the
+  // name is a catalog fallback. Version uses `||` (not `??`) so a reported-but-
+  // empty version also reads as unknown rather than a blank row.
+  const displayName = serverInfoReported ? serverInfo.name : NOT_REPORTED;
+  const displayVersion = serverInfoReported
+    ? serverInfo.version || "—"
+    : NOT_REPORTED;
 
   const serverCaps = getCapabilityEntries(capabilities, SERVER_CAPABILITY_KEYS);
   const clientCaps = getCapabilityEntries(
@@ -194,10 +218,10 @@ export function ConnectionInfoContent({
         <SectionHeading>Server Implementation</SectionHeading>
         <SimpleGrid cols={2}>
           <Text size="sm">Name</Text>
-          <ValueText>{serverInfo.name}</ValueText>
+          <ValueText>{displayName}</ValueText>
 
           <Text size="sm">Version</Text>
-          <ValueText>{serverInfo.version ?? "—"}</ValueText>
+          <ValueText>{displayVersion}</ValueText>
 
           <Text size="sm">Protocol</Text>
           <ValueText>{protocolVersion}</ValueText>

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
@@ -75,8 +75,9 @@ const ValueText = Text.withProps({
 
 // Shown for Name/Version when the server didn't report `serverInfo` — an em dash
 // plus an explicit note so the client-side catalog fallback is never mistaken
-// for a value the server sent.
-const NOT_REPORTED = "— (not reported by server)";
+// for a value the server sent. Exported so tests/stories assert against it
+// rather than re-typing the copy.
+export const NOT_REPORTED = "— (not reported by server)";
 
 const SectionHeading = Title.withProps({
   // `order: 3` (not 5) keeps the heading level one below the modal's `h2`
@@ -227,7 +228,7 @@ export function ConnectionInfoContent({
           <ValueText>{displayVersion}</ValueText>
 
           <Text size="sm">Protocol</Text>
-          <ValueText>{protocolVersion}</ValueText>
+          <ValueText>{protocolVersion || "—"}</ValueText>
 
           <Text size="sm">Transport</Text>
           <Badge variant="outline">{transport}</Badge>

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
@@ -77,7 +77,7 @@ const ValueText = Text.withProps({
 // plus an explicit note so the client-side catalog fallback is never mistaken
 // for a value the server sent. Exported so tests/stories assert against it
 // rather than re-typing the copy.
-export const NOT_REPORTED = "— (not reported by server)";
+export const SERVER_INFO_NOT_REPORTED_LABEL = "— (not reported by server)";
 
 const SectionHeading = Title.withProps({
   // `order: 3` (not 5) keeps the heading level one below the modal's `h2`
@@ -205,10 +205,10 @@ export function ConnectionInfoContent({
   // `initialize` mandates the fields, not non-empty values.
   const displayName = serverInfoReported
     ? serverInfo.name || "—"
-    : NOT_REPORTED;
+    : SERVER_INFO_NOT_REPORTED_LABEL;
   const displayVersion = serverInfoReported
     ? serverInfo.version || "—"
-    : NOT_REPORTED;
+    : SERVER_INFO_NOT_REPORTED_LABEL;
 
   const serverCaps = getCapabilityEntries(capabilities, SERVER_CAPABILITY_KEYS);
   const clientCaps = getCapabilityEntries(

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
@@ -199,9 +199,12 @@ export function ConnectionInfoContent({
     initializeResult;
 
   // Only trust `serverInfo` when the server actually reported it; otherwise the
-  // name is a catalog fallback. Version uses `||` (not `??`) so a reported-but-
-  // empty version also reads as unknown rather than a blank row.
-  const displayName = serverInfoReported ? serverInfo.name : NOT_REPORTED;
+  // name is a catalog fallback. Both rows use `||` (not `??`) so a reported-but-
+  // empty name/version reads as unknown ("—") rather than a blank row —
+  // `initialize` mandates the fields, not non-empty values.
+  const displayName = serverInfoReported
+    ? serverInfo.name || "—"
+    : NOT_REPORTED;
   const displayVersion = serverInfoReported
     ? serverInfo.version || "—"
     : NOT_REPORTED;

--- a/clients/web/src/components/groups/ConnectionInfoModal/ConnectionInfoModal.stories.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoModal/ConnectionInfoModal.stories.tsx
@@ -54,6 +54,7 @@ const meta: Meta<typeof ConnectionInfoModal> = {
   args: {
     opened: true,
     onClose: fn(),
+    serverInfoReported: true,
   },
 };
 

--- a/clients/web/src/components/groups/ConnectionInfoModal/ConnectionInfoModal.test.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoModal/ConnectionInfoModal.test.tsx
@@ -29,6 +29,7 @@ describe("ConnectionInfoModal", () => {
         opened={false}
         onClose={vi.fn()}
         initializeResult={initializeResult}
+        serverInfoReported
         clientCapabilities={clientCapabilities}
         transport="stdio"
       />,
@@ -42,6 +43,7 @@ describe("ConnectionInfoModal", () => {
         opened
         onClose={vi.fn()}
         initializeResult={initializeResult}
+        serverInfoReported
         clientCapabilities={clientCapabilities}
         transport="stdio"
       />,
@@ -60,6 +62,7 @@ describe("ConnectionInfoModal", () => {
         opened
         onClose={vi.fn()}
         initializeResult={initializeResult}
+        serverInfoReported
         clientCapabilities={clientCapabilities}
         transport="streamable-http"
         oauth={{
@@ -87,6 +90,7 @@ describe("ConnectionInfoModal", () => {
         opened
         onClose={onClose}
         initializeResult={initializeResult}
+        serverInfoReported
         clientCapabilities={clientCapabilities}
         transport="stdio"
       />,
@@ -103,6 +107,7 @@ describe("ConnectionInfoModal", () => {
         opened
         onClose={onClose}
         initializeResult={initializeResult}
+        serverInfoReported
         clientCapabilities={clientCapabilities}
         transport="stdio"
       />,

--- a/clients/web/src/components/groups/ConnectionInfoModal/ConnectionInfoModal.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoModal/ConnectionInfoModal.tsx
@@ -15,6 +15,13 @@ export interface ConnectionInfoModalProps {
   opened: boolean;
   onClose: () => void;
   initializeResult: InitializeResult;
+  /**
+   * Whether the server actually reported `serverInfo`. False for a modern server
+   * that omitted the optional `_meta` stamp — in which case `initializeResult`'s
+   * name is a client-side catalog fallback, and the modal shows "not reported"
+   * rather than passing it off as server-sent (#1772).
+   */
+  serverInfoReported: boolean;
   clientCapabilities: ClientCapabilities;
   transport: ServerType;
   protocolEra?: ProtocolEra;
@@ -27,6 +34,7 @@ export function ConnectionInfoModal({
   opened,
   onClose,
   initializeResult,
+  serverInfoReported,
   clientCapabilities,
   transport,
   protocolEra,
@@ -60,6 +68,7 @@ export function ConnectionInfoModal({
         <Modal.Body>
           <ConnectionInfoContent
             initializeResult={initializeResult}
+            serverInfoReported={serverInfoReported}
             clientCapabilities={clientCapabilities}
             transport={transport}
             protocolEra={protocolEra}


### PR DESCRIPTION
Closes #1772

## Problem

Connecting to a **modern-era** MCP server whose `server/discover` omits the (now-optional) `serverInfo` produces a `connected` session with **no header tab bar at all** — no Servers / Tools / Resources / Tasks, just the "MCP Inspector" title. The server is effectively uninspectable through the UI even though the connection succeeded.

Reproduced against `test-servers/configs/tasks-modern-http.json` (port 3222): green "Connected", modern `server/discover` + `tools/list` in the Protocol view, but no tabs. Confirmed via live DOM that `data-status="connected"` while the header renders the disconnected/title branch — i.e. `initializeResult` was falsy despite being connected.

## Root cause

- `InspectorView` gates the connected header (and its whole tab bar) on `connectionStatus === "connected" && initializeResult`.
- `App`'s `initializeResult` returned `undefined` whenever `!serverInfo`.
- `serverInfo` comes from the SDK's `getServerVersion()`, filled from `serverInfoFromDiscover()`, which reads `discover._meta["io.modelcontextprotocol/serverInfo"]`. The modern spec makes that **optional** (SHOULD, not MUST), so a conforming modern server may omit it → `serverInfo` stays `undefined` → `initializeResult` `undefined` → the header collapses to the title branch.

Legacy `initialize` always carries `serverInfo`, so only modern servers hit this.

## Fix

Gate `initializeResult` on `connectionStatus` alone (never on `serverInfo` — matching the existing deliberate choice not to gate on `protocolVersion`), and fall back to the active server's catalog name when `serverInfo` is absent. Everything downstream already tolerates an empty version (and now an inferred name). The fallback only ever fires for a modern server that skipped the optional field; a reported `serverInfo` still wins.

## Tests

Adds three `App` tests: `initializeResult` is built when connected without `serverInfo`, is absent while disconnected, and uses the reported `serverInfo` name when present. Full web unit suite green.

## Note

Surfaced while manually testing #1771 (the AGENTS.md `.withProps()` styling sweep), but it's a **pre-existing** connection/modern-era bug — unrelated to that PR (which changes none of the header-gate / `initializeResult` / `serverInfo` / `InspectorView` / core-connection code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)