### PR TITLE
docs: unpin the branch-pinned CONTRIBUTORS.md links in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,13 +17,14 @@
     → Open an issue and share the PROMPT(S) you used to generate it, not a
       diff. We'll reproduce it through our own workflow.
 
-  Full policy: https://github.com/modelcontextprotocol/inspector/blob/main/CONTRIBUTORS.md
+  Full policy: ../CONTRIBUTORS.md (relative to this template — the file lives
+  at the repository root, on whatever branch you're reading).
 
   Maintainers: delete this template body and describe your change normally.
 -->
 
 > **Heads up:** this repository accepts **issues, not pull requests** from
-> external contributors. Please read [`CONTRIBUTORS.md`](../blob/main/CONTRIBUTORS.md)
+> external contributors. Please read [`CONTRIBUTORS.md`](../CONTRIBUTORS.md)
 > before continuing. If you're an external contributor, open an issue (and
 > share the prompt you used, if you've already built the change) rather than
 > this PR.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npx @modelcontextprotocol/inspector --cli    # CLI
 npx @modelcontextprotocol/inspector --tui    # TUI
 ```
 
-> **Repo status.** This is the **v2** line of the Inspector (branch `v2/main`). The `main` branch is the legacy v1 implementation (security fixes only). v2 will eventually replace `main`. See [`AGENTS.md`](./AGENTS.md) for branch/board conventions.
+> **Repo status.** This is the **v2** line of the Inspector (branch `v2/main`). The `main` branch is the legacy v1 implementation (bug fixes only). v2 will eventually replace `main`. See [`AGENTS.md`](./AGENTS.md) for branch/board conventions.
 
 ## Project layout
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npx @modelcontextprotocol/inspector --cli    # CLI
 npx @modelcontextprotocol/inspector --tui    # TUI
 ```
 
-> **Repo status.** This is the **v2** line of the Inspector (branch `v2/main`). The `main` branch is the legacy v1 implementation (bug fixes only). v2 will eventually replace `main`. See [`AGENTS.md`](./AGENTS.md) for branch/board conventions.
+> **Repo status.** This is the **v2** line of the Inspector (branch `v2/main`). The `main` branch is the legacy v1 implementation (security fixes only). v2 will eventually replace `main`. See [`AGENTS.md`](./AGENTS.md) for branch/board conventions.
 
 ## Project layout
 


### PR DESCRIPTION
Closes #1813

> **Scope note.** #1813 has two halves. **This PR is the PR-template-link half only.** The v1-policy *wording* reconciliation is being handled on #1866's branch (`v2/docs/post-swap-branch-model-and-pr-policy`), which rewrites that prose wholesale and merges first — doing it in both places would produce contradictory text plus a merge conflict.
>
> One wording line was changed here before that split was agreed and is left in place rather than reverted piecemeal: `README.md`'s "Repo status" callout, `(bug fixes only)` → `(security fixes only)`. If #1866 ends up covering it, drop it from this PR at merge time.

## Branch-pinned PR-template links

`.github/pull_request_template.md` linked to `CONTRIBUTORS.md` twice, both pinned to `blob/main/`:

- the HTML-comment "Full policy:" line
- the rendered "Heads up" blockquote — `[`CONTRIBUTORS.md`](../blob/main/CONTRIBUTORS.md)`

`main` is release-only, so those resolved against the last *released* tree rather than the branch the reader is on — and they'd break outright when `CONTRIBUTORS.md` is renamed (#1821) until a milestone merge carries the new name to `main`.

Both are now **relative** (`../CONTRIBUTORS.md`, relative to `.github/`), so they follow whatever branch is being read rather than being repointed at another fixed branch.

## Conflict avoidance

Everything touched here is outside #1866's diff — that PR changes `AGENTS.md` and `.github/copilot-instructions.md` only. The four `AGENTS.md` locations listed in #1813's table are all inside #1866's rewrite (three of them don't exist on `v2/main` yet), and `CONTRIBUTORS.md:54` already read "security fixes only", so neither file is touched here.

## Testing

Docs-only. No format/lint/typecheck/coverage gate covers `.md` (the `format:check` globs are source-extension only), and no code paths are touched.
