### PR TITLE
docs: restore SECURITY.md on v2/main, so the next tree swap can't drop it

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+Thank you for helping keep the Model Context Protocol and its ecosystem secure.
+
+## Supported Versions
+
+| Version | Package                                  | Support                                                 |
+| ------- | ---------------------------------------- | ------------------------------------------------------- |
+| **2.x** | `@modelcontextprotocol/inspector`        | ✅ Actively supported                                   |
+| 1.x     | `@modelcontextprotocol/inspector`        | ⚠️ **Security fixes only**, published under `v1-latest` |
+| 1.x     | `@modelcontextprotocol/inspector-client` | ⚠️ Security fixes only                                  |
+| 1.x     | `@modelcontextprotocol/inspector-server` | ⚠️ Security fixes only                                  |
+| 1.x     | `@modelcontextprotocol/inspector-cli`    | ⚠️ Security fixes only                                  |
+| < 1.0.0 | any                                      | ❌ Unsupported                                          |
+
+v2 ships as a **single** package — `@modelcontextprotocol/inspector`. The three
+`inspector-client` / `inspector-server` / `inspector-cli` sub-packages exist only
+on the v1 line and are deprecated.
+
+v1 development happens on the `v1/main` branch and is limited to security fixes.
+Those releases are published under the **`v1-latest`** dist-tag so they never
+displace the current v2 release:
+
+```bash
+npm i @modelcontextprotocol/inspector@v1-latest
+```
+
+Everything else — features, bug fixes, improvements — lands in v2 only.
+
+## Reporting Security Issues
+
+If you discover a security vulnerability in this repository, please report it through
+the [GitHub Security Advisory process](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+for this repository. Private vulnerability reporting is enabled, so this is the
+fastest route to a maintainer.
+
+Please **do not** report security vulnerabilities through public GitHub issues, discussions,
+or pull requests.
+
+Note that this repository does not accept pull requests from outside contributors
+(see [CONTRIBUTORS.md](./CONTRIBUTORS.md)) — **this does not apply to security
+reports**, which should always go through the advisory process above rather than
+any public channel.
+
+## What to Include
+
+To help us triage and respond quickly, please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- The potential impact
+- Whether it affects v2, v1, or both
+- Any suggested fixes (optional)


### PR DESCRIPTION
Closes #1864.

Follow-up to #1843, and the same reasoning that moved #1851 onto `v2/main`.

## The gap

`SECURITY.md` was restored to `main` in #1843, but it was never added to `v2/main`.

`v2/main` is the develop branch, merged into `main` at milestone releases — and the two share **no common git ancestor** (`git merge-base main v2/main` returns nothing; the v2 tree swap created unrelated histories). So the next milestone merge re-swaps the tree and silently removes the security policy from the default branch a **second** time.

```
$ git ls-tree --name-only origin/v2/main SECURITY.md
(empty)
```

## The change

Copied **byte-for-byte** from `main` — sha256 `bbc8aaa5a33d481f902c1b7ac260a4c9c0d41dac5bb2916607222dd205dda924`, 2633 bytes, verified after the copy. No content changes: #1843 already wrote this file for the post-swap world, so it describes the v2 single-package model and the `v1-latest` dist-tag correctly as-is.

## Testing

No source files are touched, so no `validate` / `coverage` gate measures this change. `npx prettier --check SECURITY.md` passes.

## Note

`.github/workflows/claude.yml` (#1851) and this file are the two known instances. Anything else restored directly to `main` after the swap is suspect for the same reason — a sweep is probably worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAt8rqxysNbhYWLhoRm3fU