### PR TITLE
chore: 2.0.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/inspector",
-      "version": "2.0.0",
+      "version": "2.0.0-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.1",
   "description": "The Model Context Protocol Inspector",
   "keywords": [
     "MCP",


### PR DESCRIPTION
Release candidate for the 2.0.0 go-live — part of #1818 (§6).

**This PR publishes nothing.** Merging it only sets the version; publishing happens when a GitHub release is cut against the merged commit.

## What happens when the release is cut

`2.0.0-rc.1` contains a hyphen after the patch component, so the derivation added in #1834 resolves it to the **`next`** dist-tag:

```
2.0.0-rc.1 → dist-tag 'next'
```

`latest` stays on **1.0.1** and is not touched. Before #1834 this same release would have published the RC to `latest` — see that PR for why.

## Why bother with an RC

The runbook (§6) asks for one, and its stated value is validating what only exists against the live registry: provenance/OIDC minting, the `files` allowlist as npm actually packs it, and the postinstall cascade's early-exit under a real `npm install`.

Two of those are arguably already covered — phase 2 (#1815) proved OIDC publishing works on this repo, and `pack:verify` drives the real tarball end to end in a clean consumer. The reason to still do it: **#1834 is newly-written code on the publish path**, and the `next`-tag branch has never executed. An RC exercises it against a version number nobody will miss.

## Verification after publish

```sh
npm view @modelcontextprotocol/inspector dist-tags
# expect: latest 1.0.1, v1-latest 1.0.1, next 2.0.0-rc.1

npx @modelcontextprotocol/inspector@next --help    # on a clean machine
```

`latest` remaining at 1.0.1 is the specific thing to confirm — it is what proves the tag derivation works.

## Diff

Two files: root `package.json` version and the matching `package-lock.json` entries. The four client `package.json`s carry no version by design (single-version package), so nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txmv2qqv3yeKgRzoqXytzD