### PR TITLE
fix: v1 dist-tag must be `v1-latest` — npm rejects `v1`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,10 +65,15 @@ jobs:
       - name: Ensure npm CLI supports OIDC trusted publishing
         run: npm install -g npm@^11.5.1
 
-      # `publish-all` pins `--tag v1` on all four packages. Do NOT remove it:
-      # without an explicit tag npm assigns `latest`, so a v1 security release
-      # would drag `latest` back from v2 and every `npx
-      # @modelcontextprotocol/inspector` would silently get deprecated v1.
+      # `publish-all` pins `--tag v1-latest` on all four packages.
+      #
+      # Do NOT drop the flag: without an explicit tag npm assigns `latest`, so a
+      # v1 security release would drag `latest` back from v2 and every
+      # `npx @modelcontextprotocol/inspector` would silently get deprecated v1.
+      #
+      # Do NOT "simplify" the tag to `v1`: npm rejects any dist-tag that parses
+      # as a SemVer range, and `v1` does (`npm error Tag name must not be a
+      # valid SemVer range: v1`). That would fail the publish outright.
       - run: npm run publish-all
         env:
           NPM_CONFIG_PROVENANCE: "true"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier-check": "prettier --check .",
     "lint": "prettier --check . && cd client && npm run lint",
     "prepare": "husky && npm run build",
-    "publish-all": "npm publish --workspaces --access public --tag v1 && npm publish --access public --tag v1",
+    "publish-all": "npm publish --workspaces --access public --tag v1-latest && npm publish --access public --tag v1-latest",
     "update-version": "node scripts/update-version.js",
     "check-version": "node scripts/check-version-consistency.js"
   },


### PR DESCRIPTION
Follow-up to #1828, part of #1816.

## The bug

#1828 pinned v1 publishes to `--tag v1`, straight from the runbook (#1804 §1). **That tag name is not legal.** npm rejects any dist-tag that parses as a SemVer range, and `v1` parses as `1.x`:

```
npm error Tag name must not be a valid SemVer range: v1
```

Found by running the companion `npm dist-tag add ...@1.0.1 v1` step, which failed identically.

## Why this mattered more than it looks

The merged flag would not have published to a *wrong* tag — **the next v1 security release would have failed to publish at all**, and only at release time, months from now, mid-incident. The failure mode the original comment warned about (silently stealing `latest`) was replaced by a louder but worse-timed one.

## The fix

`v1-latest`, verified against `semver.validRange` along with the other candidate, `legacy`:

| Candidate | Legal? |
| --- | --- |
| `v1` | ❌ valid SemVer range |
| `v1-latest` | ✅ |
| `legacy` | ✅ |

Picked `v1-latest` as self-describing and matching npm's own convention for this case.

The workflow comment now records **both** failure modes — dropping the flag, and "simplifying" the tag back to `v1` — so neither gets cleaned up by a future editor.

## Note for #1816

The issue text still says `v1`. The registry-side commands must use `v1-latest`, and the deprecation message should point there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txmv2qqv3yeKgRzoqXytzD