### PR TITLE
ci: derive the npm dist-tag from the version instead of defaulting to latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,23 @@ jobs:
         # prepack); the redundancy is intentional — each is a clean-tree rebuild
         # and the `prepack` one is what actually populates the published tarball,
         # so don't "optimize" it away.
-        run: npm publish --access public --provenance
+        #
+        # The dist-tag is derived from the version, and passing it explicitly is
+        # NOT optional: `npm publish` defaults to `--tag latest` regardless of
+        # semver prerelease status, so publishing `2.0.0-rc.1` without this would
+        # point every `npx @modelcontextprotocol/inspector` at a release
+        # candidate. A prerelease is a hyphen after the patch component
+        # (`2.0.0-rc.1`); build metadata uses `+` and is not a prerelease. Done
+        # in shell rather than with `semver` because that package is only a
+        # transitive dependency here and must not be relied on in CI.
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          case "$VERSION" in
+            *-*) NPM_TAG=next ;;
+            *)   NPM_TAG=latest ;;
+          esac
+          echo "Publishing $VERSION under dist-tag '$NPM_TAG'"
+          npm publish --access public --provenance --tag "$NPM_TAG"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Blocking prerequisite for #1818. **Found while preparing the RC step, which could not have worked as written.**

## The bug

`npm publish` defaults to `--tag latest` **regardless of semver prerelease status**, and the publish step passed no `--tag`:

```yaml
run: npm publish --access public --provenance
```

So cutting the `2.0.0-rc.1` release that #1818 calls for would have published the release candidate to **`latest`** — every `npx @modelcontextprotocol/inspector` in the world would resolve to an RC.

That is the same class of failure #1816 fixed for v1 (a missing `--tag` silently claiming `latest`), except here it would have been triggered *deliberately, by following the runbook*.

There was also simply **no mechanism** to pass a dist-tag through a release-triggered publish, so the RC step was not achievable at all before this.

## The fix

```sh
VERSION="$(node -p "require('./package.json').version")"
case "$VERSION" in
  *-*) NPM_TAG=next ;;
  *)   NPM_TAG=latest ;;
esac
npm publish --access public --provenance --tag "$NPM_TAG"
```

A hyphen after the patch component is a prerelease per semver; build metadata uses `+` and correctly is not. Verified against real inputs:

| Version | Tag |
| --- | --- |
| `2.0.0` | `latest` |
| `2.0.1` | `latest` |
| `10.20.30` | `latest` |
| `2.0.0-rc.1` | `next` |
| `2.0.0-beta.3` | `next` |
| `2.0.0+build.5` | `latest` |

## Why shell and not `semver`

`semver` resolves in this repo only as a **transitive** dependency. Relying on it in CI means a publish step that breaks whenever some unrelated package drops it from its tree — not a dependency worth taking for a one-line predicate.

## Notes

The step also logs the chosen tag before publishing, so the release run shows which dist-tag was claimed rather than leaving it to be inferred afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txmv2qqv3yeKgRzoqXytzD