### PR TITLE
ci: restore the Claude Code workflow and .mcp.json, lost in the v2 tree swap

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,93 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (
+        (github.event_name == 'issue_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' &&
+          contains(github.event.review.body, '@claude') &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' &&
+          (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Get PR details
+        if: |
+          (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
+          github.event_name == 'pull_request_review_comment' ||
+          github.event_name == 'pull_request_review'
+        id: pr
+        uses: actions/github-script@v8
+        with:
+          script: |
+            let prNumber;
+            if (context.eventName === 'issue_comment') {
+              prNumber = context.issue.number;
+            } else {
+              prNumber = context.payload.pull_request.number;
+            }
+
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            core.setOutput('sha', pr.data.head.sha);
+            core.setOutput('repo', pr.data.head.repo.full_name);
+
+      - name: Checkout PR branch
+        if: steps.pr.outcome == 'success'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+          repository: ${{ steps.pr.outputs.repo }}
+          fetch-depth: 0
+
+      - name: Checkout repository
+        if: steps.pr.outcome != 'success'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Allow Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Trigger when assigned to an issue
+          assignee_trigger: "claude"
+
+          claude_args: |
+            --mcp-config .mcp.json
+            --allowedTools "Bash,mcp__mcp-docs"
+            --append-system-prompt "If posting a comment to GitHub, give a concise summary of the comment at the top and put all the details in a <details> block. When working on MCP-related code or reviewing MCP-related changes, use the mcp-docs MCP server to look up the latest protocol documentation. For schema details, reference https://github.com/modelcontextprotocol/modelcontextprotocol/tree/main/schema which contains versioned schemas in JSON (schema.json) and TypeScript (schema.ts) formats."

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "mcp-docs": {
+      "type": "http",
+      "url": "https://modelcontextprotocol.io/mcp"
+    }
+  }
+}


### PR DESCRIPTION

Same regression class as #1843 (`SECURITY.md`): the v2 tree swap replaced the default branch's tree, and neither `.github/workflows/claude.yml` nor `.mcp.json` existed in the v2 tree, so both were silently dropped.

## Impact

`issue_comment` / `pull_request_review_comment` / `issues` events always run workflows from the **default branch**, so losing the workflow disabled `@claude` **repo-wide** — including on PRs targeting `v2/main`.

Found the hard way: two `@claude review` comments on #1847 (19:08 and 19:10 UTC) produced no bot reply and no workflow run.

## Evidence

| Check | Result |
| --- | --- |
| `actions/workflows/173749385` state | `deleted` |
| Last 3 runs (`issue_comment`, latest 03:10 UTC today) | all `skipped` |
| `.github/workflows/` on `main` | only `main.yml` |
| `ac3c1a12` (last commit carrying the file) | **not** an ancestor of current `main` |

## The change

Two files, both restored **byte-for-byte**, both verified after the copy:

| File | Source | sha256 | Bytes |
| --- | --- | --- | --- |
| `.github/workflows/claude.yml` | `ac3c1a12` | `1c44f2d9d51c936adb40c9acefd4b44628fe7810360e2f8196034347f9d2602d` | 3592 |
| `.mcp.json` | `47f92841` (`v1/main`) | `b0f0b8ea0d6c6e4bd9d19270db8c4ed13a951c6a7d8fa9a7b76d0d12ddd2491f` | 123 |

No content changes to either. The `@claude` trigger remains gated to `OWNER` / `MEMBER` / `COLLABORATOR` author associations, which is the behavior we want under the issues-only contribution model (#1820).

### Why `.mcp.json` is in the same PR

The workflow runs with `--mcp-config .mcp.json` and `--allowedTools "Bash,mcp__mcp-docs"`. `.mcp.json` registers the `mcp-docs` HTTP server (`https://modelcontextprotocol.io/mcp`) and was lost in the same swap — it survives only on `v1/main`:

```sh
git ls-tree --name-only origin/main .mcp.json     # (empty)
git ls-tree --name-only origin/v2/main .mcp.json  # (empty)
git ls-tree --name-only origin/v1/main .mcp.json  # .mcp.json
```

Restoring the workflow without it would register no MCP server, so the `mcp__mcp-docs` tools would not resolve and the protocol-documentation lookups that `--append-system-prompt` explicitly directs it to make would silently do nothing. Shipping them together avoids a window where the workflow is on `v2/main` pointing at a file that isn't.

## Why this targets `v2/main` and not `main`

This PR originally targeted `main`. It now targets `v2/main`, the develop branch that merges into `main` at milestone releases.

The two branches share **no common git ancestor** — `git merge-base main v2/main` returns nothing, because the tree swap created unrelated histories. A branch cut from `main` and opened against `v2/main` therefore diffs the entire v1 tree against the entire v2 tree, which is what made this PR read as conflicted across a dozen files it never touched. It has been rebuilt on `v2/main`; the diff is now the two files above and nothing else.

Landing on `v2/main` is also what makes the fix durable: restoring only to `main` would be undone by the next milestone tree swap, which is precisely how these files were lost.

## Verifying after merge

`@claude` cannot work until this reaches **`main`**, which happens at the next milestone merge — a workflow on a non-default branch is not consulted for `issue_comment` events. After that, comment `@claude review` on any open PR; `claude[bot]` should reply within ~20s (it took 19s on #1825). If it's needed before the milestone, that wants a separate direct-to-`main` PR in addition to this one.

## Testing

No source files are touched, so nothing in `validate` or `coverage` measures this change — the format globs cover `core/`, `scripts/`, the shared surface, and each client's scope, none of which reach a workflow YAML or a root-level JSON. `npx prettier --check .mcp.json` passes. I did not run the full `npm run ci` gate, as it would measure nothing here.

## Note

`SECURITY.md` (#1843, plus #1864/#1865 for the `v2/main` half), `claude.yml`, and `.mcp.json` are three instances of one pattern, and none was caught by CI. A sweep for anything else the swap dropped is worth doing separately — since the histories are unrelated, no git tooling will surface them on its own.
