### PR TITLE
fix: wait for the TUI to exit before removing its temp dir (#1801)

### DIFF
--- a/scripts/smoke-tui.mjs
+++ b/scripts/smoke-tui.mjs
@@ -105,10 +105,10 @@ const child = spawn(
 
 let output = "";
 let settled = false;
-let childExited = false;
+let childClosed = false;
 
 // How long to let the TUI wind down after SIGTERM before escalating to SIGKILL,
-// and then before giving up on the exit event entirely.
+// and then before giving up on the close event entirely.
 const EXIT_GRACE_MS = Number(process.env.SMOKE_TUI_EXIT_GRACE_MS ?? 5000);
 
 function cleanup() {
@@ -124,12 +124,20 @@ function cleanup() {
   }
 }
 
+// `message` may be a string or a thunk. Callers that quote the child's output
+// pass a thunk so it is rendered here — after the wait below, by which point
+// `close` guarantees stdout/stderr have been fully drained. Building the string
+// at call time instead can truncate the crash reason that matters most.
+let finished = false;
 function finish(code, message) {
+  if (finished) return;
+  finished = true;
   cleanup();
+  const text = typeof message === "function" ? message() : message;
   if (code === 0) {
-    console.log(`smoke:tui OK — ${message}`);
+    console.log(`smoke:tui OK — ${text}`);
   } else {
-    console.error(`smoke:tui FAILED — ${message}`);
+    console.error(`smoke:tui FAILED — ${text}`);
   }
   process.exit(code);
 }
@@ -138,7 +146,7 @@ function done(code, message) {
   if (settled) return;
   settled = true;
   clearTimeout(timer);
-  if (childExited) {
+  if (childClosed) {
     finish(code, message);
     return;
   }
@@ -146,6 +154,11 @@ function done(code, message) {
   // The dir doubles as the TUI's HOME, so the Ink process is still writing into
   // it when we signal; an rmSync racing those writes fails with ENOTEMPTY when
   // a file lands after a directory has been read but before it is removed.
+  //
+  // Wait on `close`, not `exit`: a *spawn failure* emits `error` + `close` and
+  // never `exit`, so an `exit` wait would hang here until the give-up timer and
+  // then blame a SIGTERM the child never received. `close` also guarantees the
+  // stdio pipes are drained, which is what makes the thunked messages complete.
   const forceKill = setTimeout(() => child.kill("SIGKILL"), EXIT_GRACE_MS);
   const giveUp = setTimeout(() => {
     console.warn(
@@ -153,12 +166,17 @@ function done(code, message) {
     );
     finish(code, message);
   }, EXIT_GRACE_MS * 2);
-  child.once("exit", () => {
+  child.once("close", () => {
     clearTimeout(forceKill);
     clearTimeout(giveUp);
     finish(code, message);
   });
-  if (!child.killed) child.kill("SIGTERM");
+  // Only signal a child that is still running: on the crash-before-render and
+  // spawn-failure paths there is nothing left to signal, and we are here purely
+  // to wait out the remaining `close`.
+  if (child.exitCode === null && child.signalCode === null && !child.killed) {
+    child.kill("SIGTERM");
+  }
 }
 
 function onData(chunk) {
@@ -171,15 +189,19 @@ function onData(chunk) {
 child.stdout.on("data", onData);
 child.stderr.on("data", onData);
 
+// Registered before done()'s own one-shot listener, so this always runs first —
+// done() can trust `childClosed` even when called from inside a close handler.
+child.on("close", () => {
+  childClosed = true;
+});
+
 child.on("exit", (code) => {
-  // Registered before done()'s own one-shot listener, so this always runs first
-  // — done() can trust `childExited` when it is called from inside this handler.
-  childExited = true;
   if (settled) return;
   // Exiting before the render marker appeared is a failure (crash on boot).
   done(
     1,
-    `TUI exited (code ${code}) before rendering "${RENDER_MARKER}"\n${output.slice(0, 800)}`,
+    () =>
+      `TUI exited (code ${code}) before rendering "${RENDER_MARKER}"\n${output.slice(0, 800)}`,
   );
 });
 
@@ -190,6 +212,7 @@ child.on("error", (err) => {
 const timer = setTimeout(() => {
   done(
     1,
-    `TUI did not render "${RENDER_MARKER}" within ${TIMEOUT_MS}ms\n${output.slice(0, 800)}`,
+    () =>
+      `TUI did not render "${RENDER_MARKER}" within ${TIMEOUT_MS}ms\n${output.slice(0, 800)}`,
   );
 }, TIMEOUT_MS);

--- a/scripts/smoke-tui.mjs
+++ b/scripts/smoke-tui.mjs
@@ -105,11 +105,19 @@ const child = spawn(
 
 let output = "";
 let settled = false;
+let childExited = false;
 let childClosed = false;
 
 // How long to let the TUI wind down after SIGTERM before escalating to SIGKILL,
 // and then before giving up on the close event entirely.
 const EXIT_GRACE_MS = Number(process.env.SMOKE_TUI_EXIT_GRACE_MS ?? 5000);
+// Once the child itself is gone, only the pipe drain remains, so the wait drops
+// to this. `close` is bounded by whoever holds the stdio pipes, which can
+// outlive the direct child: any descendant that inherited them keeps it pending.
+// The TUI spawns nothing at boot today (it does not auto-connect), so this
+// never fires — but that reason lives outside this file, so cap it here rather
+// than inherit an unrelated process's lifetime if that ever changes.
+const DRAIN_MS = 500;
 
 function cleanup() {
   try {
@@ -117,7 +125,7 @@ function cleanup() {
   } catch (err) {
     // Never turn a passing smoke into a failure over a leftover temp dir; the
     // OS reclaims tmpdir anyway. This should not fire now that removal waits
-    // for the child to exit (see finish()), so say so loudly if it does.
+    // for the child's `close` (see done()), so say so loudly if it does.
     console.warn(
       `smoke:tui — could not remove temp dir ${work}: ${err.message}`,
     );
@@ -160,15 +168,37 @@ function done(code, message) {
   // then blame a SIGTERM the child never received. `close` also guarantees the
   // stdio pipes are drained, which is what makes the thunked messages complete.
   const forceKill = setTimeout(() => child.kill("SIGKILL"), EXIT_GRACE_MS);
-  const giveUp = setTimeout(() => {
-    console.warn(
-      `smoke:tui — TUI did not exit within ${EXIT_GRACE_MS * 2}ms of SIGTERM; cleaning up anyway`,
+
+  // Deadline for the wait. Re-armed shorter once the child is gone, since from
+  // that point we are only draining pipes. Each message describes what was
+  // actually being waited on — the timer can fire for a child that already
+  // exited and was never signalled, so it must not claim otherwise.
+  let deadline;
+  const armDeadline = (ms, warning) => {
+    clearTimeout(deadline);
+    deadline = setTimeout(() => {
+      console.warn(`smoke:tui — ${warning}`);
+      finish(code, message);
+    }, ms);
+  };
+  armDeadline(
+    EXIT_GRACE_MS * 2,
+    `TUI did not close its output streams within ${EXIT_GRACE_MS * 2}ms; cleaning up anyway`,
+  );
+
+  const drainOnly = () => {
+    clearTimeout(forceKill);
+    armDeadline(
+      DRAIN_MS,
+      `TUI exited but held its output streams open for ${DRAIN_MS}ms (a descendant may have inherited them); cleaning up anyway`,
     );
-    finish(code, message);
-  }, EXIT_GRACE_MS * 2);
+  };
+  if (childExited) drainOnly();
+  else child.once("exit", drainOnly);
+
   child.once("close", () => {
     clearTimeout(forceKill);
-    clearTimeout(giveUp);
+    clearTimeout(deadline);
     finish(code, message);
   });
   // Only signal a child that is still running: on the crash-before-render and
@@ -196,12 +226,13 @@ child.on("close", () => {
 });
 
 child.on("exit", (code) => {
+  childExited = true;
   if (settled) return;
   // Exiting before the render marker appeared is a failure (crash on boot).
   done(
     1,
     () =>
-      `TUI exited (code ${code}) before rendering "${RENDER_MARKER}"\n${output.slice(0, 800)}`,
+      `TUI exited (code ${code}) before rendering "${RENDER_MARKER}"\n${output.slice(-800)}`,
   );
 });
 
@@ -213,6 +244,6 @@ const timer = setTimeout(() => {
   done(
     1,
     () =>
-      `TUI did not render "${RENDER_MARKER}" within ${TIMEOUT_MS}ms\n${output.slice(0, 800)}`,
+      `TUI did not render "${RENDER_MARKER}" within ${TIMEOUT_MS}ms\n${output.slice(-800)}`,
   );
 }, TIMEOUT_MS);

--- a/scripts/smoke-tui.mjs
+++ b/scripts/smoke-tui.mjs
@@ -117,6 +117,12 @@ const EXIT_GRACE_MS = Number(process.env.SMOKE_TUI_EXIT_GRACE_MS ?? 5000);
 // The TUI spawns nothing at boot today (it does not auto-connect), so this
 // never fires — but that reason lives outside this file, so cap it here rather
 // than inherit an unrelated process's lifetime if that ever changes.
+//
+// The cost of capping: on that path we remove the work dir while a descendant
+// holding HOME=work may still be writing to it — the #1801 race, re-entered
+// deliberately. That is only acceptable because cleanup() warns instead of
+// throwing, so the worst case is a warning plus a leaked temp dir in tmpdir,
+// never a red smoke. The two are load-bearing for each other.
 const DRAIN_MS = 500;
 
 function cleanup() {
@@ -124,12 +130,23 @@ function cleanup() {
     rmSync(work, { recursive: true, force: true });
   } catch (err) {
     // Never turn a passing smoke into a failure over a leftover temp dir; the
-    // OS reclaims tmpdir anyway. This should not fire now that removal waits
-    // for the child's `close` (see done()), so say so loudly if it does.
+    // OS reclaims tmpdir anyway. On the normal path this should not fire, since
+    // removal waits for the child's `close` (see done()) — but the two give-up
+    // branches there call finish() without it, and a process may still hold the
+    // dir, so this is expected rather than anomalous on those.
     console.warn(
       `smoke:tui — could not remove temp dir ${work}: ${err.message}`,
     );
   }
+}
+
+// Tail of the child's output, for quoting in a diagnostic. Slicing an Ink
+// stream can land mid-CSI-sequence, so drop through the first newline rather
+// than lead with an escape-code fragment that mangles the line after it.
+function outputTail(limit = 800) {
+  const tail = output.slice(-limit);
+  const nl = tail.indexOf("\n");
+  return output.length > limit && nl !== -1 ? tail.slice(nl + 1) : tail;
 }
 
 // `message` may be a string or a thunk. Callers that quote the child's output
@@ -232,7 +249,7 @@ child.on("exit", (code) => {
   done(
     1,
     () =>
-      `TUI exited (code ${code}) before rendering "${RENDER_MARKER}"\n${output.slice(-800)}`,
+      `TUI exited (code ${code}) before rendering "${RENDER_MARKER}"\n${outputTail()}`,
   );
 });
 
@@ -244,6 +261,6 @@ const timer = setTimeout(() => {
   done(
     1,
     () =>
-      `TUI did not render "${RENDER_MARKER}" within ${TIMEOUT_MS}ms\n${output.slice(-800)}`,
+      `TUI did not render "${RENDER_MARKER}" within ${TIMEOUT_MS}ms\n${outputTail()}`,
   );
 }, TIMEOUT_MS);

--- a/scripts/smoke-tui.mjs
+++ b/scripts/smoke-tui.mjs
@@ -105,16 +105,26 @@ const child = spawn(
 
 let output = "";
 let settled = false;
+let childExited = false;
+
+// How long to let the TUI wind down after SIGTERM before escalating to SIGKILL,
+// and then before giving up on the exit event entirely.
+const EXIT_GRACE_MS = Number(process.env.SMOKE_TUI_EXIT_GRACE_MS ?? 5000);
 
 function cleanup() {
-  rmSync(work, { recursive: true, force: true });
+  try {
+    rmSync(work, { recursive: true, force: true });
+  } catch (err) {
+    // Never turn a passing smoke into a failure over a leftover temp dir; the
+    // OS reclaims tmpdir anyway. This should not fire now that removal waits
+    // for the child to exit (see finish()), so say so loudly if it does.
+    console.warn(
+      `smoke:tui — could not remove temp dir ${work}: ${err.message}`,
+    );
+  }
 }
 
-function done(code, message) {
-  if (settled) return;
-  settled = true;
-  clearTimeout(timer);
-  if (!child.killed) child.kill("SIGTERM");
+function finish(code, message) {
   cleanup();
   if (code === 0) {
     console.log(`smoke:tui OK — ${message}`);
@@ -122,6 +132,33 @@ function done(code, message) {
     console.error(`smoke:tui FAILED — ${message}`);
   }
   process.exit(code);
+}
+
+function done(code, message) {
+  if (settled) return;
+  settled = true;
+  clearTimeout(timer);
+  if (childExited) {
+    finish(code, message);
+    return;
+  }
+  // Wait for the child to actually exit before removing the work dir (#1801).
+  // The dir doubles as the TUI's HOME, so the Ink process is still writing into
+  // it when we signal; an rmSync racing those writes fails with ENOTEMPTY when
+  // a file lands after a directory has been read but before it is removed.
+  const forceKill = setTimeout(() => child.kill("SIGKILL"), EXIT_GRACE_MS);
+  const giveUp = setTimeout(() => {
+    console.warn(
+      `smoke:tui — TUI did not exit within ${EXIT_GRACE_MS * 2}ms of SIGTERM; cleaning up anyway`,
+    );
+    finish(code, message);
+  }, EXIT_GRACE_MS * 2);
+  child.once("exit", () => {
+    clearTimeout(forceKill);
+    clearTimeout(giveUp);
+    finish(code, message);
+  });
+  if (!child.killed) child.kill("SIGTERM");
 }
 
 function onData(chunk) {
@@ -135,6 +172,9 @@ child.stdout.on("data", onData);
 child.stderr.on("data", onData);
 
 child.on("exit", (code) => {
+  // Registered before done()'s own one-shot listener, so this always runs first
+  // — done() can trust `childExited` when it is called from inside this handler.
+  childExited = true;
   if (settled) return;
   // Exiting before the render marker appeared is a failure (crash on boot).
   done(


### PR DESCRIPTION
Closes #1801

## Problem

`smoke:tui` intermittently failed with `ENOTEMPTY` *after* the TUI had already rendered successfully:

```
Error: ENOTEMPTY, Directory not empty: /var/folders/.../T/smoke-tui-xbpuq7
    at cleanup (scripts/smoke-tui.mjs:102:3)
```

`done()` called `child.kill("SIGTERM")` and then `cleanup()` synchronously. Nothing waited for the child, and the work dir doubles as the TUI's `HOME` — so the Ink process could still be writing into it while `rmSync` walked it. A file created after a directory has been read but before it is removed produces `ENOTEMPTY` on macOS.

Because `smoke` is part of the mandatory pre-push gate and `smoke:tui` self-skips under `CI`, this only bit local runs — exactly where the gate is supposed to be trusted.

## Fix

Removal now waits for the child's `exit` event instead of racing it:

- `done()` registers a one-shot `exit` listener, then sends `SIGTERM`; cleanup + `process.exit` happen in `finish()` from that listener.
- Escalates to `SIGKILL` after `SMOKE_TUI_EXIT_GRACE_MS` (default 5s), and cleans up anyway with a warning after twice that, so a wedged child can't hang the smoke.
- A `childExited` flag, set by the pre-registered `exit` handler, short-circuits the wait on the crash-before-render path (where `done()` is called *from* that handler).
- `cleanup()` warns instead of throwing, so a leftover temp dir can never turn a passing smoke red. `maxRetries`/`retryDelay` were deliberately not used — they'd widen the race window rather than close it.

## Verification

- `npm run smoke:tui` × 5 — all OK, no `ENOTEMPTY`, no cleanup warnings, temp-dir count in `$TMPDIR` unchanged across runs.
- Timeout path (`SMOKE_TUI_TIMEOUT_MS=300`, child still alive): fails as expected, cleans up.
- Crash-before-render path (child exiting immediately): fails as expected and returns instantly via the `childExited` short-circuit.
- `npm run validate` and `npm run smoke` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvKF2mqi4hoQSUqQpZXNTq