### PR TITLE
docs: restore SECURITY.md, lost in the v2 tree swap

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+Thank you for helping keep the Model Context Protocol and its ecosystem secure.
+
+## Supported Versions
+
+| Version | Package                                  | Support                                                 |
+| ------- | ---------------------------------------- | ------------------------------------------------------- |
+| **2.x** | `@modelcontextprotocol/inspector`        | ✅ Actively supported                                   |
+| 1.x     | `@modelcontextprotocol/inspector`        | ⚠️ **Security fixes only**, published under `v1-latest` |
+| 1.x     | `@modelcontextprotocol/inspector-client` | ⚠️ Security fixes only                                  |
+| 1.x     | `@modelcontextprotocol/inspector-server` | ⚠️ Security fixes only                                  |
+| 1.x     | `@modelcontextprotocol/inspector-cli`    | ⚠️ Security fixes only                                  |
+| < 1.0.0 | any                                      | ❌ Unsupported                                          |
+
+v2 ships as a **single** package — `@modelcontextprotocol/inspector`. The three
+`inspector-client` / `inspector-server` / `inspector-cli` sub-packages exist only
+on the v1 line and are deprecated.
+
+v1 development happens on the `v1/main` branch and is limited to security fixes.
+Those releases are published under the **`v1-latest`** dist-tag so they never
+displace the current v2 release:
+
+```bash
+npm i @modelcontextprotocol/inspector@v1-latest
+```
+
+Everything else — features, bug fixes, improvements — lands in v2 only.
+
+## Reporting Security Issues
+
+If you discover a security vulnerability in this repository, please report it through
+the [GitHub Security Advisory process](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+for this repository. Private vulnerability reporting is enabled, so this is the
+fastest route to a maintainer.
+
+Please **do not** report security vulnerabilities through public GitHub issues, discussions,
+or pull requests.
+
+Note that this repository does not accept pull requests from outside contributors
+(see [CONTRIBUTORS.md](./CONTRIBUTORS.md)) — **this does not apply to security
+reports**, which should always go through the advisory process above rather than
+any public channel.
+
+## What to Include
+
+To help us triage and respond quickly, please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- The potential impact
+- Whether it affects v2, v1, or both
+- Any suggested fixes (optional)


### PR DESCRIPTION
Part of #1820.

## The regression

`SECURITY.md` exists on the **pre-swap `main`** (`ac3c1a12`) and on **`v1/main`** — but the v2 tree never had one, so #1817 silently removed the security policy from the default branch.

I found this while checking #1820's prerequisites, not from any alert. Nothing flagged it.

## Why it matters right now

It is where **private vulnerability reporting** is advertised, and it vanished in the same window as 2.0.0 shipping and external pull requests being switched off.

Losing the PR path and the security-report path together would leave an outside reporter with **no documented route at all** — exactly the wrong gap for a tool that connects to arbitrary MCP servers.

## What's restored, plus what #1820 asked for

Base content restored from `v1/main`, with three additions:

**Supported-versions table** covering all four package names:

| Version | Package | Support |
| --- | --- | --- |
| **2.x** | `@modelcontextprotocol/inspector` | ✅ Actively supported |
| 1.x | `@modelcontextprotocol/inspector` | ⚠️ Security fixes only, under `v1-latest` |
| 1.x | `-client` / `-server` / `-cli` | ⚠️ Security fixes only |
| < 1.0.0 | any | ❌ Unsupported |

The three sub-packages are named explicitly because they exist **only** on the v1 line and are deprecated — v2 ships a single package, so someone reading "is my version supported?" needs them listed.

**A carve-out for security reports.** The doc now states that the repo does not accept outside pull requests, *and* that this does not apply to security reports. Without it, the new issues-only policy reads as "no way to reach us".

**"Whether it affects v2, v1, or both"** added to the report checklist, now that two lines are live.

## Verified

Private vulnerability reporting is **enabled** on the repo (`GET /repos/.../private-vulnerability-reporting` → `{"enabled": true}`), so the advisory link is a working route rather than an aspiration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txmv2qqv3yeKgRzoqXytzD