### PR TITLE
ci: sync the release workflow on v2/main with main's verbatim

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,15 @@ on:
   release:
     types: [published]
 
+# Default least-privilege scope for GITHUB_TOKEN. Without this, jobs inherit the
+# repository's default token permissions, which are broader than any job here
+# needs (CodeQL `actions/missing-workflow-permissions`). The `publish` and
+# `publish-github-container-registry` jobs declare their own blocks below, which
+# override this one entirely rather than adding to it — so each publish job must
+# continue to list every scope it needs, including `contents: read`.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -145,6 +154,11 @@ jobs:
             exit 1
           fi
 
+      # OIDC trusted publishing requires npm >= 11.5.1; Node 22's bundled npm is
+      # 10.x, which fails with ENEEDAUTH before OIDC is ever attempted.
+      - name: Ensure npm CLI supports OIDC trusted publishing
+        run: npm install -g npm@^11.5.1
+
       - name: Install dependencies (root + all clients)
         run: npm install
 
@@ -160,9 +174,30 @@ jobs:
         # prepack); the redundancy is intentional — each is a clean-tree rebuild
         # and the `prepack` one is what actually populates the published tarball,
         # so don't "optimize" it away.
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        #
+        # The dist-tag is derived from the version, and passing it explicitly is
+        # NOT optional: `npm publish` defaults to `--tag latest` regardless of
+        # semver prerelease status, so publishing `2.0.0-rc.1` without this would
+        # point every `npx @modelcontextprotocol/inspector` at a release
+        # candidate. A prerelease is a hyphen after the patch component
+        # (`2.0.0-rc.1`); build metadata uses `+` and is not a prerelease. Done
+        # in shell rather than with `semver` because that package is only a
+        # transitive dependency here and must not be relied on in CI.
+        #
+        # There is deliberately NO `NODE_AUTH_TOKEN` here. Publishing uses npm
+        # OIDC trusted publishing (`id-token: write` + `environment: release`),
+        # which needs no token — and the repo has no `NPM_TOKEN` secret. Setting
+        # it from a non-existent secret writes an EMPTY `_authToken` into the
+        # `.npmrc` that `setup-node` generates, and npm then fails `ENEEDAUTH`
+        # before OIDC is ever attempted. Do not "restore" it.
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          case "$VERSION" in
+            *-*) NPM_TAG=next ;;
+            *)   NPM_TAG=latest ;;
+          esac
+          echo "Publishing $VERSION under dist-tag '$NPM_TAG'"
+          npm publish --access public --provenance --tag "$NPM_TAG"
 
   # Build and push the multi-arch container image to GHCR on a published
   # release. The image installs the packed tarball (`Dockerfile`) so it ships


### PR DESCRIPTION
Closes #1902

Surfaced while building the v2.1.0 milestone-merge resolution branch (#1903): after resolving all eight conflicts, `.github/workflows/main.yml` was the **only** file where the merged tree still differed from `v2/main`.

## The question this answers

Rather than forward-port the three commits hunk by hunk, I diffed the file **both directions** first. `v2/main` has **nothing** `main` lacks — its only unique content is the superseded publish step:

```yaml
        run: npm publish --access public --provenance
        env:
          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

which is precisely what #1836 replaced. Every other line already matched. So this is a **verbatim copy of `main`'s file** — fewer ways to get it wrong than reconstructing hunks, and it leaves the two branches byte-identical.

## What v2/main gains

| From | Change |
| --- | --- |
| #1831 | least-privilege default `permissions: contents: read` for `GITHUB_TOKEN` |
| #1834 | dist-tag derived from the version, so a `-rc` can't publish to `latest` |
| #1836 | npm **OIDC trusted publishing** (`id-token: write` + `environment: release`) |

That last one matters most: `v2/main`'s copy authenticated with `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` against a secret **this repo does not have**, which writes an empty `_authToken` into the generated `.npmrc` and fails `ENEEDAUTH` before OIDC is ever attempted.

Nothing was actually broken — releases are cut from `main`, which has the good copy — but `v2/main`'s is the one every future PR edits, so the divergence was a live trap.

## Not a back-merge

Only this one file is taken from `main`. None of main's pre-swap v1 lineage enters `v2/main`'s ancestry, so the #1868 reasoning is respected.

## Verification

- `git diff origin/main -- .github/workflows/main.yml` on this branch is **empty** — the two are now byte-identical.
- YAML parses (`yaml.safe_load`).
- The heavier gates are deliberately not cited as evidence here: this changes **only** a GitHub Actions workflow file, which `validate` / `coverage` / `smoke` / Storybook do not read or execute. The content's real proof is that it is the exact file `main` has been publishing 2.0.0 with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAt8rqxysNbhYWLhoRm3fU