### PR TITLE
fix(core): start OAuth on a modern/auto-era connect (#1805)

### DIFF
--- a/clients/web/src/test/core/auth/challenge.test.ts
+++ b/clients/web/src/test/core/auth/challenge.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   AuthChallengeError,
   AuthRecoveryRequiredError,
+  findNestedAuthError,
   isAuthChallengeError,
   isConnectAuthRecoveryError,
   parseAuthChallengeFromError,
@@ -389,5 +390,91 @@ describe("isConnectAuthRecoveryError", () => {
         new AuthChallengeError({ reason: "token_expired" }, 403),
       ),
     ).toBe(false);
+  });
+});
+
+/**
+ * The SDK's era-negotiation probe (protocolEra "auto"/"modern") reports a failed
+ * `server/discover` as `SdkError(ERA_NEGOTIATION_FAILED)` and moves the real
+ * error to `data.cause`, hiding the auth signal connect-time recovery matches on
+ * (#1805). These cover the recovery walk over both link names.
+ */
+describe("findNestedAuthError", () => {
+  const authorizationUrl = new URL("https://as.example/authorize");
+  const recoveryRequired = () =>
+    new AuthRecoveryRequiredError(authorizationUrl, { reason: "unauthorized" });
+
+  it("recovers an AuthRecoveryRequiredError from `data.cause` (the SDK probe wrapper)", () => {
+    const nested = recoveryRequired();
+    const wrapper = new Error(
+      "Version negotiation probe failed: Interactive auth recovery required",
+    ) as Error & { data?: { cause?: unknown } };
+    wrapper.data = { cause: nested };
+
+    expect(findNestedAuthError(wrapper)).toBe(nested);
+  });
+
+  it("recovers an AuthChallengeError from `data.cause` (direct transport, intercepted 401)", () => {
+    const nested = new AuthChallengeError({ reason: "token_expired" }, 401);
+    const wrapper = new Error("Version negotiation probe failed") as Error & {
+      data?: { cause?: unknown };
+    };
+    wrapper.data = { cause: nested };
+
+    expect(findNestedAuthError(wrapper)).toBe(nested);
+  });
+
+  it("follows the native `cause` link", () => {
+    const nested = recoveryRequired();
+    expect(findNestedAuthError(new Error("outer", { cause: nested }))).toBe(
+      nested,
+    );
+  });
+
+  it("walks more than one level and prefers the native `cause` branch", () => {
+    const nested = recoveryRequired();
+    const middle = new Error("middle") as Error & {
+      data?: { cause?: unknown };
+    };
+    middle.data = { cause: nested };
+
+    expect(findNestedAuthError(new Error("outer", { cause: middle }))).toBe(
+      nested,
+    );
+  });
+
+  it("returns the error itself when it is already a typed auth error", () => {
+    const err = recoveryRequired();
+    expect(findNestedAuthError(err)).toBe(err);
+  });
+
+  it("returns undefined when no auth error is in the chain", () => {
+    const plain = new Error("outer", { cause: new Error("inner") }) as Error & {
+      data?: { cause?: unknown };
+    };
+    plain.data = { cause: new Error("also not auth") };
+
+    expect(findNestedAuthError(plain)).toBeUndefined();
+  });
+
+  it("returns undefined for non-object errors and a non-object `data`", () => {
+    expect(findNestedAuthError(undefined)).toBeUndefined();
+    expect(findNestedAuthError(null)).toBeUndefined();
+    expect(findNestedAuthError("failed (401)")).toBeUndefined();
+    const stringData = new Error("outer") as Error & { data?: unknown };
+    stringData.data = "not an object";
+    expect(findNestedAuthError(stringData)).toBeUndefined();
+    const nullData = new Error("outer") as Error & { data?: unknown };
+    nullData.data = null;
+    expect(findNestedAuthError(nullData)).toBeUndefined();
+  });
+
+  it("terminates on a cyclic cause chain", () => {
+    const a = new Error("a") as Error & { cause?: unknown };
+    const b = new Error("b") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+
+    expect(findNestedAuthError(a)).toBeUndefined();
   });
 });

--- a/clients/web/src/test/core/mcp/inspectorClient-era-probe-auth.test.ts
+++ b/clients/web/src/test/core/mcp/inspectorClient-era-probe-auth.test.ts
@@ -1,11 +1,43 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   AuthChallengeError,
   AuthRecoveryRequiredError,
 } from "@inspector/core/auth/challenge.js";
 import { InspectorClient } from "@inspector/core/mcp/inspectorClient.js";
 import { eraToVersionNegotiation } from "@inspector/core/mcp/types.js";
+import type { CreateTransportOptions } from "@inspector/core/mcp/types.js";
+import { BrowserOAuthStorage } from "@inspector/core/auth/browser/storage.js";
 import type { JSONRPCMessage, Transport } from "@modelcontextprotocol/client";
+
+/**
+ * Minimal transport whose `send` rejects — which is what the probe's
+ * `server/discover` exchange hits. The remote path rejects with
+ * `AuthRecoveryRequiredError` (after the backend intercepted the 401 and
+ * `handleAuthChallenge` returned `interactive`); a direct transport with
+ * challenge interception rejects with `AuthChallengeError`.
+ */
+class RejectingTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  private readonly rejection: Error;
+
+  // A parameter property would trip `erasableSyntaxOnly`.
+  constructor(rejection: Error) {
+    this.rejection = rejection;
+  }
+
+  async start(): Promise<void> {}
+
+  async send(): Promise<void> {
+    throw this.rejection;
+  }
+
+  async close(): Promise<void> {
+    this.onclose?.();
+  }
+}
 
 /**
  * Connecting with `protocolEra: "auto" | "modern"` sends the SDK's
@@ -21,36 +53,6 @@ import type { JSONRPCMessage, Transport } from "@modelcontextprotocol/client";
  * `src/test/integration/mcp/inspectorClient-modern-era-oauth.test.ts`.
  */
 describe("InspectorClient connect() era-probe auth unwrapping (#1805)", () => {
-  /**
-   * Minimal transport whose `send` rejects — which is what the probe's
-   * `server/discover` exchange hits. The remote path rejects with
-   * `AuthRecoveryRequiredError` (after the backend intercepted the 401 and
-   * `handleAuthChallenge` returned `interactive`); a direct transport with
-   * challenge interception rejects with `AuthChallengeError`.
-   */
-  class RejectingTransport implements Transport {
-    onclose?: () => void;
-    onerror?: (error: Error) => void;
-    onmessage?: (message: JSONRPCMessage) => void;
-
-    private readonly rejection: Error;
-
-    // A parameter property would trip `erasableSyntaxOnly`.
-    constructor(rejection: Error) {
-      this.rejection = rejection;
-    }
-
-    async start(): Promise<void> {}
-
-    async send(): Promise<void> {
-      throw this.rejection;
-    }
-
-    async close(): Promise<void> {
-      this.onclose?.();
-    }
-  }
-
   function makeClient(
     rejection: Error,
     era: "legacy" | "auto" | "modern",
@@ -94,10 +96,21 @@ describe("InspectorClient connect() era-probe auth unwrapping (#1805)", () => {
     it(`leaves a non-auth probe failure untouched on the "${era}" era`, async () => {
       const client = makeClient(new Error("ECONNREFUSED"), era);
 
-      // No auth error in the chain: the SDK's typed negotiation error stands, so
-      // callers still report a plain connection failure.
-      await expect(client.connect()).rejects.toThrow(
-        /Version negotiation|ECONNREFUSED/,
+      // No auth error in the chain, so nothing is unwrapped: whatever the SDK
+      // produced reaches the caller as a plain connection failure. Pin that it
+      // is *not* an auth error rather than matching a message alternation
+      // (which would pass on either branch and assert nothing) — "auto" falls
+      // back to the legacy handshake and rejects with the raw error, while
+      // "modern" pins and rejects with the wrapped negotiation error.
+      const error = await client.connect().then(
+        () => undefined,
+        (err: unknown) => err,
+      );
+      expect(error).toBeInstanceOf(Error);
+      expect(error).not.toBeInstanceOf(AuthChallengeError);
+      expect(error).not.toBeInstanceOf(AuthRecoveryRequiredError);
+      expect((error as Error).message).toMatch(
+        era === "auto" ? /ECONNREFUSED/ : /Version negotiation/,
       );
     });
   }
@@ -112,32 +125,64 @@ describe("InspectorClient connect() era-probe auth unwrapping (#1805)", () => {
   });
 });
 
-describe("InspectorClient probesProtocolEra (#1805)", () => {
-  function probesFor(
+/**
+ * The workaround half of #1805: with no stored tokens there is no authProvider,
+ * so the direct path only intercepts the probe's 401 — turning it into a typed
+ * `AuthChallengeError` that survives as `data.cause` — when the era actually
+ * probes. Asserted through the transport options the factory receives (the
+ * load-bearing effect) rather than the private predicate behind it.
+ */
+describe("InspectorClient era-scoped interceptAuthChallenges (#1805)", () => {
+  async function interceptFlagFor(
     versionNegotiation:
       | { mode?: "legacy" | "auto" | { pin: string } }
       | undefined,
-  ): boolean {
+  ): Promise<boolean | undefined> {
+    let seen: CreateTransportOptions | undefined;
     const client = new InspectorClient(
       { type: "streamable-http", url: "https://mcp.example/mcp" },
       {
-        environment: { transport: () => ({}) as never },
+        environment: {
+          transport: (_config, options) => {
+            seen = options;
+            return {
+              transport: new RejectingTransport(new Error("ECONNREFUSED")),
+            };
+          },
+          // Real but empty storage (sessionStorage under happy-dom) plus the
+          // other two components an OAuthManager requires. No stored tokens, so
+          // `isOAuthAuthorized()` is false and no authProvider is attached —
+          // the case this clause exists for.
+          oauth: {
+            storage: new BrowserOAuthStorage(),
+            navigation: { navigateToAuthorization: vi.fn() },
+            redirectUrlProvider: {
+              getRedirectUrl: () => "http://localhost/callback",
+            },
+          },
+        },
+        oauth: { clientId: "era-probe-test" },
+        directAuthRecovery: true,
         ...(versionNegotiation ? { versionNegotiation } : {}),
       },
     );
-    return (
-      client as unknown as { probesProtocolEra: () => boolean }
-    ).probesProtocolEra();
+
+    await client.connect().catch(() => {});
+    return seen?.interceptAuthChallenges;
   }
 
-  it("is true for the probing eras and false for legacy", () => {
-    expect(probesFor(eraToVersionNegotiation("auto"))).toBe(true);
-    expect(probesFor(eraToVersionNegotiation("modern"))).toBe(true);
-    expect(probesFor(eraToVersionNegotiation("legacy"))).toBe(false);
+  it("is enabled for the probing eras and left off for legacy", async () => {
+    expect(await interceptFlagFor(eraToVersionNegotiation("auto"))).toBe(true);
+    expect(await interceptFlagFor(eraToVersionNegotiation("modern"))).toBe(
+      true,
+    );
+    expect(
+      await interceptFlagFor(eraToVersionNegotiation("legacy")),
+    ).toBeFalsy();
   });
 
-  it("treats an absent mode and an absent option as legacy (the SDK default)", () => {
-    expect(probesFor({})).toBe(false);
-    expect(probesFor(undefined)).toBe(false);
+  it("treats an absent mode and an absent option as legacy (the SDK default)", async () => {
+    expect(await interceptFlagFor({})).toBeFalsy();
+    expect(await interceptFlagFor(undefined)).toBeFalsy();
   });
 });

--- a/clients/web/src/test/core/mcp/inspectorClient-era-probe-auth.test.ts
+++ b/clients/web/src/test/core/mcp/inspectorClient-era-probe-auth.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  AuthChallengeError,
+  AuthRecoveryRequiredError,
+} from "@inspector/core/auth/challenge.js";
+import { InspectorClient } from "@inspector/core/mcp/inspectorClient.js";
+import { eraToVersionNegotiation } from "@inspector/core/mcp/types.js";
+import type { JSONRPCMessage, Transport } from "@modelcontextprotocol/client";
+
+/**
+ * Connecting with `protocolEra: "auto" | "modern"` sends the SDK's
+ * `server/discover` negotiation probe first, and the probe's classifier reports
+ * whatever the transport threw as `SdkError(ERA_NEGOTIATION_FAILED)` with the
+ * original error moved to `data.cause`. That buried the auth signals every
+ * client's connect-error handling matches on, so an OAuth-protected server that
+ * authorized fine on the legacy era produced a dead-end "Version negotiation
+ * probe failed" instead of starting authorization (#1805).
+ *
+ * `connect()` unwraps the rejection, so these assert the *type* that reaches the
+ * caller. The live counterpart (a real modern server answering 401) is
+ * `src/test/integration/mcp/inspectorClient-modern-era-oauth.test.ts`.
+ */
+describe("InspectorClient connect() era-probe auth unwrapping (#1805)", () => {
+  /**
+   * Minimal transport whose `send` rejects — which is what the probe's
+   * `server/discover` exchange hits. The remote path rejects with
+   * `AuthRecoveryRequiredError` (after the backend intercepted the 401 and
+   * `handleAuthChallenge` returned `interactive`); a direct transport with
+   * challenge interception rejects with `AuthChallengeError`.
+   */
+  class RejectingTransport implements Transport {
+    onclose?: () => void;
+    onerror?: (error: Error) => void;
+    onmessage?: (message: JSONRPCMessage) => void;
+
+    private readonly rejection: Error;
+
+    // A parameter property would trip `erasableSyntaxOnly`.
+    constructor(rejection: Error) {
+      this.rejection = rejection;
+    }
+
+    async start(): Promise<void> {}
+
+    async send(): Promise<void> {
+      throw this.rejection;
+    }
+
+    async close(): Promise<void> {
+      this.onclose?.();
+    }
+  }
+
+  function makeClient(
+    rejection: Error,
+    era: "legacy" | "auto" | "modern",
+  ): InspectorClient {
+    return new InspectorClient(
+      { type: "streamable-http", url: "https://mcp.example/mcp" },
+      {
+        environment: {
+          transport: () => ({ transport: new RejectingTransport(rejection) }),
+        },
+        versionNegotiation: eraToVersionNegotiation(era),
+      },
+    );
+  }
+
+  const recoveryRequired = () =>
+    new AuthRecoveryRequiredError(new URL("https://as.example/authorize"), {
+      reason: "unauthorized",
+    });
+
+  for (const era of ["auto", "modern"] as const) {
+    it(`surfaces AuthRecoveryRequiredError from the probe wrapper on the "${era}" era`, async () => {
+      const rejection = recoveryRequired();
+      const client = makeClient(rejection, era);
+
+      await expect(client.connect()).rejects.toBe(rejection);
+    });
+
+    it(`surfaces AuthChallengeError from the probe wrapper on the "${era}" era`, async () => {
+      const rejection = new AuthChallengeError(
+        { reason: "token_expired" },
+        401,
+      );
+      const client = makeClient(rejection, era);
+
+      // The direct-recovery retry is off for this client, so the challenge
+      // itself reaches the caller rather than a recovery outcome.
+      await expect(client.connect()).rejects.toBe(rejection);
+    });
+
+    it(`leaves a non-auth probe failure untouched on the "${era}" era`, async () => {
+      const client = makeClient(new Error("ECONNREFUSED"), era);
+
+      // No auth error in the chain: the SDK's typed negotiation error stands, so
+      // callers still report a plain connection failure.
+      await expect(client.connect()).rejects.toThrow(
+        /Version negotiation|ECONNREFUSED/,
+      );
+    });
+  }
+
+  it("passes an unwrapped legacy-era rejection through unchanged", async () => {
+    // Legacy sends no probe, so nothing wraps the error — the baseline the
+    // probing eras now match.
+    const rejection = recoveryRequired();
+    const client = makeClient(rejection, "legacy");
+
+    await expect(client.connect()).rejects.toBe(rejection);
+  });
+});
+
+describe("InspectorClient probesProtocolEra (#1805)", () => {
+  function probesFor(
+    versionNegotiation:
+      | { mode?: "legacy" | "auto" | { pin: string } }
+      | undefined,
+  ): boolean {
+    const client = new InspectorClient(
+      { type: "streamable-http", url: "https://mcp.example/mcp" },
+      {
+        environment: { transport: () => ({}) as never },
+        ...(versionNegotiation ? { versionNegotiation } : {}),
+      },
+    );
+    return (
+      client as unknown as { probesProtocolEra: () => boolean }
+    ).probesProtocolEra();
+  }
+
+  it("is true for the probing eras and false for legacy", () => {
+    expect(probesFor(eraToVersionNegotiation("auto"))).toBe(true);
+    expect(probesFor(eraToVersionNegotiation("modern"))).toBe(true);
+    expect(probesFor(eraToVersionNegotiation("legacy"))).toBe(false);
+  });
+
+  it("treats an absent mode and an absent option as legacy (the SDK default)", () => {
+    expect(probesFor({})).toBe(false);
+    expect(probesFor(undefined)).toBe(false);
+  });
+});

--- a/clients/web/src/test/core/mcp/inspectorClient-satisfied-recovery-connect.test.ts
+++ b/clients/web/src/test/core/mcp/inspectorClient-satisfied-recovery-connect.test.ts
@@ -80,6 +80,29 @@ describe("InspectorClient connect() after a silently satisfied auth challenge", 
     }
   }
 
+  /** Rejects the handshake for a non-auth reason (no recovery re-entry). */
+  class FailingTransport implements Transport {
+    onclose?: () => void;
+    onerror?: (error: Error) => void;
+    onmessage?: (message: JSONRPCMessage) => void;
+
+    private readonly reason: string;
+
+    // A parameter property would trip `erasableSyntaxOnly`.
+    constructor(reason: string) {
+      this.reason = reason;
+    }
+
+    async start(): Promise<void> {}
+    async close(): Promise<void> {
+      this.onclose?.();
+    }
+
+    async send(): Promise<void> {
+      throw new Error(this.reason);
+    }
+  }
+
   it("resolves, reports connected, and dispatches exactly one connect event", async () => {
     let transportsCreated = 0;
     const client = new InspectorClient(
@@ -137,13 +160,25 @@ describe("InspectorClient connect() after a silently satisfied auth challenge", 
   });
 
   it("still rejects when the reconnect underneath the recovery fails", async () => {
-    // The short-circuit must not mask a failed re-handshake: the nested
-    // connect() throws, so connect() rejects and the status lands on "error".
+    // The short-circuit must not mask a failed re-handshake. The reconnect
+    // fails for a *non-auth* reason, so recovery does not re-enter: the outer
+    // connect() surfaces that error and lands on "error" (a second auth
+    // challenge instead would be held by isConnectAuthRecoveryError, which is
+    // the bounded chain the next test covers).
+    let transportsCreated = 0;
     const client = new InspectorClient(
       { type: "streamable-http", url: "https://mcp.example/mcp" },
       {
         environment: {
-          transport: () => ({ transport: new ChallengingTransport() }),
+          transport: () => {
+            transportsCreated += 1;
+            return {
+              transport:
+                transportsCreated === 1
+                  ? new ChallengingTransport()
+                  : new FailingTransport("handshake refused"),
+            };
+          },
           oauth: oauthEnvironment(),
         },
         oauth: { clientId: "satisfied-recovery-test" },
@@ -154,7 +189,47 @@ describe("InspectorClient connect() after a silently satisfied auth challenge", 
       kind: "satisfied",
     });
 
-    await expect(client.connect()).rejects.toThrow();
+    await expect(client.connect()).rejects.toThrow(/handshake refused/);
+    expect(client.getStatus()).toBe("error");
+  });
+
+  it("reports the teardown, not the stale challenge, when the recovered session dies first", async () => {
+    // The retry leg is reached only after the nested connect() completed, but
+    // the session can die in between. Simulated deterministically: the nested
+    // connect dispatches `connect` after setting "connected", so closing the
+    // live transport from that listener flips the status before the retry leg
+    // runs. It must report why the session died rather than rethrowing the
+    // original 401 the recovery already dealt with.
+    let transportsCreated = 0;
+    let live: HandshakingTransport | undefined;
+    const client = new InspectorClient(
+      { type: "streamable-http", url: "https://mcp.example/mcp" },
+      {
+        environment: {
+          transport: () => {
+            transportsCreated += 1;
+            if (transportsCreated === 1) {
+              return { transport: new ChallengingTransport() };
+            }
+            live = new HandshakingTransport();
+            return { transport: live };
+          },
+          oauth: oauthEnvironment(),
+        },
+        oauth: { clientId: "satisfied-recovery-test" },
+        directAuthRecovery: true,
+      },
+    );
+    vi.spyOn(client, "handleAuthChallenge").mockResolvedValue({
+      kind: "satisfied",
+    });
+    client.addEventListener("connect", () => {
+      live?.onclose?.();
+    });
+
+    await expect(client.connect()).rejects.toThrow(
+      /Connection closed during authorization recovery/,
+    );
     expect(client.getStatus()).not.toBe("connected");
   });
 

--- a/clients/web/src/test/core/mcp/inspectorClient-satisfied-recovery-connect.test.ts
+++ b/clients/web/src/test/core/mcp/inspectorClient-satisfied-recovery-connect.test.ts
@@ -114,9 +114,19 @@ describe("InspectorClient connect() after a silently satisfied auth challenge", 
     client.addEventListener("connect", () => {
       connectEvents += 1;
     });
+    let connectedStatusEvents = 0;
+    client.addEventListener("statusChange", (event) => {
+      if (event.detail === "connected") connectedStatusEvents += 1;
+    });
 
     await expect(client.connect()).resolves.toBeUndefined();
     expect(client.getStatus()).toBe("connected");
+    // The outer call skips fetchServerInfo(); this pins that the nested connect
+    // populated it, i.e. the early return loses nothing.
+    expect(client.getServerInfo()?.name).toBe("recovered-server");
+    // The duplicate statusChange("connected") is suppressed with the duplicate
+    // connect event.
+    expect(connectedStatusEvents).toBe(1);
     expect(transportsCreated).toBe(2);
     // The nested connect() already ran the post-connect block; the outer call
     // must not run it a second time (a duplicate `connect` re-triggers every
@@ -124,5 +134,57 @@ describe("InspectorClient connect() after a silently satisfied auth challenge", 
     expect(connectEvents).toBe(1);
 
     await client.disconnect();
+  });
+
+  it("still rejects when the reconnect underneath the recovery fails", async () => {
+    // The short-circuit must not mask a failed re-handshake: the nested
+    // connect() throws, so connect() rejects and the status lands on "error".
+    const client = new InspectorClient(
+      { type: "streamable-http", url: "https://mcp.example/mcp" },
+      {
+        environment: {
+          transport: () => ({ transport: new ChallengingTransport() }),
+          oauth: oauthEnvironment(),
+        },
+        oauth: { clientId: "satisfied-recovery-test" },
+        directAuthRecovery: true,
+      },
+    );
+    vi.spyOn(client, "handleAuthChallenge").mockResolvedValue({
+      kind: "satisfied",
+    });
+
+    await expect(client.connect()).rejects.toThrow();
+    expect(client.getStatus()).not.toBe("connected");
+  });
+
+  it("bounds nested recoveries when refreshed credentials keep being rejected", async () => {
+    // Every transport challenges and every challenge reports satisfied, so each
+    // recovery reconnects into a fresh challenge. Recovery is counted across
+    // the nesting boundary, so this terminates instead of recursing forever.
+    let transportsCreated = 0;
+    const client = new InspectorClient(
+      { type: "streamable-http", url: "https://mcp.example/mcp" },
+      {
+        environment: {
+          transport: () => {
+            transportsCreated += 1;
+            return { transport: new ChallengingTransport() };
+          },
+          oauth: oauthEnvironment(),
+        },
+        oauth: { clientId: "satisfied-recovery-test" },
+        directAuthRecovery: true,
+      },
+    );
+    vi.spyOn(client, "handleAuthChallenge").mockResolvedValue({
+      kind: "satisfied",
+    });
+
+    await expect(client.connect()).rejects.toBeInstanceOf(AuthChallengeError);
+    // One transport per connect attempt: the initial one plus the three
+    // bounded nested recoveries (MAX_NESTED_AUTH_RECOVERIES), not an unbounded
+    // chain.
+    expect(transportsCreated).toBe(4);
   });
 });

--- a/clients/web/src/test/core/mcp/inspectorClient-satisfied-recovery-connect.test.ts
+++ b/clients/web/src/test/core/mcp/inspectorClient-satisfied-recovery-connect.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from "vitest";
+import { AuthChallengeError } from "@inspector/core/auth/challenge.js";
+import { InspectorClient } from "@inspector/core/mcp/inspectorClient.js";
+import { BrowserOAuthStorage } from "@inspector/core/auth/browser/storage.js";
+import type { JSONRPCMessage, Transport } from "@modelcontextprotocol/client";
+
+/**
+ * The three environment components an OAuthManager needs to exist. Storage is
+ * real but empty (sessionStorage under happy-dom), so there are no tokens and
+ * no authProvider is attached — the connect path this covers.
+ */
+function oauthEnvironment() {
+  return {
+    storage: new BrowserOAuthStorage(),
+    navigation: { navigateToAuthorization: vi.fn() },
+    redirectUrlProvider: {
+      getRedirectUrl: () => "http://localhost/callback",
+    },
+  };
+}
+
+/**
+ * A connect-time auth challenge that recovery satisfies *silently* (a refresh
+ * token, say) must leave `connect()` resolved, not rejected.
+ *
+ * `connect()` builds its handshake promise once, outside the `runConnect`
+ * closure that `withDirectAuthRecovery` retries. On a `satisfied` outcome
+ * recovery calls `reconnectAfterAuthRecovery()`, which runs a complete nested
+ * `connect()` — so by the time the retry leg runs, the client is connected and
+ * the original promise is still rejected. Re-awaiting it rethrew that first
+ * error and rejected a `connect()` whose client was in fact connected (found in
+ * review of #1809; reachable on the legacy era before #1805 and on auto/modern
+ * after it, since a probe 401 now arrives as a typed challenge).
+ */
+describe("InspectorClient connect() after a silently satisfied auth challenge", () => {
+  /** Answers `initialize`, so a connect over it completes the handshake. */
+  class HandshakingTransport implements Transport {
+    onclose?: () => void;
+    onerror?: (error: Error) => void;
+    onmessage?: (message: JSONRPCMessage) => void;
+
+    async start(): Promise<void> {}
+    async close(): Promise<void> {
+      this.onclose?.();
+    }
+
+    async send(message: JSONRPCMessage): Promise<void> {
+      if (
+        "method" in message &&
+        message.method === "initialize" &&
+        "id" in message
+      ) {
+        const params = message.params as { protocolVersion: string };
+        this.onmessage?.({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            protocolVersion: params.protocolVersion,
+            capabilities: {},
+            serverInfo: { name: "recovered-server", version: "1.0.0" },
+          },
+        });
+      }
+    }
+  }
+
+  /** Rejects the handshake with the challenge recovery will satisfy. */
+  class ChallengingTransport implements Transport {
+    onclose?: () => void;
+    onerror?: (error: Error) => void;
+    onmessage?: (message: JSONRPCMessage) => void;
+
+    async start(): Promise<void> {}
+    async close(): Promise<void> {
+      this.onclose?.();
+    }
+
+    async send(): Promise<void> {
+      throw new AuthChallengeError({ reason: "token_expired" }, 401);
+    }
+  }
+
+  it("resolves, reports connected, and dispatches exactly one connect event", async () => {
+    let transportsCreated = 0;
+    const client = new InspectorClient(
+      { type: "streamable-http", url: "https://mcp.example/mcp" },
+      {
+        environment: {
+          transport: () => {
+            transportsCreated += 1;
+            // First connect challenges; the reconnect underneath the satisfied
+            // recovery gets a transport that completes the handshake.
+            return {
+              transport:
+                transportsCreated === 1
+                  ? new ChallengingTransport()
+                  : new HandshakingTransport(),
+            };
+          },
+          oauth: oauthEnvironment(),
+        },
+        oauth: { clientId: "satisfied-recovery-test" },
+        directAuthRecovery: true,
+      },
+    );
+
+    // Recovery succeeds without user interaction — the case that ends in the
+    // retry leg rather than an AuthRecoveryRequiredError.
+    vi.spyOn(client, "handleAuthChallenge").mockResolvedValue({
+      kind: "satisfied",
+    });
+
+    let connectEvents = 0;
+    client.addEventListener("connect", () => {
+      connectEvents += 1;
+    });
+
+    await expect(client.connect()).resolves.toBeUndefined();
+    expect(client.getStatus()).toBe("connected");
+    expect(transportsCreated).toBe(2);
+    // The nested connect() already ran the post-connect block; the outer call
+    // must not run it a second time (a duplicate `connect` re-triggers every
+    // list-state manager's refresh).
+    expect(connectEvents).toBe(1);
+
+    await client.disconnect();
+  });
+});

--- a/clients/web/src/test/integration/mcp/inspectorClient-modern-era-oauth.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient-modern-era-oauth.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Live coverage of an OAuth-protected connect on the probing eras (#1805).
+ *
+ * A modern (2026-07-28) server behind `requireAuth` answers the SDK's
+ * `server/discover` negotiation probe with 401 — the probe runs before anything
+ * else, so it, not `initialize`, is where authorization first surfaces. The
+ * probe's classifier reports the failure as `SdkError(ERA_NEGOTIATION_FAILED)`
+ * with the real error moved to `data.cause`, which used to bury the auth signal
+ * and leave `connect()` rejecting with a dead-end "Version negotiation probe
+ * failed" instead of starting the authorization flow (the same server authorized
+ * fine on `protocolEra: "legacy"`).
+ *
+ * Complements `inspectorClient-modern-era.test.ts` (modern era, no auth) and
+ * `inspectorClient-oauth-direct-mid-session-e2e.test.ts` (auth, legacy era).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, afterAll } from "vitest";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InspectorClient } from "@inspector/core/mcp/inspectorClient.js";
+import { createTransportNode } from "@inspector/core/mcp/node/transport.js";
+import { NodeOAuthStorage } from "@inspector/core/auth/node/storage-node.js";
+import {
+  TestServerHttp,
+  waitForOAuthWellKnown,
+  getDefaultServerConfig,
+  createOAuthTestServerConfig,
+  clearOAuthTestData,
+} from "@modelcontextprotocol/inspector-test-server";
+import {
+  AuthRecoveryRequiredError,
+  isConnectAuthRecoveryError,
+} from "@inspector/core/auth/challenge.js";
+import {
+  eraToVersionNegotiation,
+  MODERN_PROTOCOL_VERSION,
+} from "@inspector/core/mcp/types.js";
+import {
+  createOAuthClientConfig,
+  completeOAuthAuthorization,
+} from "../helpers/oauth-client-fixtures.js";
+import { ConsoleNavigation } from "@inspector/core/auth/providers.js";
+import type { InspectorClientOptions } from "@inspector/core/mcp/inspectorClient.js";
+import type { MCPServerConfig } from "@inspector/core/mcp/types.js";
+
+const oauthTestStatePath = join(
+  tmpdir(),
+  `mcp-oauth-${process.pid}-modern-era-oauth.json`,
+);
+
+const testRedirectUrl = "http://localhost:3000/oauth/callback";
+const staticClientId = "test-modern-era-oauth";
+const staticClientSecret = "test-secret-modern-era-oauth";
+
+describe("OAuth connect on the probing eras (#1805)", () => {
+  let mcpServer: TestServerHttp | null = null;
+  let client: InspectorClient | null = null;
+
+  beforeEach(() => {
+    clearOAuthTestData();
+  });
+
+  afterEach(async () => {
+    if (client) {
+      await client.disconnect().catch(() => {});
+      client = null;
+    }
+    if (mcpServer) {
+      await mcpServer.stop();
+      mcpServer = null;
+    }
+  }, 30_000);
+
+  afterAll(() => {
+    try {
+      rmSync(oauthTestStatePath, { force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  /** Modern-era MCP server that requires a Bearer token on /mcp. */
+  async function startProtectedModernServer(): Promise<string> {
+    const started = new TestServerHttp({
+      ...getDefaultServerConfig(),
+      serverType: "streamable-http" as const,
+      // Modern (2026-07-28) serving: the bearer middleware guards this leg too,
+      // so the negotiation probe itself is answered 401.
+      modern: {},
+      ...createOAuthTestServerConfig({
+        requireAuth: true,
+        supportRefreshTokens: true,
+        staticClients: [
+          {
+            clientId: staticClientId,
+            clientSecret: staticClientSecret,
+            redirectUris: [testRedirectUrl],
+          },
+        ],
+      }),
+    });
+    const port = await started.start();
+    mcpServer = started;
+    const serverUrl = `http://localhost:${port}`;
+    await waitForOAuthWellKnown(serverUrl);
+    return serverUrl;
+  }
+
+  function createClient(
+    serverUrl: string,
+    era: "auto" | "modern",
+  ): InspectorClient {
+    const oauthConfig = {
+      ...createOAuthClientConfig({
+        mode: "static",
+        clientId: staticClientId,
+        clientSecret: staticClientSecret,
+        redirectUrl: testRedirectUrl,
+      }),
+      storage: new NodeOAuthStorage(oauthTestStatePath),
+    };
+
+    const clientConfig: InspectorClientOptions = {
+      environment: {
+        transport: createTransportNode,
+        oauth: {
+          storage: oauthConfig.storage,
+          navigation: new ConsoleNavigation(),
+          redirectUrlProvider: oauthConfig.redirectUrlProvider,
+        },
+      },
+      // The CLI/TUI shape (see core/client/runner.ts).
+      directAuthRecovery: true,
+      versionNegotiation: eraToVersionNegotiation(era),
+      oauth: {
+        clientId: oauthConfig.clientId,
+        clientSecret: oauthConfig.clientSecret,
+        clientMetadataUrl: oauthConfig.clientMetadataUrl,
+        scope: oauthConfig.scope,
+      },
+    };
+
+    const created = new InspectorClient(
+      { type: "streamable-http", url: `${serverUrl}/mcp` } as MCPServerConfig,
+      clientConfig,
+    );
+    client = created;
+    return created;
+  }
+
+  for (const era of ["auto", "modern"] as const) {
+    it(`surfaces a recoverable auth error (not a negotiation failure) on the "${era}" era with no stored tokens`, async () => {
+      const serverUrl = await startProtectedModernServer();
+      const connecting = createClient(serverUrl, era).connect();
+
+      // Recoverable: the caller can drive the OAuth redirect from this error.
+      // Before the fix the probe's wrapper reached here instead, so every
+      // client fell through to a generic "failed to connect" report.
+      await expect(connecting).rejects.toBeInstanceOf(
+        AuthRecoveryRequiredError,
+      );
+      const error = await connecting.catch((err: unknown) => err);
+      expect(isConnectAuthRecoveryError(error)).toBe(true);
+      expect((error as Error).message).not.toMatch(/version negotiation/i);
+      expect(
+        (error as AuthRecoveryRequiredError).authorizationUrl,
+      ).toBeInstanceOf(URL);
+    }, 30_000);
+
+    it(`connects on the "${era}" era once authorization completes`, async () => {
+      const serverUrl = await startProtectedModernServer();
+      const authorizing = createClient(serverUrl, era);
+
+      const authUrl = await authorizing.authenticate();
+      if (!authUrl) throw new Error("Expected an authorization URL");
+      const { code, iss } = await completeOAuthAuthorization(authUrl);
+      await authorizing.completeOAuthFlow(code, iss);
+      await authorizing.connect();
+
+      // With a token the probe is answered, so the modern era is reached — the
+      // outcome the negotiation failure was masking.
+      expect(authorizing.getProtocolEra()).toBe("modern");
+      expect(authorizing.getProtocolVersion()).toBe(MODERN_PROTOCOL_VERSION);
+      expect((await authorizing.listTools()).tools.length).toBeGreaterThan(0);
+    }, 30_000);
+  }
+});

--- a/core/auth/challenge.ts
+++ b/core/auth/challenge.ts
@@ -103,6 +103,62 @@ export function isConnectAuthRecoveryError(err: unknown): boolean {
   return isUnauthorizedError(err);
 }
 
+/**
+ * Recover a typed auth error that another error is carrying in its cause chain.
+ *
+ * Under `protocolEra: auto|modern` the SDK sends a `server/discover` negotiation
+ * probe before anything else, and its classifier reports whatever the transport
+ * threw as `SdkError(ERA_NEGOTIATION_FAILED)` with the original error moved to
+ * `data.cause`. That buries the two connect-time auth signals recovery keys off
+ * — {@link AuthRecoveryRequiredError} on the remote path (it carries the
+ * authorization URL and is matched with `instanceof`), and
+ * {@link AuthChallengeError} on a direct transport — so a modern-era connect
+ * against an OAuth server reported "Version negotiation probe failed" instead of
+ * starting authorization (#1805).
+ *
+ * Walks `cause` and `data.cause` (the same two links {@link isUnauthorizedError}
+ * follows for a nested 401) and returns the first such error. Deliberately not
+ * gated on the SDK's error code or message: any wrapper that keeps the cause
+ * chain intact should surface the same signal, so this survives SDK rewording.
+ */
+export function findNestedAuthError(
+  err: unknown,
+): AuthRecoveryRequiredError | AuthChallengeError | undefined {
+  return findNestedAuthErrorDeep(err, new Set());
+}
+
+function findNestedAuthErrorDeep(
+  err: unknown,
+  seen: Set<unknown>,
+): AuthRecoveryRequiredError | AuthChallengeError | undefined {
+  if (err === null || typeof err !== "object" || seen.has(err)) {
+    return undefined;
+  }
+  seen.add(err);
+
+  if (
+    err instanceof AuthRecoveryRequiredError ||
+    err instanceof AuthChallengeError
+  ) {
+    return err;
+  }
+
+  const nested = findNestedAuthErrorDeep(
+    (err as { cause?: unknown }).cause,
+    seen,
+  );
+  if (nested) {
+    return nested;
+  }
+
+  const data = (err as { data?: unknown }).data;
+  if (data !== null && typeof data === "object") {
+    return findNestedAuthErrorDeep((data as { cause?: unknown }).cause, seen);
+  }
+
+  return undefined;
+}
+
 export interface WwwAuthenticateBearerParams {
   error?: string;
   scope?: string;

--- a/core/auth/index.ts
+++ b/core/auth/index.ts
@@ -78,6 +78,7 @@ export {
   unionAuthorizationScopes,
   isAuthChallengeError,
   isConnectAuthRecoveryError,
+  findNestedAuthError,
   EMA_STEP_UP_PENDING_URL,
 } from "./challenge.js";
 

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -1719,6 +1719,12 @@ export class InspectorClient extends InspectorClientEventTarget {
         // discarded entirely: no status, not even a cause. Intercepting makes
         // the 401 a typed AuthChallengeError, which survives the probe as
         // `data.cause` for `findNestedAuthError` to recover (#1805).
+        //
+        // WORKAROUND (#1807, upstream modelcontextprotocol/typescript-sdk#2561):
+        // remove this clause once the SDK classifies a probe 401/403 as
+        // auth-required. `findNestedAuthError` is the permanent fix; the
+        // `|| this.probesProtocolEra()` clause below exists only to compensate
+        // for that upstream gap and should be deleted with it.
         (transportOptions.authProvider || this.probesProtocolEra())
       ) {
         transportOptions.interceptAuthChallenges = true;

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -536,6 +536,22 @@ export class InspectorClient extends InspectorClientEventTarget {
   /** null until first transport is built; then true for in-process OAuth runners. */
   private directAuthRecoveryActive: boolean | null = null;
   /**
+   * Nesting depth of in-flight silent auth recoveries. `withDirectAuthRecovery`
+   * bounds retries per call (`attempt >= 1`), but a satisfied outcome recovers
+   * by running a *nested* `connect()`, which starts its own recovery with a
+   * fresh counter — so a server that keeps answering 401 with freshly refreshed
+   * tokens would recurse without bound. Counted across the nesting boundary and
+   * capped at {@link InspectorClient.MAX_NESTED_AUTH_RECOVERIES}.
+   */
+  private authRecoveryDepth = 0;
+  /**
+   * Cap on nested silent recoveries. One is the normal case (challenge →
+   * refresh → reconnect); a couple more absorb a legitimately re-challenged
+   * reconnect. Beyond that the credentials are not fixing the challenge, so the
+   * challenge is surfaced to the caller instead of recovered again.
+   */
+  private static readonly MAX_NESTED_AUTH_RECOVERIES = 3;
+  /**
    * Opt-in from {@link InspectorClientOptions.directAuthRecovery}: when true and
    * the live transport is direct (not {@link RemoteClientTransport}), RPCs use
    * fetch intercept + {@link withDirectAuthRecovery}.
@@ -1809,10 +1825,10 @@ export class InspectorClient extends InspectorClientEventTarget {
       // Set when a satisfied auth recovery already completed a full connect()
       // underneath us — see the short-circuit in `runConnect`.
       let recoveredByNestedConnect = false;
-      const runConnect = async (): Promise<void> => {
-        if (this.status === "connected") {
-          // We are the *retry* leg of `withDirectAuthRecovery`: the challenge
-          // was satisfied silently (e.g. a refresh token), so
+      const runConnect = async (attempt: number): Promise<void> => {
+        if (attempt > 0) {
+          // The *retry* leg of `withDirectAuthRecovery`: the challenge was
+          // satisfied silently (e.g. a refresh token), so
           // `reconnectAfterAuthRecovery()` has already run a complete
           // `connect()` — handshake, server info, `connect` event and all.
           // `connectPromise` is created once, outside this closure, so
@@ -1821,7 +1837,17 @@ export class InspectorClient extends InspectorClientEventTarget {
           // circuit instead, and let the caller skip the post-connect block the
           // nested connect already ran (dispatching a second `connect` event
           // would re-trigger every list-state manager's refresh).
+          //
+          // Keyed off the leg rather than live status: an `onclose` landing
+          // between the nested connect and here would flip status off
+          // "connected" and fall through to the rejected `connectPromise`,
+          // reporting the stale handshake 401 as the reason the session died.
           recoveredByNestedConnect = true;
+          if (this.status !== "connected") {
+            throw new Error(
+              "Connection closed during authorization recovery, after re-authorizing successfully",
+            );
+          }
           return;
         }
         if (connectTimeoutMs > 0) {
@@ -5336,17 +5362,27 @@ export class InspectorClient extends InspectorClientEventTarget {
   }
 
   private async withDirectAuthRecovery<T>(
-    operation: () => Promise<T>,
+    operation: (attempt: number) => Promise<T>,
     context?: { method?: string; toolName?: string },
     attempt = 0,
   ): Promise<T> {
     try {
-      return await operation();
+      // `attempt` is passed through so an operation can tell the first leg from
+      // the post-recovery retry leg — `connect()` needs that distinction, and
+      // live connection status is a racy proxy for it.
+      return await operation(attempt);
     } catch (err) {
       if (attempt >= 1 || !this.usesDirectAuthRecovery()) {
         throw err;
       }
       if (!isAuthChallengeError(err)) {
+        throw err;
+      }
+      if (
+        this.authRecoveryDepth >= InspectorClient.MAX_NESTED_AUTH_RECOVERIES
+      ) {
+        // Refreshed credentials are not satisfying the server: recovering again
+        // would just re-enter the nested connect() below. Surface the challenge.
         throw err;
       }
       const challenge = parseAuthChallengeFromError(err, context);
@@ -5367,7 +5403,12 @@ export class InspectorClient extends InspectorClientEventTarget {
         if (this.activeToolCallAbortController) {
           this.activeToolCallAbortController = undefined;
         }
-        await this.reconnectAfterAuthRecovery();
+        this.authRecoveryDepth += 1;
+        try {
+          await this.reconnectAfterAuthRecovery();
+        } finally {
+          this.authRecoveryDepth -= 1;
+        }
         this.dispatchTypedEvent("authChallengeRecovered", { challenge });
         return this.withDirectAuthRecovery(operation, context, attempt + 1);
       }
@@ -5390,11 +5431,11 @@ export class InspectorClient extends InspectorClientEventTarget {
   }
 
   private async invokeMcpClient<T>(
-    operation: () => Promise<T>,
+    operation: (attempt: number) => Promise<T>,
     context?: { method?: string; toolName?: string },
   ): Promise<T> {
     if (!this.usesDirectAuthRecovery()) {
-      return operation();
+      return operation(0);
     }
     return this.withDirectAuthRecovery(operation, context);
   }

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -1725,6 +1725,14 @@ export class InspectorClient extends InspectorClientEventTarget {
         // auth-required. `findNestedAuthError` is the permanent fix; the
         // `|| this.probesProtocolEra()` clause below exists only to compensate
         // for that upstream gap and should be deleted with it.
+        //
+        // Known, accepted side effect of turning intercept on with no stored
+        // tokens: `parseAuthChallengeFromResponse` treats 403 as a challenge
+        // too, so a probe answered 403 for a *non-auth* reason (a gateway
+        // rejecting the unknown `server/discover` method, say) now starts OAuth
+        // discovery instead of letting "auto" fall back to the legacy
+        // `initialize`. The outcome is a surfaced `oauthError`, not a hang, and
+        // it goes away with this clause.
         (transportOptions.authProvider || this.probesProtocolEra())
       ) {
         transportOptions.interceptAuthChallenges = true;
@@ -1798,7 +1806,24 @@ export class InspectorClient extends InspectorClientEventTarget {
         .catch((err: unknown) => {
           throw findNestedAuthError(err) ?? err;
         });
+      // Set when a satisfied auth recovery already completed a full connect()
+      // underneath us — see the short-circuit in `runConnect`.
+      let recoveredByNestedConnect = false;
       const runConnect = async (): Promise<void> => {
+        if (this.status === "connected") {
+          // We are the *retry* leg of `withDirectAuthRecovery`: the challenge
+          // was satisfied silently (e.g. a refresh token), so
+          // `reconnectAfterAuthRecovery()` has already run a complete
+          // `connect()` — handshake, server info, `connect` event and all.
+          // `connectPromise` is created once, outside this closure, so
+          // re-awaiting it here would rethrow the *original* rejection and
+          // reject a `connect()` whose client is in fact connected. Short-
+          // circuit instead, and let the caller skip the post-connect block the
+          // nested connect already ran (dispatching a second `connect` event
+          // would re-trigger every list-state manager's refresh).
+          recoveredByNestedConnect = true;
+          return;
+        }
         if (connectTimeoutMs > 0) {
           connectPromise.catch(() => {});
           let timer: ReturnType<typeof setTimeout> | undefined;
@@ -1830,6 +1855,10 @@ export class InspectorClient extends InspectorClientEventTarget {
           await this.disconnect().catch(() => {});
         }
         throw err;
+      }
+      if (recoveredByNestedConnect) {
+        // The nested connect() from the auth recovery did all of the below.
+        return;
       }
       this.status = "connected";
       this.dispatchTypedEvent("statusChange", this.status);
@@ -5290,8 +5319,16 @@ export class InspectorClient extends InspectorClientEventTarget {
 
   /**
    * True when connect() sends the SDK's `server/discover` negotiation probe —
-   * i.e. `protocolEra` is "auto" or "modern" (`{ pin }`). Legacy is the default
-   * for an absent `mode`, matching the SDK.
+   * i.e. `protocolEra` is "auto", or "modern" (`{ pin: MODERN_PROTOCOL_VERSION }`).
+   * Legacy is the default for an absent `mode`, matching the SDK.
+   *
+   * `versionNegotiation` is a public option, so a caller can pin a revision the
+   * repo's own {@link eraToVersionNegotiation} never produces (it only ever
+   * pins {@link MODERN_PROTOCOL_VERSION}). That is still "probing" and
+   * deliberately reports true: per the SDK, *any* `{ pin }` sends the
+   * connect-time `server/discover` — "the connect-time `server/discover` must
+   * offer it. No fallback" — so the pinned revision doesn't change whether the
+   * probe (and hence the buried-401 problem) happens. Only "legacy" skips it.
    */
   private probesProtocolEra(): boolean {
     const mode = this.versionNegotiation.mode;

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -186,6 +186,7 @@ import type {
 import {
   AuthRecoveryRequiredError,
   EMA_STEP_UP_PENDING_URL,
+  findNestedAuthError,
   isAuthChallengeError,
   isConnectAuthRecoveryError,
   parseAuthChallengeFromError,
@@ -1710,7 +1711,15 @@ export class InspectorClient extends InspectorClientEventTarget {
         this.directAuthRecoveryActive !== false &&
         this.isHttpOAuthConfig() &&
         oauthManager &&
-        transportOptions.authProvider
+        // No stored tokens means no authProvider (see above), and then a 401 on
+        // the era-negotiation probe reaches the SDK as a raw `SdkHttpError`.
+        // The probe's classifier ignores the HTTP status — it only looks for a
+        // JSON-RPC error body — so it verdicts "not a modern server", and pin
+        // ("modern") mode rethrows that as ERA_NEGOTIATION_FAILED with the 401
+        // discarded entirely: no status, not even a cause. Intercepting makes
+        // the 401 a typed AuthChallengeError, which survives the probe as
+        // `data.cause` for `findNestedAuthError` to recover (#1805).
+        (transportOptions.authProvider || this.probesProtocolEra())
       ) {
         transportOptions.interceptAuthChallenges = true;
       }
@@ -1772,7 +1781,17 @@ export class InspectorClient extends InspectorClientEventTarget {
       // Promise.race. On timeout, tear the transport down so the next
       // connect() starts clean and the upstream socket isn't left hanging.
       const connectTimeoutMs = this.serverSettings?.connectionTimeout ?? 0;
-      const connectPromise = this.client.connect(this.transport);
+      // Unwrap here — the earliest point — so an auth error the SDK's
+      // era-negotiation probe buried in its cause chain is surfaced before
+      // anything downstream inspects it: `withDirectAuthRecovery` (whose
+      // `isAuthChallengeError` check is shallow), the outer catch's
+      // `isConnectAuthRecoveryError` status guard, and every client's connect
+      // error handling. See {@link findNestedAuthError} (#1805).
+      const connectPromise = this.client
+        .connect(this.transport)
+        .catch((err: unknown) => {
+          throw findNestedAuthError(err) ?? err;
+        });
       const runConnect = async (): Promise<void> => {
         if (connectTimeoutMs > 0) {
           connectPromise.catch(() => {});
@@ -5261,6 +5280,16 @@ export class InspectorClient extends InspectorClientEventTarget {
   /** Direct (non-remote) OAuth transports recover via fetch intercept + handleAuthChallenge. */
   private usesDirectAuthRecovery(): boolean {
     return this.directAuthRecovery && this.directAuthRecoveryActive === true;
+  }
+
+  /**
+   * True when connect() sends the SDK's `server/discover` negotiation probe —
+   * i.e. `protocolEra` is "auto" or "modern" (`{ pin }`). Legacy is the default
+   * for an absent `mode`, matching the SDK.
+   */
+  private probesProtocolEra(): boolean {
+    const mode = this.versionNegotiation.mode;
+    return mode !== undefined && mode !== "legacy";
   }
 
   private async withDirectAuthRecovery<T>(


### PR DESCRIPTION
Closes #1805
Closes #1806

Maintainer-run version of @rinormaloku's #1806 — the same fix, rebased onto current `v2/main`, with the one review change applied and the full `ci` chain run locally (external PRs can't trigger workflows without approval, and #1806 had never been through the gate).

Supersedes #1806; please close that PR in favour of this one. Original commit authorship is preserved.

## The bug

Connecting to an OAuth-protected HTTP server with **Protocol Era = Auto or Modern** never started the authorization flow. The same server authorized fine on **Legacy**, and the user saw a red toast instead of the OAuth redirect:

```
Failed to connect to "<server>": Version negotiation probe failed: Interactive auth recovery required
```

## Root cause

Era `auto`/`modern` sends the SDK's `server/discover` negotiation probe before anything else, so the probe — not `initialize` — is where authorization first surfaces. Its classifier reports whatever the transport threw as `SdkError(ERA_NEGOTIATION_FAILED)`, keeping the real error at `data.cause`. That buried both connect-time auth signals:

- **Remote path (web).** The backend always sets `interceptAuthChallenges: true`, so a 401 becomes `AuthChallengeError` → `auth_challenge` → `RemoteClientTransport` rejects with `AuthRecoveryRequiredError` (carrying the authorization URL). Wrapped, it no longer matched `err instanceof AuthRecoveryRequiredError` in `App.tsx`, and `isUnauthorizedError()` couldn't see it either (no `status`/`code`). It also flipped connection status to `error`, which `isConnectAuthRecoveryError` exists to prevent.
- **Direct path (CLI/TUI).** No stored tokens means no `authProvider`, so no interception, so the 401 reached the SDK as a raw `SdkHttpError`. The classifier ignores the HTTP status — it only looks for a JSON-RPC error body — and verdicts "not a modern server"; pin mode then rethrew that with the 401 **discarded entirely**: no status, not even a `cause`.

| era | error out of `client.connect()` | recovery matched? |
| --- | --- | --- |
| legacy | `AuthRecoveryRequiredError` | ✅ redirect |
| auto | `SdkError` / `ERA_NEGOTIATION_FAILED` | ❌ generic toast |
| modern (pin) | `SdkError` / `ERA_NEGOTIATION_FAILED` | ❌ generic toast |

## Changes

- **`core/auth/challenge.ts`** — `findNestedAuthError()` walks `cause` / `data.cause` for a nested `AuthRecoveryRequiredError` / `AuthChallengeError`. Deliberately not gated on the SDK's error code or message, so it survives SDK rewording. **This is the permanent fix.**
- **`core/mcp/inspectorClient.ts`** — `connect()` unwraps the `client.connect()` rejection at the earliest point: ahead of `withDirectAuthRecovery` (whose `isAuthChallengeError` check is shallow), the outer status guard, and every client's connect-error handling. Web, CLI, and TUI are all fixed with no client-side change.
- **`core/mcp/inspectorClient.ts`** — on the direct path, enable `interceptAuthChallenges` for the probing eras even with no stored tokens, so the 401 becomes a typed `AuthChallengeError` that survives the probe as `data.cause`. **This half is a workaround** for the upstream gap and is now commented as removable — see below.

### Review change applied on top of #1806

The era-scoped guard is kept exactly as written; only its comment changed, so its lifespan is explicit for whoever picks up #1807:

```
// WORKAROUND (#1807, upstream modelcontextprotocol/typescript-sdk#2561):
// remove this clause once the SDK classifies a probe 401/403 as auth-required.
```

## Tests

- `clients/web/src/test/core/auth/challenge.test.ts` — 8 cases over the walk (both link names, multi-level, already-typed, absent, non-object/null `data`, cyclic chain).
- `clients/web/src/test/core/mcp/inspectorClient-era-probe-auth.test.ts` — `connect()` surfaces each typed error on `auto`/`modern`, leaves a non-auth probe failure untouched, and keeps the legacy baseline; plus `probesProtocolEra()`.
- `clients/web/src/test/integration/mcp/inspectorClient-modern-era-oauth.test.ts` — live modern-era server behind `requireAuth`: `connect()` rejects with a recoverable auth error (not a negotiation failure) on both probing eras, and connects reporting the modern era once authorization completes.

Each half of the fix is load-bearing — reverting either one fails the new integration tests.

**Gate:** `npm run ci` run locally on this branch — green end to end (`validate` → `coverage` per-file ≥90 gate → `verify:build-gate` → `smoke` incl. headless-Chromium web boot → Storybook 108 files / 460 tests).

## Follow-ups (tracked, not in this PR)

- #1807 — upstream SDK: probe classifier should treat 401/403 as auth-required, and pin mode must not drop the status (modelcontextprotocol/typescript-sdk#2561). Landing it removes the workaround clause above.
- #1808 — OAuth callback leg dead-ends when discovery state is missing (`AuthorizationServerMismatchError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016S7h83UKNQ7kvSiFDNksCt
