### PR TITLE
fix(cli): use MCP logging levels

### DIFF
--- a/cli/__tests__/cli.test.ts
+++ b/cli/__tests__/cli.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { LoggingLevelSchema } from "@modelcontextprotocol/sdk/types.js";
 import { runCli } from "./helpers/cli-runner.js";
 import {
   expectCliSuccess,
@@ -18,6 +19,7 @@ import {
   createEchoTool,
   createTestServerInfo,
 } from "./helpers/test-fixtures.js";
+import { validLogLevels } from "../src/client/connection.js";
 
 describe("CLI Tests", () => {
   describe("Basic CLI Mode", () => {
@@ -363,6 +365,10 @@ describe("CLI Tests", () => {
   });
 
   describe("Logging Options", () => {
+    it("should use MCP spec logging levels", () => {
+      expect(validLogLevels).toEqual(LoggingLevelSchema.options);
+    });
+
     it("should set log level", async () => {
       const server = createTestServerHttp({
         serverInfo: createTestServerInfo(),
@@ -396,7 +402,24 @@ describe("CLI Tests", () => {
       }
     });
 
-    it("should reject invalid log level", async () => {
+    it.each(["trace", "warn"])(
+      "should reject non-spec log level %s before connecting",
+      async (logLevel) => {
+        const result = await runCli([
+          NO_SERVER_SENTINEL,
+          "--cli",
+          "--method",
+          "logging/setLevel",
+          "--log-level",
+          logLevel,
+        ]);
+
+        expectCliFailure(result);
+        expect(result.output).toContain(`Invalid log level: ${logLevel}`);
+      },
+    );
+
+    it("should reject unknown log level", async () => {
       const { command, args } = getTestMcpServerCommand();
       const result = await runCli([
         command,

--- a/cli/src/client/connection.ts
+++ b/cli/src/client/connection.ts
@@ -1,14 +1,9 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { LoggingLevelSchema } from "@modelcontextprotocol/sdk/types.js";
 import { McpResponse } from "./types.js";
 
-export const validLogLevels = [
-  "trace",
-  "debug",
-  "info",
-  "warn",
-  "error",
-] as const;
+export const validLogLevels = LoggingLevelSchema.options;
 
 export type LogLevel = (typeof validLogLevels)[number];
 
@@ -47,7 +42,7 @@ export async function setLoggingLevel(
   level: LogLevel,
 ): Promise<McpResponse> {
   try {
-    const response = await client.setLoggingLevel(level as any);
+    const response = await client.setLoggingLevel(level);
     return response;
   } catch (error) {
     throw new Error(


### PR DESCRIPTION
## Summary

Align the CLI's `--log-level` validation with the MCP logging specification. The accepted values now come from the SDK's `LoggingLevelSchema`, so the CLI no longer rejects valid RFC 5424 levels or forwards the non-spec `trace` and `warn` aliases.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test updates
- [ ] Build/CI improvements

## Changes Made

- Derive CLI logging levels from the MCP SDK schema instead of a parallel hardcoded list.
- Pass the schema-derived level to `Client.setLoggingLevel` without an unsafe cast.
- Pin schema parity and reject `trace`/`warn` at the CLI validation boundary.

## Related Issues

Fixes #1734

## Testing

- [ ] Tested in UI mode
- [x] Tested in CLI mode
- [ ] Tested with STDIO transport
- [ ] Tested with SSE transport
- [ ] Tested with Streamable HTTP transport
- [x] Added/updated automated tests
- [x] Manual testing performed

### Test Results and/or Instructions

- Full production build: `npm run build`
- CLI TypeScript build: `npm run build-cli`
- Focused regression: 3 passed (`MCP spec logging levels` and both non-spec aliases)
- Prettier check and `git diff --check` passed for both changed files

The broad CLI suite produced 60 passes and 28 Windows-only failures after successful HTTP responses because Node 24 aborted during transport teardown with `UV_HANDLE_CLOSING`. The affected focused tests do not use that teardown path and pass consistently.

## Checklist

- [x] Code follows the style guidelines (formatted and checked with Prettier)
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (README, comments, etc.)

## Breaking Changes

None.

## Additional Context

Documentation is unchanged because the help text does not enumerate logging levels; its validation error now renders the SDK-derived list automatically. The change is limited to two CLI files.
