### PR TITLE
chore: pin v1 publishes to the `v1` dist-tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,10 @@ jobs:
       - name: Ensure npm CLI supports OIDC trusted publishing
         run: npm install -g npm@^11.5.1
 
+      # `publish-all` pins `--tag v1` on all four packages. Do NOT remove it:
+      # without an explicit tag npm assigns `latest`, so a v1 security release
+      # would drag `latest` back from v2 and every `npx
+      # @modelcontextprotocol/inspector` would silently get deprecated v1.
       - run: npm run publish-all
         env:
           NPM_CONFIG_PROVENANCE: "true"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier-check": "prettier --check .",
     "lint": "prettier --check . && cd client && npm run lint",
     "prepare": "husky && npm run build",
-    "publish-all": "npm publish --workspaces --access public && npm publish --access public",
+    "publish-all": "npm publish --workspaces --access public --tag v1 && npm publish --access public --tag v1",
     "update-version": "node scripts/update-version.js",
     "check-version": "node scripts/check-version-consistency.js"
   },


### PR DESCRIPTION
Part of #1816 (phase 3 of the v2 go-live runbook, #1804 §1) — the code half. The two npm registry operations (`dist-tag add`, `npm deprecate`) are run separately from a maintainer's machine.

## The trap this closes

`publish-all` had no `--tag`, so npm assigns `latest` to whatever it publishes.

That was **correct** for 1.0.1 — the deprecation release had to take `latest` to reach `npx` users, which is why phase 2 deliberately left it alone. But it becomes a trap the moment 2.0.0 ships: a 1.0.2 security fix published from `v1/main` would move `latest` back to v1, and every `npx @modelcontextprotocol/inspector` in the world would silently get the deprecated line.

That window is open right now, between the 1.0.1 publish and this merge.

## The change

```diff
-"publish-all": "npm publish --workspaces --access public && npm publish --access public"
+"publish-all": "npm publish --workspaces --access public --tag v1 && npm publish --access public --tag v1"
```

`--tag v1` on both halves covers all four names — `--workspaces` fans out to `inspector-client` / `-server` / `-cli`, and the second invocation is the root. Only the root package.json has a publish script, and CI calls `npm run publish-all`, so this one line is the whole surface.

## Why the workflow comment

Nothing enforces this flag. Dropping it produces no error — it just quietly publishes to `latest`, and the damage shows up months later looking like an npm bug rather than a missing argument. The comment sits at the point of use in `main.yml` so it's visible to whoever next edits that job.

## Verification

- `npm run check-version` passes
- Diff is two files, one functional line

Not verifiable until the next v1 release actually publishes — that will be the first real exercise of the `--tag v1` path, as #1804 §4 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txmv2qqv3yeKgRzoqXytzD