### PR TITLE
chore: 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/inspector",
-      "version": "2.0.0-rc.3",
+      "version": "2.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0",
   "description": "The Model Context Protocol Inspector",
   "keywords": [
     "MCP",


### PR DESCRIPTION
The v2 go-live release — phase 5 of #1804, closing #1818.

**Merging this publishes nothing.** The npm publish happens when the `2.0.0` GitHub release is cut against the merged commit. ⚠️ **That step is irreversible.**

## The diff

Two files, version only:

```
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0",
```

Byte-identical to `2.0.0-rc.3` apart from dropping the prerelease suffix. That is the whole point: **the tree that ships is the tree that was validated** against the live registry.

`2.0.0` has no hyphen, so #1834's derivation resolves it to **`latest`** — this is the release that takes the tag from 1.0.1.

## What the three RCs established

| RC | Caught / validated |
| --- | --- |
| **rc.1** | Two publish-path defects invisible to every local check: `NODE_AUTH_TOKEN` pointing at a non-existent secret (shadowing OIDC), and a missing npm CLI upgrade (trusted publishing needs ≥11.5.1; Node 22 bundles 10.x). Fixed in #1836. |
| **rc.2** | The dependency sweep (#1837) clearing every prod-scope advisory, lockfile-only. |
| **rc.3** | The vite 8.1.5 bump (#1841) closing three high-severity dev-server file-read advisories. |

Each was verified with a **cold `node:22` container** driving the published tarball end to end — install, `--help`, and a real `--cli tools/list` against a live stdio server.

`latest` stayed on **1.0.1** through all three, which is what proves the `--tag` derivation works.

## State at release time

| | |
| --- | --- |
| Open Dependabot alerts | **0** |
| Open CodeQL alerts | **0** |
| npm `latest` | 1.0.1 (about to become 2.0.0) |
| npm `v1-latest` | 1.0.1 |
| `v1/main` | protected, publishes under `v1-latest` |

## Rollback

Written and verified before any publish — see [the plan on #1818](https://github.com/modelcontextprotocol/inspector/issues/1818#issuecomment-5099811765). npm unpublish is not available in practice; recovery is dist-tag surgery (`npm dist-tag add @modelcontextprotocol/inspector@1.0.1 latest`, deprecate the bad version, ship 2.0.1). npm rights confirmed for the release cutter plus four other maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txmv2qqv3yeKgRzoqXytzD