### PR TITLE
fix: construct AsyncEntry inside the try so keychain degradation engages (#1848)

### DIFF
--- a/clients/web/src/test/core/mcp/serverList.test.ts
+++ b/clients/web/src/test/core/mcp/serverList.test.ts
@@ -1076,6 +1076,36 @@ describe("expectedSecretFields", () => {
       }),
     ).toEqual([SECRET_FIELD_OAUTH_CLIENT_SECRET]);
   });
+
+  it("keeps a secret-only OAuth config reachable across the disk round trip", () => {
+    // The OAuth slot is unconditional, and that is load-bearing rather
+    // than merely defensive — skipping the keychain read for servers with
+    // "no OAuth config" is a tempting optimization that would silently
+    // stop rehydrating exactly this shape.
+    //
+    // `extractSecretsFromStored` deletes the `oauth` block outright when
+    // `clientSecret` was its only property, so the on-disk entry carries
+    // NO marker that a secret exists — the keychain is the only record.
+    // The unconditional slot is what finds it again.
+    const { stripped, secrets } = extractSecretsFromStored({
+      type: "streamable-http",
+      url: "https://x.test",
+      oauth: { clientSecret: "shh" },
+    });
+    expect(stripped).not.toHaveProperty("oauth");
+
+    // What a GET does: enumerate fields from the *stripped* on-disk shape,
+    // read those from the keychain, merge back.
+    const fields = expectedSecretFields(stripped);
+    expect(fields).toContain(SECRET_FIELD_OAUTH_CLIENT_SECRET);
+
+    const fromKeychain = Object.fromEntries(
+      fields.filter((f) => f in secrets).map((f) => [f, secrets[f]!]),
+    );
+    expect(mergeSecretsIntoStored(stripped, fromKeychain).oauth).toEqual({
+      clientSecret: "shh",
+    });
+  });
 });
 
 describe("enterpriseManaged oauth settings", () => {

--- a/clients/web/src/test/integration/auth/node/secret-store.test.ts
+++ b/clients/web/src/test/integration/auth/node/secret-store.test.ts
@@ -24,6 +24,12 @@ const keyringMocks = vi.hoisted(() => {
     deleteThrows: false,
     findThrows: false,
     deleteThrowsNoEntry: false,
+    // `AsyncEntry::new` itself does the platform-store setup and throws
+    // when no backend is reachable (a container with no D-Bus session,
+    // Linux without libsecret). Modelling it is what catches #1848: a
+    // stub that can only fail per-method leaves the construction path
+    // untested, so an escaping constructor error looks green here.
+    constructorThrows: false,
   };
   const credentials = (): Array<{ account: string; password: string }> => {
     const out: Array<{ account: string; password: string }> = [];
@@ -35,6 +41,11 @@ const keyringMocks = vi.hoisted(() => {
   class AsyncEntry {
     private readonly key: string;
     constructor(_service: string, username: string) {
+      if (failures.constructorThrows) {
+        throw new Error(
+          "Couldn't access platform storage: PermissionDenied (constructor)",
+        );
+      }
       this.key = username;
     }
     async getPassword(): Promise<string | undefined> {
@@ -215,6 +226,7 @@ describe("KeyringSecretStore (mocked native bindings)", () => {
     keyringMocks.failures.deleteThrows = false;
     keyringMocks.failures.findThrows = false;
     keyringMocks.failures.deleteThrowsNoEntry = false;
+    keyringMocks.failures.constructorThrows = false;
     store = new KeyringSecretStore();
   });
 
@@ -328,5 +340,49 @@ describe("KeyringSecretStore (mocked native bindings)", () => {
       expect((err as Error).message).toMatch(/keychain set unavailable/);
       expect((err as Error).message).toMatch(/libsecret/);
     }
+  });
+
+  describe("keychain unreachable at AsyncEntry construction (#1848)", () => {
+    // `AsyncEntry::new` — not just its methods — throws when no platform
+    // store is reachable. The degradation contract must hold identically
+    // for that failure mode; constructing outside the `try` let the raw
+    // keyring error escape and 500 `GET /api/servers` before any secret
+    // was touched.
+    beforeEach(() => {
+      keyringMocks.failures.constructorThrows = true;
+    });
+
+    it("get returns null", async () => {
+      expect(await store.get("alpha", SECRET_FIELD_OAUTH_CLIENT_SECRET)).toBe(
+        null,
+      );
+    });
+
+    it("set throws KeychainUnavailableError, not the raw keyring error", async () => {
+      // The typed error is what the routes translate to a 503 and what
+      // `migratePlaintextSecrets` matches on to skip migration.
+      await expect(
+        store.set("alpha", SECRET_FIELD_OAUTH_CLIENT_SECRET, "v"),
+      ).rejects.toBeInstanceOf(KeychainUnavailableError);
+      await expect(
+        store.set("alpha", SECRET_FIELD_OAUTH_CLIENT_SECRET, "v"),
+      ).rejects.toThrow(/Couldn't access platform storage/);
+    });
+
+    it("delete silently no-ops", async () => {
+      await expect(
+        store.delete("alpha", SECRET_FIELD_OAUTH_CLIENT_SECRET),
+      ).resolves.toBeUndefined();
+    });
+
+    it("deleteAllForServer no-ops even when the credential sweep finds entries", async () => {
+      // findCredentialsAsync can succeed while per-entry construction
+      // fails; the sweep must still resolve rather than escape.
+      keyringMocks.failures.constructorThrows = false;
+      await store.set("alpha", SECRET_FIELD_OAUTH_CLIENT_SECRET, "a");
+      keyringMocks.failures.constructorThrows = true;
+
+      await expect(store.deleteAllForServer("alpha")).resolves.toBeUndefined();
+    });
   });
 });

--- a/core/auth/node/secret-store.ts
+++ b/core/auth/node/secret-store.ts
@@ -80,18 +80,27 @@ export interface SecretStore {
  * a real value and must round-trip).
  *
  * **Availability behavior.** When the keychain is unavailable (the
- * typical case is Linux without libsecret / gnome-keyring), `set` is
- * the only operation that throws `KeychainUnavailableError` — that's
- * the moment where data would actually be lost. `get` returns `null`
- * (as if no entry existed) and the destructive operations silently
- * no-op (there's nothing to delete anyway). This keeps non-secret
- * flows working on a stock CI runner / minimal Linux box; the user
- * only hits a hard error when they actually try to save a secret.
+ * typical case is Linux without libsecret / gnome-keyring, or a
+ * container with no D-Bus session), `set` is the only operation that
+ * throws `KeychainUnavailableError` — that's the moment where data
+ * would actually be lost. `get` returns `null` (as if no entry
+ * existed) and the destructive operations silently no-op (there's
+ * nothing to delete anyway). This keeps non-secret flows working on a
+ * stock CI runner / minimal Linux box; the user only hits a hard error
+ * when they actually try to save a secret.
+ *
+ * The `AsyncEntry` construction is deliberately **inside** each
+ * method's `try`: `AsyncEntry::new` performs the platform-store setup
+ * (on Linux, the Secret Service connect with a keyutils fallback) and
+ * throws when no backend is reachable. Constructing it outside the
+ * `try` let that raw error escape, 500ing every `GET /api/servers`
+ * before any secret was involved — the contract above only holds if
+ * construction failures are funneled through the same handlers (#1848).
  */
 export class KeyringSecretStore implements SecretStore {
   async get(serverId: string, field: string): Promise<string | null> {
-    const entry = new AsyncEntry(SERVICE_NAME, buildAccount(serverId, field));
     try {
+      const entry = new AsyncEntry(SERVICE_NAME, buildAccount(serverId, field));
       const v = await entry.getPassword();
       return v ?? null;
     } catch {
@@ -104,8 +113,8 @@ export class KeyringSecretStore implements SecretStore {
   }
 
   async set(serverId: string, field: string, value: string): Promise<void> {
-    const entry = new AsyncEntry(SERVICE_NAME, buildAccount(serverId, field));
     try {
+      const entry = new AsyncEntry(SERVICE_NAME, buildAccount(serverId, field));
       await entry.setPassword(value);
     } catch (err) {
       // The only operation that hard-fails — if we can't persist the
@@ -116,17 +125,17 @@ export class KeyringSecretStore implements SecretStore {
   }
 
   async delete(serverId: string, field: string): Promise<void> {
-    const entry = new AsyncEntry(SERVICE_NAME, buildAccount(serverId, field));
     try {
+      const entry = new AsyncEntry(SERVICE_NAME, buildAccount(serverId, field));
       await entry.deleteCredential();
     } catch {
-      // Both reasons for a throw collapse to the same desired outcome
+      // Every reason for a throw collapses to the same desired outcome
       // ("the entry isn't there anymore"): `deleteCredential` raises
-      // NoEntry for a missing credential, and the native binding
-      // raises a runtime error when the keychain itself is unavailable.
-      // We treat both as success — there's no value to lose either
-      // way, and `set` is the operation that hard-fails when the
-      // keychain is actually down.
+      // NoEntry for a missing credential, and both the constructor and
+      // the native binding raise a runtime error when the keychain
+      // itself is unavailable. We treat all of them as success — there's
+      // no value to lose either way, and `set` is the operation that
+      // hard-fails when the keychain is actually down.
     }
   }
 


### PR DESCRIPTION
Closes #1848

Also fixes **#1845**, **#1918**, and **#1931** — all three closed as duplicates of #1848, all reporting the same `Failed to read server list: Couldn't access platform storage: PermissionDenied` from a container with no D-Bus session:

| Issue | Reported against | Notes |
| --- | --- | --- |
| #1845 | `ghcr.io/modelcontextprotocol/inspector` | The original report; #1848 was filed as its follow-up with a root cause. |
| #1918 | `@modelcontextprotocol/inspector@2.0.0`, `node:24-alpine` | Independently root-caused this precisely — names both the `expectedSecretFields` amplification and the constructor sitting outside the `try`. |
| #1931 | `ghcr.io/…:2.1.0`, Docker Swarm | Same, plus the `POST` succeeds → `409` on re-add → empty UI symptom chain. |

Four separate reporters, three of whom independently identified the same line. That is the argument for the test-side half of this PR: the gap survived a ≥90% per-file gate because the stub constructor could not fail.

`KeyringSecretStore` constructed its `AsyncEntry` **outside** the `try` in `get`, `set`, and `delete`. `AsyncEntry::new` performs the platform-store setup (on Linux, the Secret Service connect with a keyutils fallback) and returns a `Result`, so it throws when no backend is reachable — and the degradation contract documented at `secret-store.ts:79-89` never engaged for that failure. The raw keyring error escaped instead, 500ing every `GET /api/servers` on a box without a Secret Service (the published container, which has no D-Bus session).

Two consequences beyond the 500 itself, both from the reporter's analysis and both confirmed here:

- `expectedSecretFields` always includes the OAuth slot, so `rehydrateConfig` constructs an entry for **every** server. The default seeded catalog is enough to 500 the first list load, before any server is added.
- The escaping error is not a `KeychainUnavailableError`, so it bypasses both the routes' 503 translation (`core/mcp/remote/node/server.ts:1784`, `:1874`) and the `migratePlaintextSecrets` skip branch — a generic 500 instead of the actionable message.

## The change

Construction moved inside the existing `try` in all three methods, so the documented contract holds for a construction-time failure: `get` returns `null`, `delete` silently no-ops, and `set` is the only operation that throws — as `KeychainUnavailableError`. The class doc comment now states that the placement is deliberate and why; the `delete` catch comment covers the constructor as a third throw source.

### On the judgment call the reporter flagged

Having `set` wrap a *constructor* failure as `KeychainUnavailableError` is what makes the 503 translation and the migration-skip branch fire, and it matches the documented contract. Both consumers (`core/mcp/remote/node/server.ts`, `core/client/node-persistence.ts:61`) match on the type with `instanceof`, and nothing in the tree matches on the raw keyring message — so the typed error is strictly what makes the intended behavior reachable.

## Tests

The `vi.mock` stub constructor could not fail, which is exactly why the coverage gate never saw this gap. Added a `constructorThrows` hook alongside the existing method-level `failures` flags, plus a nested describe covering `get` / `set` / `delete` under it and `deleteAllForServer` in the case where the credential sweep succeeds but per-entry construction fails.

Verified red-without / green-with: all four new tests fail against the pre-fix `secret-store.ts` and pass after.

## Verification

`npm run ci` green, run in stages:

- `validate` — pass
- `coverage` — 4812 passed; `secret-store.ts` at 97.5 / 94.44 / 100 / 100 (lines/branches/functions/statements). The run also surfaces two pre-existing unhandled rejections in `inspectorClient.test.ts` (teardown `disconnect` races) that reproduce identically in a sibling worktree on unmodified code whose CI is green — local flake, untouched by this change.
- `verify:build-gate` — pass
- `smoke` — all five pass, including `smoke:web:app`
- `ci:storybook` — 462 passed

No UI change, so no screenshots.

## Not fixed by this: #1905

[#1905](https://github.com/modelcontextprotocol/inspector/issues/1905) (Android/Termux) is a *module-load* failure, one layer earlier: there is no `@napi-rs/keyring-android-arm64` binary, so the static `import { AsyncEntry, findCredentialsAsync } from "@napi-rs/keyring"` at `core/auth/node/secret-store.ts:16` throws during module evaluation and no `KeyringSecretStore` method ever runs. That needs the import itself made lazy/guarded and funnelled into this same contract — a separate change, for which the `constructorThrows` hook added here is the natural place to add a `moduleLoadThrows` sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAR2Nr9kXbrywFNUVoTe9F
