### PR TITLE
ci: set a least-privilege default GITHUB_TOKEN scope

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,15 @@ on:
   release:
     types: [published]
 
+# Default least-privilege scope for GITHUB_TOKEN. Without this, jobs inherit the
+# repository's default token permissions, which are broader than any job here
+# needs (CodeQL `actions/missing-workflow-permissions`). The `publish` and
+# `publish-github-container-registry` jobs declare their own blocks below, which
+# override this one entirely rather than adding to it — so each publish job must
+# continue to list every scope it needs, including `contents: read`.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes the one CodeQL alert left open after the v2 tree swap (#1817).

## The alert

**#64 — medium — `actions/missing-workflow-permissions`** on `.github/workflows/main.yml:13`:

> Actions job or workflow does not limit the permissions of the GITHUB_TOKEN.

The other 10 alerts surfaced by the swap were all test fixtures and were dismissed as *used in tests*. This one is real infrastructure, so it wasn't dismissible under that reason.

## Why it's worth more than "medium"

This is the workflow that **publishes to npm under OIDC trusted publishing**. An over-permissioned `GITHUB_TOKEN` in a workflow that mints publish credentials is worth tightening *before* 2.0.0 goes out (#1818), not after.

## The change

A workflow-level default:

```yaml
permissions:
  contents: read
```

The `build` job needs nothing more. The two publish jobs already declare their own blocks (`id-token: write`, `packages: write`, `attestations: write`) and are unaffected — **job-level permissions override the workflow-level default outright rather than merging with it.**

That override semantic is the one trap here, so the comment in the file records it: each publish job must keep listing *every* scope it needs, including `contents: read`. A future edit that trims one "because it's inherited from the top" would silently break publishing.

## Verification

- Additive only — 9 lines, no existing line modified
- `permissions` parses as a top-level key alongside `name` / `on` / `jobs`
- Both job-level `permissions:` blocks still present; both `id-token: write` occurrences intact

## Provenance

Pre-existing on `v2/main` — `main` had simply never scanned this workflow before the swap. Not introduced by #1830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txmv2qqv3yeKgRzoqXytzD