### PR TITLE
chore: restore repo files dropped by the v2 tree swap

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+package-lock.json linguist-generated=true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,8 +10,9 @@ assignees: ""
 Issues are how work reaches the Inspector — we accept issues, not pull
 requests. See CONTRIBUTORS.md for the full policy.
 
-Please label this issue `v2` (or `v1`, if it is a security or bug fix for the
-deprecated v1 line). When in doubt, it's `v2`.
+Just tick the version below — a maintainer applies the `v1` / `v2` label
+during triage (most reporters can't set labels themselves). When in doubt,
+it's v2.
 -->
 
 **Which version?**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,72 @@
+---
+name: Bug report
+about: Report something broken in the Inspector
+title: ""
+labels: ""
+assignees: ""
+---
+
+<!--
+Issues are how work reaches the Inspector — we accept issues, not pull
+requests. See CONTRIBUTORS.md for the full policy.
+
+Please label this issue `v2` (or `v1`, if it is a security or bug fix for the
+deprecated v1 line). When in doubt, it's `v2`.
+-->
+
+**Which version?**
+
+- [ ] v2 — current, published as `@modelcontextprotocol/inspector@latest`
+- [ ] v1 — deprecated, `@v1-latest` (security and bug fixes only)
+
+**Inspector version**
+
+<!-- e.g. 2.0.0 — the version you actually ran, not "latest" -->
+
+**Which client?**
+
+- [ ] Web
+- [ ] CLI
+- [ ] TUI
+- [ ] All / shared core
+
+**What happened**
+
+<!-- The actual behavior you observed. -->
+
+**What you expected instead**
+
+**Steps to reproduce**
+
+1.
+2.
+3.
+
+<!--
+If it depends on a particular MCP server, say which one and how it's
+configured — transport (stdio / streamable HTTP / SSE), protocol era
+(legacy / modern), and whether OAuth is involved.
+-->
+
+**Environment**
+
+- OS:
+- Node version:
+- Browser (web client only):
+- MCP server under inspection:
+
+**Logs, errors, or screenshots**
+
+<!--
+Console output, the Inspector's Protocol or Network tab, or a screenshot.
+Redact tokens and secrets first.
+-->
+
+**Already prototyped a fix?**
+
+<!--
+Please don't attach a diff or open a PR. Share the *prompt* you used to
+produce the change, plus what you verified — we'll reproduce it through our
+own workflow so it lands with the right conventions, tests, and coverage.
+See CONTRIBUTORS.md → "If you've already fixed it locally".
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,88 @@
+version: 2
+
+# Version updates target `v2/main` (the develop branch), not the default
+# branch — `main` is release-only and takes milestone merges from `v2/main`.
+#
+# Two things to know about this file:
+#   1. Dependabot reads it from the DEFAULT branch (`main`). Changes here are
+#      inert until the next milestone merge carries them there.
+#   2. `target-branch` scopes VERSION updates. Dependabot SECURITY updates are
+#      enabled in repo settings, not here, and always target the default
+#      branch — they kept working while this file was missing entirely
+#      (see #1833, #1840).
+#
+# v2 is not an npm workspace: the root and each client under `clients/*` carry
+# their own package.json + lockfile, so each needs its own entry.
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "v2/main"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "v2"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "v2/main"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "v2"
+    groups:
+      root-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/clients/web"
+    target-branch: "v2/main"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "v2"
+    groups:
+      web-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/clients/cli"
+    target-branch: "v2/main"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "v2"
+    groups:
+      cli-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/clients/tui"
+    target-branch: "v2/main"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "v2"
+    groups:
+      tui-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/clients/launcher"
+    target-branch: "v2/main"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "v2"
+    groups:
+      launcher-dependencies:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 
-# Version updates target `v2/main` (the develop branch), not the default
-# branch — `main` is release-only and takes milestone merges from `v2/main`.
+# Version updates target `v2/main`, the active development branch, not the
+# default branch — `main` still holds the legacy v1 implementation and takes
+# only security and bug fixes (see README.md "Repo status").
 #
 # Two things to know about this file:
 #   1. Dependabot reads it from the DEFAULT branch (`main`). Changes here are

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,12 @@ version: 2
 #   1. Dependabot reads it from the DEFAULT branch (`main`). Changes here are
 #      inert until the next milestone merge carries them there.
 #   2. `target-branch` scopes VERSION updates. Dependabot SECURITY updates are
-#      enabled in repo settings, not here, and always target the default
+#      enabled in repo settings, not here, and are raised against the default
 #      branch — they kept working while this file was missing entirely
-#      (see #1833, #1840).
+#      (see #1833, #1840). Per GitHub's Dependabot options reference, an entry
+#      whose `target-branch` names a non-default branch is NOT applied to
+#      security updates, so the schedule/labels/groups below shape version
+#      updates only. Re-confirm security PRs still appear after this lands.
 #
 # v2 is not an npm workspace: the root and each client under `clients/*` carry
 # their own package.json + lockfile, so each needs its own entry.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 version: 2
 
-# Version updates target `v2/main`, the active development branch, not the
-# default branch — `main` still holds the legacy v1 implementation and takes
-# only security and bug fixes (see README.md "Repo status").
+# Version updates target `v2/main`, the develop branch where all v2 work lands,
+# not the default branch — `main` is release-only, holding the latest released
+# v2 and receiving milestone merges from `v2/main`. (The deprecated v1 line
+# lives on `v1/main` and takes security fixes only.)
 #
 # Two things to know about this file:
 #   1. Dependabot reads it from the DEFAULT branch (`main`). Changes here are

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+mcp-coc@anthropic.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.


### PR DESCRIPTION
Closes #1870

Fourth instance of the #1843 / #1850 / #1864 pattern. Full sweep of the pre-swap tree (`ac3c1a12`) against `v2/main` found 14 dropped files; ten are correctly gone (rationale in #1870), these four are worth having.

## `.github/dependabot.yml` — rewritten

Not a restore. v1's config covered only `github-actions` at `/`; this covers that plus the **six npm manifests v2 actually has** (root + four clients), since v2 is not a workspace.

Per your direction: **monthly** (v1 was weekly) and **targeting `v2/main`**, not the default branch. Also grouped to one PR per ecosystem/directory to keep the volume sane, and labeled `v2` so the version-label rule holds for bot PRs too.

Two properties worth knowing:

- **Dependabot reads this from the default branch (`main`).** It is inert on `v2/main` until the next milestone merge carries it over — the same dormancy as `claude.yml` in #1869.
- **`target-branch` scopes _version_ updates only.** Security updates are a repo setting and always target the default branch — they kept running while this file was missing entirely (#1833, #1840 on 2026-07-28). Worth re-confirming security updates still appear after this lands, since GitHub documents `target-branch` as affecting security-update behavior for the configured ecosystem/directory.

## `.github/ISSUE_TEMPLATE/bug_report.md` — rewritten

Under the issues-only policy this is the primary intake path, and it's been missing. v1's version asked for "Inspector Version e.g. 0.16.5", with no client field and no v1/v2 question. The new one leads with the two routing decisions (**which version**, **which client**), asks for transport / protocol era / OAuth when a server is involved, reminds people to redact secrets, and ends with the prompt-not-a-diff path pointing at `CONTRIBUTORS.md`.

Kept as a markdown template rather than converting to a YAML issue form — a form could enforce fields and auto-apply the `v1`/`v2` label, which is tempting given 154 open issues currently carry neither, but that's a bigger change and belongs with the triage work, not here.

## `.gitattributes` — byte-for-byte

42 bytes: `package-lock.json linguist-generated=true`. The pattern has no slash, so it matches at any depth — all six lockfiles. More valuable in v2 than v1, as dependency PRs are mostly lockfile churn.

## `CODE_OF_CONDUCT.md` — byte-for-byte

Verbatim upstream Contributor Covenant, so GitHub surfaces it as a community standard. **Deliberately left unformatted**: it's upstream text, v1 listed it in `.prettierignore` for exactly that reason, and no v2 format glob reaches root markdown — `npx prettier --check` flags it, but nothing in `validate` does.

## Not included

`CONTRIBUTING.md` — handled by renaming `CONTRIBUTORS.md` to that name instead, which lights up GitHub's contributing banner without two files to keep in sync.

## Testing

No source files touched, so nothing in `validate` or `coverage` measures this. The dependabot config parses (6 entries, all `monthly`, all `target-branch: v2/main`, all labeled `v2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAt8rqxysNbhYWLhoRm3fU