### PR TITLE
fix: surface list-fetch failures instead of swallowing them

### DIFF
--- a/clients/web/src/App.tsx
+++ b/clients/web/src/App.tsx
@@ -994,24 +994,33 @@ function App() {
   } = useInspectorClient(inspectorClient);
   const {
     tools: managedTools,
+    error: toolsLoadError,
     listChanged: toolsListChanged,
     refresh: refreshTools,
     clearListChanged: clearToolsListChanged,
   } = useManagedTools(inspectorClient, managedToolsState);
   const {
     prompts: managedPrompts,
+    error: promptsLoadError,
     listChanged: promptsListChanged,
     refresh: refreshPrompts,
     clearListChanged: clearPromptsListChanged,
   } = useManagedPrompts(inspectorClient, managedPromptsState);
   const {
     resources: managedResources,
+    error: resourcesLoadError,
     listChanged: resourcesListChanged,
     refresh: refreshResources,
     clearListChanged: clearResourcesListChanged,
   } = useManagedResources(inspectorClient, managedResourcesState);
-  const { resourceTemplates, refresh: refreshResourceTemplates } =
-    useManagedResourceTemplates(inspectorClient, managedResourceTemplatesState);
+  const {
+    resourceTemplates,
+    error: resourceTemplatesLoadError,
+    refresh: refreshResourceTemplates,
+  } = useManagedResourceTemplates(
+    inspectorClient,
+    managedResourceTemplatesState,
+  );
   // Paged (paginated) list sources. When `paginatedLists` is on the managed
   // states skip their all-page walk and these drive the sidebar instead (#1721).
   const {
@@ -4373,6 +4382,9 @@ function App() {
           toolsListChanged={toolsListChanged}
           promptsListChanged={promptsListChanged}
           resourcesListChanged={resourcesListChanged}
+          toolsLoadError={toolsLoadError}
+          promptsLoadError={promptsLoadError}
+          resourcesLoadError={resourcesLoadError ?? resourceTemplatesLoadError}
           subscriptions={subscriptions}
           subscriptionStreamState={subscriptionStreamState}
           logs={logs}

--- a/clients/web/src/components/elements/ListLoadError/ListLoadError.stories.tsx
+++ b/clients/web/src/components/elements/ListLoadError/ListLoadError.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { ListLoadError } from "./ListLoadError";
+
+const meta: Meta<typeof ListLoadError> = {
+  title: "Elements/ListLoadError",
+  component: ListLoadError,
+};
+
+export default meta;
+type Story = StoryObj<typeof ListLoadError>;
+
+/** The failure this was built for: a modern server returning a list result the
+ *  SDK codec rejects (#1953). */
+export const CodecRejection: Story = {
+  args: {
+    what: "tools",
+    error: new Error(
+      'Invalid result for tools/list: [\n  {\n    "expected": "number",\n    "code": "invalid_type",\n    "path": [\n      "ttlMs"\n    ]\n  }\n]',
+    ),
+    onRetry: fn(),
+  },
+};
+
+export const TransportFailure: Story = {
+  args: {
+    what: "prompts",
+    error: new Error("fetch failed: ECONNREFUSED 127.0.0.1:3100"),
+    onRetry: fn(),
+  },
+};
+
+/** No retry handler — the alert renders without the affordance. */
+export const WithoutRetry: Story = {
+  args: {
+    what: "resources",
+    error: new Error("Request timed out"),
+  },
+};
+
+/** The resting state: no error, nothing rendered. */
+export const NoError: Story = {
+  args: {
+    what: "tools",
+    error: null,
+    onRetry: fn(),
+  },
+};

--- a/clients/web/src/components/elements/ListLoadError/ListLoadError.test.tsx
+++ b/clients/web/src/components/elements/ListLoadError/ListLoadError.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import { ListLoadError } from "./ListLoadError";
+
+describe("ListLoadError", () => {
+  it("renders nothing when there is no error", () => {
+    renderWithMantine(<ListLoadError error={null} what="tools" />);
+    expect(screen.queryByText(/Couldn't load/)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the error prop is omitted", () => {
+    renderWithMantine(<ListLoadError what="tools" />);
+    expect(screen.queryByText(/Couldn't load/)).not.toBeInTheDocument();
+  });
+
+  it("names what failed to load and shows the reason verbatim", () => {
+    // The exact text is the diagnostic — a validation failure names the JSON
+    // path and what was expected, so it is rendered unabridged (#1953).
+    const message = 'Invalid result for tools/list: [{"path":["ttlMs"]}]';
+    renderWithMantine(
+      <ListLoadError error={new Error(message)} what="tools" />,
+    );
+
+    expect(screen.getByText("Couldn't load tools")).toBeInTheDocument();
+    expect(screen.getByText(message)).toBeInTheDocument();
+  });
+
+  it("uses the given noun so each list names itself", () => {
+    renderWithMantine(<ListLoadError error={new Error("x")} what="prompts" />);
+    expect(screen.getByText("Couldn't load prompts")).toBeInTheDocument();
+  });
+
+  it("invokes onRetry when Retry is clicked", async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    renderWithMantine(
+      <ListLoadError error={new Error("x")} what="tools" onRetry={onRetry} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the retry affordance when no handler is given", () => {
+    renderWithMantine(<ListLoadError error={new Error("x")} what="tools" />);
+    expect(
+      screen.queryByRole("button", { name: "Retry" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/clients/web/src/components/elements/ListLoadError/ListLoadError.tsx
+++ b/clients/web/src/components/elements/ListLoadError/ListLoadError.tsx
@@ -1,0 +1,65 @@
+import { Alert, Button, Code, ScrollArea, Stack } from "@mantine/core";
+
+export interface ListLoadErrorProps {
+  /**
+   * The failed load's error, or `null`/`undefined` when the last load
+   * succeeded (renders nothing).
+   */
+  error?: Error | null;
+  /** What failed to load, for the alert title — e.g. "tools", "prompts". */
+  what: string;
+  /** Retry the load. Omit to render the alert without a retry affordance. */
+  onRetry?: () => void;
+}
+
+// `variant="light"` + red: an error the user can act on (retry), not a fatal
+// one. Sits above the list rather than replacing it — a stale list plus a
+// visible "this didn't reload" beats an empty panel that looks like an answer.
+const ErrorAlert = Alert.withProps({
+  color: "red",
+  variant: "light",
+});
+
+// The raw message, monospaced and wrapping: these are validation failures
+// (JSON paths, schema expectations) where the exact text is the diagnostic.
+const ErrorMessage = Code.withProps({
+  block: true,
+  variant: "wrapping",
+});
+
+// Caps the message: a schema-validation failure serializes to a dozen-plus
+// lines, which would otherwise push the list itself off the sidebar.
+const MessageScroll = ScrollArea.withProps({
+  mah: 180,
+  type: "auto",
+});
+
+const RetryButton = Button.withProps({
+  size: "xs",
+  variant: "light",
+  color: "red",
+  w: "fit-content",
+});
+
+/**
+ * The list panel's "couldn't load" state (#1953).
+ *
+ * A list fetch that fails — a transport error, or a result the SDK codec
+ * rejects as invalid for the negotiated protocol era — used to leave the panel
+ * empty, which is indistinguishable from a server that legitimately has no
+ * tools/prompts/resources. This says what happened and offers a retry.
+ */
+export function ListLoadError({ error, what, onRetry }: ListLoadErrorProps) {
+  if (!error) return null;
+
+  return (
+    <ErrorAlert title={`Couldn't load ${what}`}>
+      <Stack gap="xs">
+        <MessageScroll>
+          <ErrorMessage>{error.message}</ErrorMessage>
+        </MessageScroll>
+        {onRetry && <RetryButton onClick={onRetry}>Retry</RetryButton>}
+      </Stack>
+    </ErrorAlert>
+  );
+}

--- a/clients/web/src/components/groups/PromptControls/PromptControls.test.tsx
+++ b/clients/web/src/components/groups/PromptControls/PromptControls.test.tsx
@@ -160,4 +160,29 @@ describe("PromptControls", () => {
     expect(screen.getByText("Prompts")).toBeInTheDocument();
     expect(screen.queryByText("translate")).not.toBeInTheDocument();
   });
+
+  // A failed load is rendered above the list instead of leaving the panel
+  // empty, which is indistinguishable from a server that has none (#1953).
+  it("renders a failed load above the list and retries via onRefreshList", async () => {
+    const user = userEvent.setup();
+    const onRefreshList = vi.fn();
+    renderWithMantine(
+      <PromptControls
+        {...baseProps}
+        loadError={new Error("codec said no")}
+        onRefreshList={onRefreshList}
+      />,
+    );
+
+    expect(screen.getByText("Couldn't load prompts")).toBeInTheDocument();
+    expect(screen.getByText("codec said no")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRefreshList).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders no load error by default", () => {
+    renderWithMantine(<PromptControls {...baseProps} />);
+    expect(screen.queryByText(/Couldn't load/)).not.toBeInTheDocument();
+  });
 });

--- a/clients/web/src/components/groups/PromptControls/PromptControls.tsx
+++ b/clients/web/src/components/groups/PromptControls/PromptControls.tsx
@@ -2,6 +2,7 @@ import { Group, ScrollArea, Stack, TextInput, Title } from "@mantine/core";
 import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { Prompt } from "@modelcontextprotocol/client";
 import { ListChangedIndicator } from "../../elements/ListChangedIndicator/ListChangedIndicator";
+import { ListLoadError } from "../../elements/ListLoadError/ListLoadError";
 import {
   ListPaginationControls,
   type ListPaginationControlsProps,
@@ -36,6 +37,11 @@ export interface PromptControlsProps {
   searchText?: string;
   listChanged: boolean;
   onRefreshList: () => void;
+  /**
+   * A failed list load, surfaced above the list instead of leaving the panel
+   * empty (which reads as "this server has none") (#1953).
+   */
+  loadError?: Error | null;
   /** Pagination controls (#1721). */
   pagination: ListPaginationControlsProps;
   onSearchChange: (value: string) => void;
@@ -48,6 +54,7 @@ export function PromptControls({
   searchText = "",
   listChanged,
   onRefreshList,
+  loadError,
   pagination,
   onSearchChange,
   onSelectPrompt,
@@ -75,6 +82,7 @@ export function PromptControls({
         }
       />
       <ListPaginationControls {...pagination} />
+      <ListLoadError error={loadError} what="prompts" onRetry={onRefreshList} />
       <ListScroll viewportRef={viewportRef}>
         <Stack gap="xs">
           {filteredPrompts.map((prompt) => (

--- a/clients/web/src/components/groups/ProtocolEntry/ProtocolEntry.test.tsx
+++ b/clients/web/src/components/groups/ProtocolEntry/ProtocolEntry.test.tsx
@@ -756,6 +756,41 @@ describe("ProtocolEntry — client-rejected response", () => {
     expect(screen.getByText(REASON)).toBeInTheDocument();
   });
 
+  // messageLogState falls back to the standalone response frame when no request
+  // entry was there to fold into (a trimmed log, or a reconnect boundary). That
+  // entry is not `direction: "request"`, so the request-only status lifecycle
+  // would have rendered it without any badge at all.
+  const rejectedStandaloneResponse: MessageEntry = {
+    id: "rej-standalone",
+    timestamp: new Date("2026-07-28T10:00:00Z"),
+    direction: "response",
+    origin: "server",
+    message: {
+      jsonrpc: "2.0",
+      id: 11,
+      result: { resultType: "complete", tools: [] },
+    },
+    clientError: REASON,
+  };
+
+  it("renders Error on a rejected standalone response entry", () => {
+    renderWithMantine(
+      <ProtocolEntry {...baseProps} entry={rejectedStandaloneResponse} />,
+    );
+    expect(screen.getByText("Error")).toBeInTheDocument();
+  });
+
+  it("still renders no status badge on an unrejected standalone response", () => {
+    const clean: MessageEntry = {
+      ...rejectedStandaloneResponse,
+      clientError: undefined,
+    };
+    renderWithMantine(<ProtocolEntry {...baseProps} entry={clean} />);
+    expect(screen.queryByText("Error")).not.toBeInTheDocument();
+    expect(screen.queryByText("OK")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
+  });
+
   it("shows no rejection alert on an ordinary success", () => {
     renderWithMantine(
       <ProtocolEntry {...baseProps} entry={successEntry} isListExpanded />,

--- a/clients/web/src/components/groups/ProtocolEntry/ProtocolEntry.test.tsx
+++ b/clients/web/src/components/groups/ProtocolEntry/ProtocolEntry.test.tsx
@@ -711,3 +711,57 @@ describe("ProtocolEntry — modern vocabulary", () => {
     });
   });
 });
+
+// A response the server answered successfully but the CLIENT then refused —
+// e.g. the SDK's era codec rejecting a 2026-07-28 list result missing
+// `ttlMs`/`cacheScope`. The wire frame is a valid JSON-RPC result, so before
+// #1953 this rendered as a clean success.
+describe("ProtocolEntry — client-rejected response", () => {
+  const REASON = "Invalid result for tools/list: ttlMs required";
+
+  const rejectedEntry: MessageEntry = {
+    id: "rej-1",
+    timestamp: new Date("2026-07-28T10:00:00Z"),
+    direction: "request",
+    origin: "client",
+    message: { jsonrpc: "2.0", id: 9, method: "tools/list", params: {} },
+    response: {
+      jsonrpc: "2.0",
+      id: 9,
+      result: { resultType: "complete", tools: [] },
+    },
+    clientError: REASON,
+  };
+
+  it("renders Error rather than a success status", () => {
+    renderWithMantine(<ProtocolEntry {...baseProps} entry={rejectedEntry} />);
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.queryByText("OK")).not.toBeInTheDocument();
+  });
+
+  it("shows the Error badge even though a resultType badge is present", () => {
+    // The resultType normally suppresses the status badge (a modern success
+    // says "complete"). A rejected result must not hide behind it — the wire
+    // said complete, the client disagreed, and both are worth seeing.
+    renderWithMantine(<ProtocolEntry {...baseProps} entry={rejectedEntry} />);
+    expect(screen.getByText("complete")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
+  });
+
+  it("names the Inspector as the rejecter and gives the reason when expanded", () => {
+    renderWithMantine(
+      <ProtocolEntry {...baseProps} entry={rejectedEntry} isListExpanded />,
+    );
+    expect(screen.getByText("Rejected by the Inspector")).toBeInTheDocument();
+    expect(screen.getByText(REASON)).toBeInTheDocument();
+  });
+
+  it("shows no rejection alert on an ordinary success", () => {
+    renderWithMantine(
+      <ProtocolEntry {...baseProps} entry={successEntry} isListExpanded />,
+    );
+    expect(
+      screen.queryByText("Rejected by the Inspector"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/clients/web/src/components/groups/ProtocolEntry/ProtocolEntry.tsx
+++ b/clients/web/src/components/groups/ProtocolEntry/ProtocolEntry.tsx
@@ -220,12 +220,16 @@ function extractResourceUri(entry: MessageEntry): string | undefined {
 function extractStatus(
   entry: MessageEntry,
 ): "success" | "error" | "pending" | "none" {
+  // A response the CLIENT refused is an error whichever entry carries it, so
+  // this is checked BEFORE the request-only lifecycle below (#1953).
+  // messageLogState annotates the request entry when the response was folded
+  // into one, but falls back to the standalone response frame when there was
+  // no matching request (a trimmed log, or a reconnect boundary) — and that
+  // entry would otherwise fall straight through to "none" and render no badge.
+  if (entry.clientError) return "error";
   if (entry.direction !== "request") return "none";
   if (!entry.response) return "pending";
   if ("error" in entry.response) return "error";
-  // The server answered with a valid result the CLIENT then refused (#1953).
-  // The call failed, so the entry must not read as a success.
-  if (entry.clientError) return "error";
   return "success";
 }
 

--- a/clients/web/src/components/groups/ProtocolEntry/ProtocolEntry.tsx
+++ b/clients/web/src/components/groups/ProtocolEntry/ProtocolEntry.tsx
@@ -135,6 +135,16 @@ const SpecErrorAlert = Alert.withProps({
   icon: <RiErrorWarningLine />,
 });
 
+// The client rejected an otherwise well-formed response (#1953). Distinct from
+// SpecErrorAlert: nothing is wrong with the server's JSON-RPC frame — the
+// Inspector's own decoding refused the result — so the title says who rejected it.
+const ClientErrorAlert = Alert.withProps({
+  variant: "light",
+  color: "red",
+  icon: <RiErrorWarningLine />,
+  title: "Rejected by the Inspector",
+});
+
 // Link (button-styled) that jumps to the correlated HTTP entry in the Network tab.
 const RevealLink = Anchor.withProps({
   component: "button",
@@ -213,6 +223,9 @@ function extractStatus(
   if (entry.direction !== "request") return "none";
   if (!entry.response) return "pending";
   if ("error" in entry.response) return "error";
+  // The server answered with a valid result the CLIENT then refused (#1953).
+  // The call failed, so the entry must not read as a success.
+  if (entry.clientError) return "error";
   return "success";
 }
 
@@ -330,11 +343,12 @@ export function ProtocolEntry({
   // Suppress the redundant green "OK" when a `resultType` badge already conveys
   // the outcome (a modern success is `complete`/`input required`); errors and
   // pending have no `resultType`, so their status badge still shows.
-  const statusBadge = status !== "none" && !resultType && (
-    <Badge color={statusColor(status)} variant="status">
-      {statusLabel(status)}
-    </Badge>
-  );
+  const statusBadge = status !== "none" &&
+    (!resultType || entry.clientError) && (
+      <Badge color={statusColor(status)} variant="status">
+        {statusLabel(status)}
+      </Badge>
+    );
   const subscriptionBadge = subscriptionId && (
     <SubscriptionCluster>
       <SubscriptionLabel>sub</SubscriptionLabel>
@@ -431,6 +445,11 @@ export function ProtocolEntry({
         <Collapse in={isExpanded}>
           <Stack gap="sm">
             <Divider />
+            {entry.clientError && (
+              <ClientErrorAlert>
+                <Text size="xs">{entry.clientError}</Text>
+              </ClientErrorAlert>
+            )}
             {specError && (
               <McpSpecErrorAlert
                 error={specError}

--- a/clients/web/src/components/groups/ResourceControls/ResourceControls.test.tsx
+++ b/clients/web/src/components/groups/ResourceControls/ResourceControls.test.tsx
@@ -395,4 +395,29 @@ describe("ResourceControls", () => {
       expect(screen.queryByText("Listening")).not.toBeInTheDocument();
     });
   });
+
+  // A failed load is rendered above the list instead of leaving the panel
+  // empty, which is indistinguishable from a server that has none (#1953).
+  it("renders a failed load above the list and retries via onRefreshList", async () => {
+    const user = userEvent.setup();
+    const onRefreshList = vi.fn();
+    renderWithMantine(
+      <ResourceControls
+        {...baseProps}
+        loadError={new Error("codec said no")}
+        onRefreshList={onRefreshList}
+      />,
+    );
+
+    expect(screen.getByText("Couldn't load resources")).toBeInTheDocument();
+    expect(screen.getByText("codec said no")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRefreshList).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders no load error by default", () => {
+    renderWithMantine(<ResourceControls {...baseProps} />);
+    expect(screen.queryByText(/Couldn't load/)).not.toBeInTheDocument();
+  });
 });

--- a/clients/web/src/components/groups/ResourceControls/ResourceControls.tsx
+++ b/clients/web/src/components/groups/ResourceControls/ResourceControls.tsx
@@ -13,6 +13,7 @@ import type {
 import { isModernEra } from "../../elements/EraBadge/eraUtils";
 import { SubscriptionStreamBadge } from "../../elements/SubscriptionStreamBadge/SubscriptionStreamBadge";
 import { ListChangedIndicator } from "../../elements/ListChangedIndicator/ListChangedIndicator";
+import { ListLoadError } from "../../elements/ListLoadError/ListLoadError";
 import {
   ListPaginationControls,
   type ListPaginationControlsProps,
@@ -66,6 +67,11 @@ export interface ResourceControlsProps {
   openSections?: string[];
   listChanged: boolean;
   onRefreshList: () => void;
+  /**
+   * A failed list load, surfaced above the list instead of leaving the panel
+   * empty (which reads as "this server has none") (#1953).
+   */
+  loadError?: Error | null;
   /** Pagination controls for the Resources list (#1721). */
   pagination: ListPaginationControlsProps;
   onSearchChange: (value: string) => void;
@@ -109,6 +115,7 @@ export function ResourceControls({
   openSections: controlledOpenSections,
   listChanged,
   onRefreshList,
+  loadError,
   pagination,
   onSearchChange,
   onOpenSectionsChange,
@@ -234,6 +241,11 @@ export function ResourceControls({
         <ListToggle compact={!allExpanded} onToggle={handleToggleList} />
       </TightRow>
       <ListPaginationControls {...pagination} />
+      <ListLoadError
+        error={loadError}
+        what="resources"
+        onRetry={onRefreshList}
+      />
       {/* Stays inline: Accordion is a compound, `multiple`-discriminated generic,
           so `.withProps({ multiple: true, ... })` loses its JSX call signature
           (same tooling limit as Box). */}

--- a/clients/web/src/components/groups/ToolControls/ToolControls.test.tsx
+++ b/clients/web/src/components/groups/ToolControls/ToolControls.test.tsx
@@ -183,4 +183,29 @@ describe("ToolControls", () => {
     );
     expect(screen.getByText("invalid_header_tool")).toBeInTheDocument();
   });
+
+  // A failed load is rendered above the list instead of leaving the panel
+  // empty, which is indistinguishable from a server that has none (#1953).
+  it("renders a failed load above the list and retries via onRefreshList", async () => {
+    const user = userEvent.setup();
+    const onRefreshList = vi.fn();
+    renderWithMantine(
+      <ToolControls
+        {...baseProps}
+        loadError={new Error("codec said no")}
+        onRefreshList={onRefreshList}
+      />,
+    );
+
+    expect(screen.getByText("Couldn't load tools")).toBeInTheDocument();
+    expect(screen.getByText("codec said no")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRefreshList).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders no load error by default", () => {
+    renderWithMantine(<ToolControls {...baseProps} />);
+    expect(screen.queryByText(/Couldn't load/)).not.toBeInTheDocument();
+  });
 });

--- a/clients/web/src/components/groups/ToolControls/ToolControls.tsx
+++ b/clients/web/src/components/groups/ToolControls/ToolControls.tsx
@@ -14,6 +14,7 @@ import { ClearButton } from "../../elements/ClearButton/ClearButton";
 import type { Tool } from "@modelcontextprotocol/client";
 import type { ExcludedTool } from "@inspector/core/mcp/types.js";
 import { ListChangedIndicator } from "../../elements/ListChangedIndicator/ListChangedIndicator";
+import { ListLoadError } from "../../elements/ListLoadError/ListLoadError";
 import {
   ListPaginationControls,
   type ListPaginationControlsProps,
@@ -32,6 +33,11 @@ export interface ToolControlsProps {
   searchText?: string;
   listChanged: boolean;
   onRefreshList: () => void;
+  /**
+   * A failed list load, surfaced above the list instead of leaving the panel
+   * empty (which reads as "this server has none") (#1953).
+   */
+  loadError?: Error | null;
   /** Pagination controls (#1721). */
   pagination: ListPaginationControlsProps;
   onSearchChange: (value: string) => void;
@@ -109,6 +115,7 @@ export function ToolControls({
   searchText = "",
   listChanged,
   onRefreshList,
+  loadError,
   pagination,
   onSearchChange,
   onSelectTool,
@@ -146,6 +153,7 @@ export function ToolControls({
         }
       />
       <ListPaginationControls {...pagination} />
+      <ListLoadError error={loadError} what="tools" onRetry={onRefreshList} />
       <SidebarScroll viewportRef={viewportRef}>
         <Stack gap="xs">
           {filteredTools.map((tool) => (

--- a/clients/web/src/components/screens/PromptsScreen/PromptsScreen.tsx
+++ b/clients/web/src/components/screens/PromptsScreen/PromptsScreen.tsx
@@ -33,6 +33,8 @@ export interface PromptsScreenProps {
   completionsSupported?: boolean;
   onUiChange: (next: PromptsUiState) => void;
   onRefreshList: () => void;
+  /** A failed list load, rendered above the sidebar list (#1953). */
+  loadError?: Error | null;
   /** Pagination controls rendered in the sidebar (#1721). */
   pagination: ListPaginationControlsProps;
   onGetPrompt: (name: string, args: Record<string, string>) => void;
@@ -136,6 +138,7 @@ export function PromptsScreen({
   completionsSupported,
   onUiChange,
   onRefreshList,
+  loadError,
   pagination,
   onGetPrompt,
   onCopyMessages,
@@ -273,6 +276,7 @@ export function PromptsScreen({
             searchText={search}
             listChanged={listChanged}
             onRefreshList={onRefreshList}
+            loadError={loadError}
             pagination={pagination}
             onSearchChange={(value) => onUiChange({ ...ui, search: value })}
             onSelectPrompt={handleSelectPrompt}

--- a/clients/web/src/components/screens/ResourcesScreen/ResourcesScreen.tsx
+++ b/clients/web/src/components/screens/ResourcesScreen/ResourcesScreen.tsx
@@ -57,6 +57,8 @@ export interface ResourcesScreenProps {
   subscriptionsSupported?: boolean;
   onUiChange: (next: ResourcesUiState) => void;
   onRefreshList: () => void;
+  /** A failed list load, rendered above the sidebar list (#1953). */
+  loadError?: Error | null;
   /** Pagination controls rendered in the sidebar (#1721). */
   pagination: ListPaginationControlsProps;
   onReadResource: (uri: string) => void;
@@ -170,6 +172,7 @@ export function ResourcesScreen({
   subscriptionsSupported = true,
   onUiChange,
   onRefreshList,
+  loadError,
   pagination,
   onReadResource,
   onSubscribeResource,
@@ -325,6 +328,7 @@ export function ResourcesScreen({
             openSections={openSections}
             listChanged={listChanged}
             onRefreshList={onRefreshList}
+            loadError={loadError}
             pagination={pagination}
             onSearchChange={(value) => onUiChange({ ...ui, search: value })}
             onOpenSectionsChange={(value) =>

--- a/clients/web/src/components/screens/ToolsScreen/ToolsScreen.tsx
+++ b/clients/web/src/components/screens/ToolsScreen/ToolsScreen.tsx
@@ -60,6 +60,8 @@ export interface ToolsScreenProps {
   modernTasks?: boolean;
   onUiChange: (next: ToolsUiState) => void;
   onRefreshList: () => void;
+  /** A failed list load, rendered above the sidebar list (#1953). */
+  loadError?: Error | null;
   /** Pagination controls rendered in the sidebar (#1721). */
   pagination: ListPaginationControlsProps;
   onCallTool: (
@@ -152,6 +154,7 @@ export function ToolsScreen({
   modernTasks = false,
   onUiChange,
   onRefreshList,
+  loadError,
   pagination,
   onCallTool,
   onCancelCall,
@@ -192,6 +195,7 @@ export function ToolsScreen({
             searchText={search}
             listChanged={listChanged}
             onRefreshList={onRefreshList}
+            loadError={loadError}
             pagination={pagination}
             onSearchChange={(value) => onUiChange({ ...ui, search: value })}
             onSelectTool={handleSelectTool}

--- a/clients/web/src/components/views/InspectorView/InspectorView.tsx
+++ b/clients/web/src/components/views/InspectorView/InspectorView.tsx
@@ -435,6 +435,17 @@ export interface InspectorViewProps {
   toolsListChanged: boolean;
   promptsListChanged: boolean;
   resourcesListChanged: boolean;
+
+  // Last list-load failure per screen, sourced from the same managed-state
+  // layer. Rendered above the sidebar list so a failed load (including the
+  // connect-time one) can't read as "this server has none" (#1953).
+  toolsLoadError?: Error | null;
+  promptsLoadError?: Error | null;
+  /**
+   * The Resources sidebar lists resources AND templates behind a single
+   * Refresh, so App passes whichever of the two loads failed.
+   */
+  resourcesLoadError?: Error | null;
   logs: LogEntryData[];
   tasks: Task[];
   progressByTaskId?: Record<string, TaskProgress>;
@@ -627,6 +638,9 @@ export function InspectorView({
   toolsListChanged,
   promptsListChanged,
   resourcesListChanged,
+  toolsLoadError,
+  promptsLoadError,
+  resourcesLoadError,
   subscriptions,
   subscriptionStreamState,
   logs,
@@ -1354,6 +1368,7 @@ export function InspectorView({
                 callState={toolCallState}
                 ui={toolsUi}
                 listChanged={toolsListChanged}
+                loadError={toolsLoadError}
                 serverSupportsTaskToolCalls={serverSupportsTaskToolCalls}
                 modernTasks={
                   protocolEra === "modern" &&
@@ -1393,6 +1408,7 @@ export function InspectorView({
                 getPromptState={getPromptState}
                 ui={promptsUi}
                 listChanged={promptsListChanged}
+                loadError={promptsLoadError}
                 completionsSupported={completionsSupported}
                 onUiChange={onPromptsUiChange}
                 onRefreshList={onRefreshPrompts}
@@ -1412,6 +1428,7 @@ export function InspectorView({
                 readState={readResourceState}
                 ui={resourcesUi}
                 listChanged={resourcesListChanged}
+                loadError={resourcesLoadError}
                 completionsSupported={completionsSupported}
                 subscriptionsSupported={subscriptionsSupported}
                 onUiChange={onResourcesUiChange}

--- a/clients/web/src/test/core/mcp/state/managedPromptsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedPromptsState.test.ts
@@ -285,6 +285,22 @@ describe("ManagedPromptsState", () => {
     });
   });
 
+  // The base class owns the error plumbing (covered in managedToolsState); this
+  // pins THIS list's method string, which is what attributes a failure to the
+  // right Protocol entry (#1953).
+  it("records a failed load and attributes it to prompts/list", async () => {
+    const boom = new Error("nope");
+    client.setStatus("connected");
+    client.listAllPrompts.mockRejectedValueOnce(boom);
+
+    await expect(state.refresh()).rejects.toThrow(boom);
+    expect(state.getError()).toBe(boom);
+    expect(client.markResponseRejected).toHaveBeenCalledWith(
+      "prompts/list",
+      "nope",
+    );
+  });
+
   it("destroy is idempotent", () => {
     state.destroy();
     expect(() => state.destroy()).not.toThrow();

--- a/clients/web/src/test/core/mcp/state/managedPromptsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedPromptsState.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { SdkError, SdkErrorCode } from "@modelcontextprotocol/client";
 import type { Prompt } from "@modelcontextprotocol/client";
 import type { InspectorServerSettings } from "@inspector/core/mcp/types.js";
 import { ManagedPromptsState } from "@inspector/core/mcp/state/managedPromptsState";
@@ -289,7 +290,7 @@ describe("ManagedPromptsState", () => {
   // pins THIS list's method string, which is what attributes a failure to the
   // right Protocol entry (#1953).
   it("records a failed load and attributes it to prompts/list", async () => {
-    const boom = new Error("nope");
+    const boom = new SdkError(SdkErrorCode.InvalidResult, "nope");
     client.setStatus("connected");
     client.listAllPrompts.mockRejectedValueOnce(boom);
 

--- a/clients/web/src/test/core/mcp/state/managedResourceTemplatesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedResourceTemplatesState.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { SdkError, SdkErrorCode } from "@modelcontextprotocol/client";
 import type { ResourceTemplateType as ResourceTemplate } from "@modelcontextprotocol/client";
 import type { InspectorServerSettings } from "@inspector/core/mcp/types.js";
 import { ManagedResourceTemplatesState } from "@inspector/core/mcp/state/managedResourceTemplatesState";
@@ -270,7 +271,7 @@ describe("ManagedResourceTemplatesState", () => {
   // pins THIS list's method string, which is what attributes a failure to the
   // right Protocol entry (#1953).
   it("records a failed load and attributes it to resources/templates/list", async () => {
-    const boom = new Error("nope");
+    const boom = new SdkError(SdkErrorCode.InvalidResult, "nope");
     client.setStatus("connected");
     client.listAllResourceTemplates.mockRejectedValueOnce(boom);
 

--- a/clients/web/src/test/core/mcp/state/managedResourceTemplatesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedResourceTemplatesState.test.ts
@@ -266,6 +266,22 @@ describe("ManagedResourceTemplatesState", () => {
     expect(state.getResourceTemplates()).toEqual([]);
   });
 
+  // The base class owns the error plumbing (covered in managedToolsState); this
+  // pins THIS list's method string, which is what attributes a failure to the
+  // right Protocol entry (#1953).
+  it("records a failed load and attributes it to resources/templates/list", async () => {
+    const boom = new Error("nope");
+    client.setStatus("connected");
+    client.listAllResourceTemplates.mockRejectedValueOnce(boom);
+
+    await expect(state.refresh()).rejects.toThrow(boom);
+    expect(state.getError()).toBe(boom);
+    expect(client.markResponseRejected).toHaveBeenCalledWith(
+      "resources/templates/list",
+      "nope",
+    );
+  });
+
   it("destroy is idempotent", () => {
     state.destroy();
     expect(() => state.destroy()).not.toThrow();

--- a/clients/web/src/test/core/mcp/state/managedResourcesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedResourcesState.test.ts
@@ -292,6 +292,22 @@ describe("ManagedResourcesState", () => {
     });
   });
 
+  // The base class owns the error plumbing (covered in managedToolsState); this
+  // pins THIS list's method string, which is what attributes a failure to the
+  // right Protocol entry (#1953).
+  it("records a failed load and attributes it to resources/list", async () => {
+    const boom = new Error("nope");
+    client.setStatus("connected");
+    client.listAllResources.mockRejectedValueOnce(boom);
+
+    await expect(state.refresh()).rejects.toThrow(boom);
+    expect(state.getError()).toBe(boom);
+    expect(client.markResponseRejected).toHaveBeenCalledWith(
+      "resources/list",
+      "nope",
+    );
+  });
+
   it("destroy is idempotent", () => {
     state.destroy();
     expect(() => state.destroy()).not.toThrow();

--- a/clients/web/src/test/core/mcp/state/managedResourcesState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedResourcesState.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { SdkError, SdkErrorCode } from "@modelcontextprotocol/client";
 import type { Resource } from "@modelcontextprotocol/client";
 import type { InspectorServerSettings } from "@inspector/core/mcp/types.js";
 import { ManagedResourcesState } from "@inspector/core/mcp/state/managedResourcesState";
@@ -296,7 +297,7 @@ describe("ManagedResourcesState", () => {
   // pins THIS list's method string, which is what attributes a failure to the
   // right Protocol entry (#1953).
   it("records a failed load and attributes it to resources/list", async () => {
-    const boom = new Error("nope");
+    const boom = new SdkError(SdkErrorCode.InvalidResult, "nope");
     client.setStatus("connected");
     client.listAllResources.mockRejectedValueOnce(boom);
 

--- a/clients/web/src/test/core/mcp/state/managedToolsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedToolsState.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { SdkError, SdkErrorCode } from "@modelcontextprotocol/client";
 import type { Tool } from "@modelcontextprotocol/client";
 import type { InspectorServerSettings } from "@inspector/core/mcp/types.js";
 import { ManagedToolsState } from "@inspector/core/mcp/state/managedToolsState";
@@ -453,14 +454,76 @@ describe("ManagedToolsState", () => {
       expect(state.getError()?.message).toBe("just a string");
     });
 
-    it("attributes the failure to its Protocol entry", async () => {
-      client.setStatus("connected");
-      client.listAllTools.mockRejectedValueOnce(boom);
-      await expect(state.refresh()).rejects.toThrow(boom);
-      expect(client.markResponseRejected).toHaveBeenCalledWith(
-        "tools/list",
-        boom.message,
+    // Only a decode rejection may be attributed to a Protocol entry. The id is
+    // recovered as "the last response for this method", which is the failing
+    // exchange ONLY when a response actually arrived and was refused — see
+    // isClientDecodeRejection.
+    describe("Protocol-entry attribution", () => {
+      const decodeRejection = new SdkError(
+        SdkErrorCode.InvalidResult,
+        "Invalid result for tools/list: ttlMs required",
       );
+
+      it("attributes a decode rejection to its Protocol entry", async () => {
+        client.setStatus("connected");
+        client.listAllTools.mockRejectedValueOnce(decodeRejection);
+        await expect(state.refresh()).rejects.toThrow(decodeRejection);
+        expect(client.markResponseRejected).toHaveBeenCalledWith(
+          "tools/list",
+          decodeRejection.message,
+        );
+      });
+
+      it("attributes an unsupported resultType too", async () => {
+        client.setStatus("connected");
+        client.listAllTools.mockRejectedValueOnce(
+          new SdkError(SdkErrorCode.UnsupportedResultType, "unknown type"),
+        );
+        await expect(state.refresh()).rejects.toThrow();
+        expect(client.markResponseRejected).toHaveBeenCalledWith(
+          "tools/list",
+          "unknown type",
+        );
+      });
+
+      // The regression this guard exists for: no response frame arrived, so the
+      // last-answered id still points at an EARLIER successful call. Marking it
+      // would stamp "Rejected by the Inspector" onto an exchange that worked.
+      it("does NOT attribute a transport failure", async () => {
+        client.setStatus("connected");
+        client.listAllTools.mockRejectedValueOnce(
+          new SdkError(SdkErrorCode.ConnectionClosed, "Connection closed"),
+        );
+        await expect(state.refresh()).rejects.toThrow();
+        expect(client.markResponseRejected).not.toHaveBeenCalled();
+      });
+
+      it("does NOT attribute a request timeout", async () => {
+        client.setStatus("connected");
+        client.listAllTools.mockRejectedValueOnce(
+          new SdkError(SdkErrorCode.RequestTimeout, "Request timed out"),
+        );
+        await expect(state.refresh()).rejects.toThrow();
+        expect(client.markResponseRejected).not.toHaveBeenCalled();
+      });
+
+      // A real response, so the id would be right — but the failure is the
+      // server's, and its entry already renders as an error from the error
+      // frame. Blaming the Inspector would misattribute the cause.
+      it("does NOT attribute a plain (non-SDK) error", async () => {
+        client.setStatus("connected");
+        client.listAllTools.mockRejectedValueOnce(boom);
+        await expect(state.refresh()).rejects.toThrow(boom);
+        expect(client.markResponseRejected).not.toHaveBeenCalled();
+      });
+
+      it("still records every failure as state, attributed or not", async () => {
+        client.setStatus("connected");
+        client.listAllTools.mockRejectedValueOnce(boom);
+        await expect(state.refresh()).rejects.toThrow(boom);
+        expect(state.getError()).toBe(boom);
+        expect(client.markResponseRejected).not.toHaveBeenCalled();
+      });
     });
 
     it("clears the error once a refresh succeeds", async () => {

--- a/clients/web/src/test/core/mcp/state/managedToolsState.test.ts
+++ b/clients/web/src/test/core/mcp/state/managedToolsState.test.ts
@@ -412,6 +412,110 @@ describe("ManagedToolsState", () => {
     });
   });
 
+  // A failed load used to vanish: the connect-time refresh is fired with no
+  // caller to await it, so its rejection became an unhandled rejection and the
+  // panel just rendered an empty list — indistinguishable from a server with no
+  // tools (#1953).
+  describe("load errors", () => {
+    const boom = new Error("Invalid result for tools/list: ttlMs required");
+
+    function waitForError(state: ManagedToolsState): Promise<Error | null> {
+      return waitForChangeEvent(state, "errorChange");
+    }
+
+    it("starts with no error", () => {
+      expect(state.getError()).toBeNull();
+    });
+
+    it("records a failed refresh as state AND re-throws", async () => {
+      client.setStatus("connected");
+      client.listAllTools.mockRejectedValueOnce(boom);
+
+      // The rejection still propagates: App's auth-recovery wrapper keys off it
+      // to detect a 401 and start a re-authorization.
+      await expect(state.refresh()).rejects.toThrow(boom);
+      expect(state.getError()).toBe(boom);
+    });
+
+    it("dispatches errorChange with the error", async () => {
+      client.setStatus("connected");
+      client.listAllTools.mockRejectedValueOnce(boom);
+      const changed = waitForError(state);
+      await expect(state.refresh()).rejects.toThrow(boom);
+      expect(await changed).toBe(boom);
+    });
+
+    it("wraps a non-Error rejection", async () => {
+      client.setStatus("connected");
+      client.listAllTools.mockRejectedValueOnce("just a string");
+      await expect(state.refresh()).rejects.toBe("just a string");
+      expect(state.getError()).toBeInstanceOf(Error);
+      expect(state.getError()?.message).toBe("just a string");
+    });
+
+    it("attributes the failure to its Protocol entry", async () => {
+      client.setStatus("connected");
+      client.listAllTools.mockRejectedValueOnce(boom);
+      await expect(state.refresh()).rejects.toThrow(boom);
+      expect(client.markResponseRejected).toHaveBeenCalledWith(
+        "tools/list",
+        boom.message,
+      );
+    });
+
+    it("clears the error once a refresh succeeds", async () => {
+      client.setStatus("connected");
+      client.listAllTools.mockRejectedValueOnce(boom);
+      await expect(state.refresh()).rejects.toThrow(boom);
+
+      const cleared = waitForError(state);
+      client.queueToolPages({ tools: [tool("a")] });
+      await state.refresh();
+      expect(await cleared).toBeNull();
+      expect(state.getError()).toBeNull();
+    });
+
+    it("keeps the connect-time failure in state instead of rejecting unobserved", async () => {
+      client.listAllTools.mockRejectedValueOnce(boom);
+      const changed = waitForError(state);
+      await client.connect();
+      expect(await changed).toBe(boom);
+    });
+
+    it("keeps the auto-refresh failure in state instead of rejecting unobserved", async () => {
+      client.setServerSettings(AUTO_REFRESH_SETTINGS);
+      client.setStatus("connected");
+      client.listAllTools.mockRejectedValueOnce(boom);
+      const changed = waitForError(state);
+      client.dispatchTypedEvent("toolsListChanged");
+      expect(await changed).toBe(boom);
+    });
+
+    it("clears the error on disconnect so it can't outlive its session", async () => {
+      client.setStatus("connected");
+      client.listAllTools.mockRejectedValueOnce(boom);
+      await expect(state.refresh()).rejects.toThrow(boom);
+
+      const cleared = waitForError(state);
+      client.setStatus("disconnected");
+      expect(await cleared).toBeNull();
+      expect(state.getError()).toBeNull();
+    });
+
+    it("does not re-dispatch when the same error is recorded twice", async () => {
+      client.setStatus("connected");
+      client.listAllTools.mockRejectedValue(boom);
+      await expect(state.refresh()).rejects.toThrow(boom);
+
+      let fired = 0;
+      state.addEventListener("errorChange", () => {
+        fired++;
+      });
+      await expect(state.refresh()).rejects.toThrow(boom);
+      expect(fired).toBe(0);
+    });
+  });
+
   it("destroy is idempotent", () => {
     state.destroy();
     expect(() => state.destroy()).not.toThrow();

--- a/clients/web/src/test/core/mcp/state/messageLogState.test.ts
+++ b/clients/web/src/test/core/mcp/state/messageLogState.test.ts
@@ -234,4 +234,69 @@ describe("MessageLogState", () => {
     state.destroy();
     expect(() => state.destroy()).not.toThrow();
   });
+
+  // A response the SERVER answered successfully but the CLIENT then refused
+  // (the SDK codec rejecting the result). The frame is a valid JSON-RPC
+  // result, so without the annotation the entry renders as a clean success
+  // (#1953).
+  describe("responseRejected", () => {
+    const REASON = "Invalid result for tools/list: ttlMs required";
+
+    it("annotates the request entry the response was folded into", () => {
+      client.dispatchTypedEvent("message", requestEntry(1));
+      client.dispatchTypedEvent("message", responseEntry(1));
+
+      const seen: MessageEntry[] = [];
+      state.addEventListener("message", (e) => seen.push(e.detail));
+      client.dispatchTypedEvent("responseRejected", { id: 1, reason: REASON });
+
+      expect(state.getMessages()[0]?.clientError).toBe(REASON);
+      expect(seen).toHaveLength(1);
+    });
+
+    it("annotates a standalone response entry with no matching request", () => {
+      client.dispatchTypedEvent("message", responseEntry(7));
+      client.dispatchTypedEvent("responseRejected", { id: 7, reason: REASON });
+
+      expect(state.getMessages()[0]?.clientError).toBe(REASON);
+    });
+
+    it("skips a request still awaiting its response", () => {
+      // Same JSON-RPC id reused after the first exchange completed: the
+      // pending one isn't what was rejected.
+      client.dispatchTypedEvent("message", requestEntry(1));
+      client.dispatchTypedEvent("message", responseEntry(1));
+      client.dispatchTypedEvent("message", requestEntry(1));
+
+      client.dispatchTypedEvent("responseRejected", { id: 1, reason: REASON });
+
+      const [completed, pending] = state.getMessages();
+      expect(pending?.clientError).toBeUndefined();
+      expect(completed?.clientError).toBe(REASON);
+    });
+
+    it("ignores an id that matches no entry", () => {
+      client.dispatchTypedEvent("message", requestEntry(1));
+      client.dispatchTypedEvent("message", responseEntry(1));
+
+      let fired = 0;
+      state.addEventListener("messagesChange", () => {
+        fired++;
+      });
+      client.dispatchTypedEvent("responseRejected", { id: 99, reason: REASON });
+
+      expect(fired).toBe(0);
+      expect(state.getMessages()[0]?.clientError).toBeUndefined();
+    });
+
+    it("never annotates a notification", () => {
+      client.dispatchTypedEvent("message", notificationEntry());
+      client.dispatchTypedEvent("responseRejected", {
+        id: 1,
+        reason: REASON,
+      });
+
+      expect(state.getMessages()[0]?.clientError).toBeUndefined();
+    });
+  });
 });

--- a/clients/web/src/test/core/react/useManagedListError.test.tsx
+++ b/clients/web/src/test/core/react/useManagedListError.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { FakeInspectorClient } from "@inspector/core/mcp/__tests__/fakeInspectorClient";
+import { ManagedToolsState } from "@inspector/core/mcp/state/managedToolsState";
+import { useManagedListError } from "@inspector/core/react/useManagedListError";
+
+// The shared subscription behind the four `useManaged*` hooks' `error` field
+// (#1953). Exercised through ManagedToolsState — any managed list would do,
+// since the error lives entirely in the shared base.
+describe("useManagedListError", () => {
+  let client: FakeInspectorClient;
+  let state: ManagedToolsState;
+  const boom = new Error("Invalid result for tools/list: ttlMs required");
+
+  beforeEach(() => {
+    client = new FakeInspectorClient({
+      status: "connected",
+      capabilities: { tools: {} },
+    });
+    state = new ManagedToolsState(client, 0);
+  });
+
+  it("returns null when there is no state", () => {
+    const { result } = renderHook(() => useManagedListError(null));
+    expect(result.current).toBeNull();
+  });
+
+  it("returns null before any load fails", () => {
+    const { result } = renderHook(() => useManagedListError(state));
+    expect(result.current).toBeNull();
+  });
+
+  it("seeds from an error the state already holds", async () => {
+    client.listAllTools.mockRejectedValueOnce(boom);
+    await expect(state.refresh()).rejects.toThrow(boom);
+
+    const { result } = renderHook(() => useManagedListError(state));
+    expect(result.current).toBe(boom);
+  });
+
+  it("updates when the state dispatches errorChange", async () => {
+    const { result } = renderHook(() => useManagedListError(state));
+
+    client.listAllTools.mockRejectedValueOnce(boom);
+    await act(async () => {
+      await expect(state.refresh()).rejects.toThrow(boom);
+    });
+    expect(result.current).toBe(boom);
+  });
+
+  it("clears when a later load succeeds", async () => {
+    client.listAllTools.mockRejectedValueOnce(boom);
+    await expect(state.refresh()).rejects.toThrow(boom);
+    const { result } = renderHook(() => useManagedListError(state));
+    expect(result.current).toBe(boom);
+
+    await act(async () => {
+      await state.refresh();
+    });
+    expect(result.current).toBeNull();
+  });
+
+  it("resets to null when the state becomes null", async () => {
+    client.listAllTools.mockRejectedValueOnce(boom);
+    await expect(state.refresh()).rejects.toThrow(boom);
+
+    const { result, rerender } = renderHook(
+      ({ s }: { s: ManagedToolsState | null }) => useManagedListError(s),
+      { initialProps: { s: state as ManagedToolsState | null } },
+    );
+    expect(result.current).toBe(boom);
+
+    rerender({ s: null });
+    expect(result.current).toBeNull();
+  });
+
+  it("unsubscribes on unmount", async () => {
+    const { unmount } = renderHook(() => useManagedListError(state));
+    unmount();
+
+    client.listAllTools.mockRejectedValueOnce(boom);
+    // No act() wrapper: a listener still attached would warn about an update
+    // outside act, and the assertion below would be the only other signal.
+    await expect(state.refresh()).rejects.toThrow(boom);
+    expect(state.getError()).toBe(boom);
+  });
+});

--- a/clients/web/src/test/core/react/useManagedListError.test.tsx
+++ b/clients/web/src/test/core/react/useManagedListError.test.tsx
@@ -84,4 +84,29 @@ describe("useManagedListError", () => {
     await expect(state.refresh()).rejects.toThrow(boom);
     expect(state.getError()).toBe(boom);
   });
+
+  // The useState+useEffect subscribe pattern would render one frame carrying
+  // the PREVIOUS store's error here, before the effect re-synced. With
+  // useSyncExternalStore the snapshot is read during render, so the swap lands
+  // in the same frame — asserted immediately after rerender, with no waitFor
+  // and no act() flush, which is what makes it a regression test rather than a
+  // restatement of eventual consistency.
+  it("reflects a store swap in the same frame", async () => {
+    client.listAllTools.mockRejectedValueOnce(boom);
+    await expect(state.refresh()).rejects.toThrow(boom);
+
+    const other = new ManagedToolsState(client, 0);
+
+    const { result, rerender } = renderHook(
+      ({ s }: { s: ManagedToolsState }) => useManagedListError(s),
+      { initialProps: { s: state } },
+    );
+    expect(result.current).toBe(boom);
+
+    rerender({ s: other });
+    expect(result.current).toBeNull();
+
+    rerender({ s: state });
+    expect(result.current).toBe(boom);
+  });
 });

--- a/clients/web/src/test/integration/mcp/inspectorClient-response-rejected.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient-response-rejected.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { InspectorClient } from "@inspector/core/mcp/inspectorClient.js";
+import { MessageLogState } from "@inspector/core/mcp/state/index.js";
+import { createTransportNode } from "@inspector/core/mcp/node/transport.js";
+import { getTestMcpServerCommand } from "@modelcontextprotocol/inspector-test-server";
+import type { MessageEntry } from "@inspector/core/mcp/types.js";
+
+/**
+ * `markResponseRejected` correlation (#1953).
+ *
+ * A response the server answered successfully but the client then refused (the
+ * SDK codec rejecting the result for the negotiated era) carries no request id
+ * in the SDK's error, so the client recovers it from the last response received
+ * for that method. These tests drive a REAL connection so the correlation runs
+ * against real JSON-RPC ids assigned by the SDK, not hand-built fixtures.
+ */
+describe("InspectorClient.markResponseRejected", () => {
+  let client: InspectorClient | null = null;
+  let log: MessageLogState | null = null;
+
+  beforeEach(async () => {
+    const serverCommand = getTestMcpServerCommand();
+    client = new InspectorClient(
+      {
+        type: "stdio",
+        command: serverCommand.command,
+        args: serverCommand.args,
+      },
+      { environment: { transport: createTransportNode } },
+    );
+    log = new MessageLogState(client);
+    await client.connect();
+  });
+
+  afterEach(async () => {
+    log?.destroy();
+    log = null;
+    try {
+      await client?.disconnect();
+    } catch {
+      // Ignore teardown failures — the assertion already ran.
+    }
+    client = null;
+  });
+
+  function entriesFor(method: string): MessageEntry[] {
+    return (log?.getMessages() ?? []).filter(
+      (entry) => "method" in entry.message && entry.message.method === method,
+    );
+  }
+
+  it("annotates the entry for the method's most recent response", async () => {
+    await client!.listTools();
+    const before = entriesFor("tools/list");
+    expect(before).toHaveLength(1);
+    expect(before[0]?.clientError).toBeUndefined();
+
+    client!.markResponseRejected("tools/list", "ttlMs required");
+
+    expect(entriesFor("tools/list")[0]?.clientError).toBe("ttlMs required");
+  });
+
+  it("annotates only the latest call, leaving earlier ones untouched", async () => {
+    await client!.listTools();
+    await client!.listTools();
+    const entries = entriesFor("tools/list");
+    expect(entries).toHaveLength(2);
+
+    client!.markResponseRejected("tools/list", "second one failed");
+
+    expect(entries[0]?.clientError).toBeUndefined();
+    expect(entries[1]?.clientError).toBe("second one failed");
+  });
+
+  it("does not cross method boundaries", async () => {
+    await client!.listTools();
+    await client!.listPrompts();
+
+    client!.markResponseRejected("tools/list", "tools failed");
+
+    expect(entriesFor("tools/list")[0]?.clientError).toBe("tools failed");
+    expect(entriesFor("prompts/list")[0]?.clientError).toBeUndefined();
+  });
+
+  it("is a no-op for a method nothing has answered", () => {
+    // No throw, and nothing annotated — a list that never reached the wire
+    // (e.g. a capability-gated one) must not mislabel some other entry.
+    expect(() =>
+      client!.markResponseRejected("resources/list", "never happened"),
+    ).not.toThrow();
+    expect((log?.getMessages() ?? []).some((entry) => entry.clientError)).toBe(
+      false,
+    );
+  });
+});

--- a/core/mcp/__tests__/fakeInspectorClient.ts
+++ b/core/mcp/__tests__/fakeInspectorClient.ts
@@ -133,6 +133,10 @@ export class FakeInspectorClient
     return this.tasksExtensionNegotiated;
   }
 
+  // Attributes a failed load back to its Protocol entry (#1953). A `vi.fn` so
+  // tests can assert the method name and reason a failing refresh reported.
+  markResponseRejected = vi.fn((_method: string, _reason: string) => {});
+
   // Aggregate variants used by the managed state stores on refresh: drain ALL
   // queued pages (mimicking the SDK's all-page walk) and return the flattened
   // list. The `options` (incl. `cacheMode`) is recorded by the `vi.fn` so tests

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -358,6 +358,13 @@ export class InspectorClient extends InspectorClientEventTarget {
   private outputValidator: AjvJsonSchemaValidator | null = null;
   private transport: Transport | MessageTrackingTransport | null = null;
   private baseTransport: Transport | null = null;
+  // Correlation for `markResponseRejected` (#1953): the method of each
+  // outbound request still awaiting a response, and — once one is answered —
+  // the id of the most recently answered request per method. Entries are
+  // dropped as responses arrive, so this holds at most one id per method
+  // rather than growing with the session.
+  private outboundRequestMethods = new Map<string | number, string>();
+  private lastAnsweredRequestByMethod = new Map<string, string | number>();
   /** True when the cached transport was built with an OAuth authProvider attached. */
   private transportHasAuthProvider = false;
   /** Dedupes concurrent ambient auth challenges (reason + scopes). */
@@ -786,6 +793,9 @@ export class InspectorClient extends InspectorClientEventTarget {
   private createMessageTrackingCallbacks(): MessageTrackingCallbacks {
     return {
       trackRequest: (message: JSONRPCRequest, origin: MessageOrigin) => {
+        if (origin === "client") {
+          this.outboundRequestMethods.set(message.id, message.method);
+        }
         const entry: MessageEntry = {
           id: crypto.randomUUID(),
           timestamp: new Date(),
@@ -799,6 +809,19 @@ export class InspectorClient extends InspectorClientEventTarget {
         message: JSONRPCResultResponse | JSONRPCErrorResponse,
         origin: MessageOrigin,
       ) => {
+        // A response to one of OUR requests closes that id's correlation entry
+        // and becomes the method's most recent answer (#1953). The transport
+        // only tracks responses that carry an id, but the JSON-RPC types leave
+        // it optional for an error frame the server couldn't attribute — such a
+        // frame answers no specific request, so it is skipped.
+        const responseId = message.id;
+        if (origin === "server" && responseId !== undefined) {
+          const method = this.outboundRequestMethods.get(responseId);
+          this.outboundRequestMethods.delete(responseId);
+          if (method !== undefined) {
+            this.lastAnsweredRequestByMethod.set(method, responseId);
+          }
+        }
         const entry: MessageEntry = {
           id: crypto.randomUUID(),
           timestamp: new Date(),
@@ -3080,8 +3103,17 @@ export class InspectorClient extends InspectorClientEventTarget {
     // reflect the current wire truth. Accepted for a debugging tool where the
     // list is small and correctness of "why did this tool vanish" matters more
     // than the extra request; it's a no-op (no round trip) on legacy/stdio.
-    // Kept best-effort: an error here must never fail the tools list itself.
-    await this.refreshExcludedTools(options?.metadata).catch(() => {});
+    // Kept best-effort: an error here must never fail the tools list itself —
+    // but it is logged rather than dropped on the floor, so a failing
+    // excluded-tools walk is diagnosable instead of silently leaving the
+    // "Excluded (SEP-2243)" section empty and looking like a clean server
+    // (#1953).
+    await this.refreshExcludedTools(options?.metadata).catch((err: unknown) => {
+      this.logger.warn(
+        { err },
+        "Excluded-tools walk failed; the SEP-2243 excluded list may be incomplete",
+      );
+    });
     return { tools: [...response.tools] };
   }
 
@@ -3093,6 +3125,27 @@ export class InspectorClient extends InspectorClientEventTarget {
    */
   private excludesInvalidXMcpHeaderTools(): boolean {
     return this.isModernEra() && this.getServerType() !== "stdio";
+  }
+
+  /**
+   * Mark the response that most recently answered `method` as rejected by the
+   * client, so its Protocol entry shows why instead of rendering as a clean
+   * success (#1953).
+   *
+   * The SDK gives no request id with a decode failure — `SdkError` carries the
+   * method and nothing else — so the id is recovered by correlation: the last
+   * response received for that method. That is exact rather than approximate,
+   * because the SDK rejects synchronously while decoding the response (inside
+   * the transport's `onmessage`) and the caller's `catch` runs in the very next
+   * microtask. Delivering another response for the same method in that window
+   * would take a macrotask (a socket read), which cannot interleave there.
+   *
+   * A no-op when nothing has answered `method` this session.
+   */
+  markResponseRejected(method: string, reason: string): void {
+    const id = this.lastAnsweredRequestByMethod.get(method);
+    if (id === undefined) return;
+    this.dispatchTypedEvent("responseRejected", { id, reason });
   }
 
   /** The current SEP-2243 excluded-tools set (empty on legacy/stdio). */

--- a/core/mcp/inspectorClient.ts
+++ b/core/mcp/inspectorClient.ts
@@ -1581,6 +1581,17 @@ export class InspectorClient extends InspectorClientEventTarget {
     this.clearReceiverTasks();
     this.resetSubscriptionStream();
     this.cancelledTaskIds.clear();
+    // Correlation data is per-session: JSON-RPC ids don't survive it, and
+    // MessageLogState drops its entries on disconnect, so anything left here
+    // could only point at an entry that no longer exists. Clearing also
+    // releases the ids of requests that never got a response (a timeout, a
+    // dropped connection) — the only entries `trackResponse` can't remove, so
+    // without this they accumulate across reconnects. Cleared here on the
+    // start-clean path rather than in `disconnect()` for the reason documented
+    // above: one route out (`onerror` with no `onclose`) tears down nothing
+    // (#1953).
+    this.outboundRequestMethods.clear();
+    this.lastAnsweredRequestByMethod.clear();
     for (const [, controller] of this.taskInputAbortControllers) {
       controller.abort(new Error("Connection ended"));
     }

--- a/core/mcp/inspectorClientEventTarget.ts
+++ b/core/mcp/inspectorClientEventTarget.ts
@@ -71,6 +71,15 @@ export interface InspectorClientEventMap {
   /** `server/discover` result on a probed/pinned connect; undefined on legacy. */
   discoverResultChange: DiscoverResult | undefined;
   message: MessageEntry;
+  /**
+   * A response the client REJECTED after it was logged — the server answered,
+   * but the SDK's era codec refused the result (e.g. a 2026-07-28 `tools/list`
+   * missing `ttlMs`/`cacheScope`). The wire frame is a valid JSON-RPC result,
+   * so the Protocol entry would otherwise render as a clean success; this
+   * carries the reason so it can be marked instead (#1953). `id` is the
+   * JSON-RPC id of the rejected response.
+   */
+  responseRejected: { id: string | number; reason: string };
   stderrLog: StderrLogEntry;
   fetchRequest: FetchRequestEntry;
   /** Fired when an in-flight fetch's response body is read asynchronously. */

--- a/core/mcp/inspectorClientProtocol.ts
+++ b/core/mcp/inspectorClientProtocol.ts
@@ -105,6 +105,15 @@ export interface InspectorClientProtocol extends InspectorClientEventTarget {
    * and the modern task store's poll-based refresh. */
   isTasksExtensionNegotiated(): boolean;
 
+  /**
+   * Mark the response that most recently answered `method` as rejected by the
+   * client, so its Protocol entry shows the reason instead of rendering as a
+   * clean success (#1953). Optional so existing test doubles satisfy the
+   * interface without implementing it; see `InspectorClient` for how the id is
+   * correlated and why that correlation is exact.
+   */
+  markResponseRejected?(method: string, reason: string): void;
+
   // Aggregate (all-page) list methods used by the managed state stores on
   // refresh. Unlike the single-page methods above, these route through the
   // SDK's cache-aware high-level verbs so `cacheMode` ('use' | 'refresh' |

--- a/core/mcp/state/managedListState.ts
+++ b/core/mcp/state/managedListState.ts
@@ -17,6 +17,7 @@ import type {
   CacheMode,
   ServerCapabilities,
 } from "@modelcontextprotocol/client";
+import { SdkError, SdkErrorCode } from "@modelcontextprotocol/client";
 import { isTerminalStatus } from "../types.js";
 import { TypedEventTarget } from "../typedEventTarget.js";
 
@@ -28,6 +29,38 @@ import { TypedEventTarget } from "../typedEventTarget.js";
  * (#1444).
  */
 export const DEFAULT_LIST_CHANGED_DEBOUNCE_MS = 250;
+
+/**
+ * Whether a failed fetch is the CLIENT refusing a response it received, rather
+ * than the request never producing one.
+ *
+ * This gates `markResponseRejected`, and the distinction is load-bearing. That
+ * correlation recovers the request id as "the last response received for this
+ * method", which is only the failing exchange when a response actually just
+ * arrived and was refused while decoding. A transport drop, a timeout, or an
+ * aborted request produces no response frame at all — the last-answered id then
+ * still points at some EARLIER, successful call, and marking it would stamp
+ * "Rejected by the Inspector" onto an exchange that succeeded. That is the very
+ * class of lie this issue exists to remove, so it must not be traded for
+ * another one.
+ *
+ * A server-sent JSON-RPC error is excluded for a different reason: it is a real
+ * response, so the id would be right, but the failure is the server's. Its
+ * entry already renders as an error from the error frame itself, and blaming
+ * the Inspector for it would misattribute the cause.
+ *
+ * `SdkErrorCode.InvalidResult` is exactly "a result arrived and failed
+ * validation for the negotiated era"; `UnsupportedResultType` is its sibling
+ * for a `resultType` the codec has no handling for. Both are decisions the
+ * client made about a frame in hand.
+ */
+function isClientDecodeRejection(err: unknown): boolean {
+  return (
+    SdkError.isInstance(err) &&
+    (err.code === SdkErrorCode.InvalidResult ||
+      err.code === SdkErrorCode.UnsupportedResultType)
+  );
+}
 
 /**
  * Every managed-list event map carries the list-changed indicator event and the
@@ -310,11 +343,14 @@ export abstract class ManagedListState<
       // Attribute the failure to the response it came from, so the Protocol
       // entry stops rendering a rejected result as a clean success (#1953).
       // Must happen in this catch, while the correlation window the client
-      // documents is still valid.
-      this.client?.markResponseRejected?.(
-        this.config.listMethod,
-        error.message,
-      );
+      // documents is still valid — and ONLY for a decode rejection, see
+      // `isClientDecodeRejection`.
+      if (isClientDecodeRejection(err)) {
+        this.client?.markResponseRejected?.(
+          this.config.listMethod,
+          error.message,
+        );
+      }
       throw err;
     }
     this.setError(null);

--- a/core/mcp/state/managedListState.ts
+++ b/core/mcp/state/managedListState.ts
@@ -29,12 +29,29 @@ import { TypedEventTarget } from "../typedEventTarget.js";
  */
 export const DEFAULT_LIST_CHANGED_DEBOUNCE_MS = 250;
 
-/** Every managed-list event map carries the list-changed indicator event. */
+/**
+ * Every managed-list event map carries the list-changed indicator event and the
+ * last-fetch error (#1953).
+ */
 export interface ManagedListEventMap {
+  /**
+   * Fires when the "list changed since last refresh" flag flips. True when
+   * this list's `list_changed` notification arrives (auto-refresh off), false
+   * once the user refreshes or the connection drops. Drives the sidebar
+   * list-changed indicator (#1402).
+   */
   listChangedChange: boolean;
+  /** The last fetch's failure, or `null` once a fetch succeeds. */
+  errorChange: Error | null;
 }
 
 export interface ManagedListConfig<T, M extends ManagedListEventMap> {
+  /**
+   * The JSON-RPC method this list pages (e.g. "tools/list"). Used to attribute
+   * a failed load back to its Protocol entry — see
+   * `InspectorClientProtocol.markResponseRejected` (#1953).
+   */
+  listMethod: string;
   /** The `*Change` event this manager dispatches (e.g. "toolsChange"). */
   changeEvent: keyof M;
   /** The client notification that signals the list changed. */
@@ -81,6 +98,11 @@ export abstract class ManagedListState<
   private unsubscribe: (() => void) | null = null;
   private _metadata: Record<string, string> | undefined = undefined;
   private listChanged = false;
+  // The last fetch's failure, kept as observable state so a load that fails
+  // (a transport error, or a result the SDK codec rejects as invalid) is
+  // rendered by the list panel instead of vanishing into an unhandled
+  // rejection — which read as "this server has no tools" (#1953).
+  private error: Error | null = null;
   private readonly config: ManagedListConfig<T, M>;
   // Debounce a burst of `list_changed` notifications into a single
   // refresh (or one indicator light) once it settles.
@@ -112,7 +134,11 @@ export abstract class ManagedListState<
       ) {
         return;
       }
-      void this.refresh();
+      // The connect-time load has no caller to await it, so its rejection is
+      // caught here rather than left to become an unhandled rejection. This is
+      // not a swallow: `refresh` has already recorded the failure via
+      // `setError`, and the list panel renders it (#1953).
+      void this.refresh().catch(() => {});
     };
     const onListChanged = (): void => {
       // Debounce: collapse a burst of notifications into one settled action
@@ -133,6 +159,9 @@ export abstract class ManagedListState<
         this.items = [];
         this.dispatchChange();
         this.setListChanged(false);
+        // A disconnect ends the session the error belonged to — a stale
+        // "couldn't load tools" must not outlive it into the next connect.
+        this.setError(null);
       }
     };
     this.client.addEventListener("connect", onConnect);
@@ -187,8 +216,10 @@ export abstract class ManagedListState<
         if (!skipAggregate && settings?.autoRefreshOnListChanged) {
           // A `list_changed` means the prior list is stale, so bypass any
           // cached entry (`cacheMode: "refresh"`) and re-store the fresh
-          // aggregate.
-          await this.refresh(undefined, "refresh");
+          // aggregate. Like the connect-time load this has no caller to await
+          // it, so a failure is caught here — already recorded by `setError`
+          // and rendered by the panel (#1953).
+          await this.refresh(undefined, "refresh").catch(() => {});
         } else if (this.config.supportsIndicator) {
           this.setListChanged(true);
         }
@@ -236,6 +267,20 @@ export abstract class ManagedListState<
     this.emit("listChangedChange", value);
   }
 
+  /** The last fetch's failure, or `null` when the last fetch succeeded. */
+  getError(): Error | null {
+    return this.error;
+  }
+
+  // Compared by identity rather than message: two distinct failures with the
+  // same text are still two events, and a re-render on a repeat failure is
+  // cheap next to silently coalescing them.
+  private setError(value: Error | null): void {
+    if (this.error === value) return;
+    this.error = value;
+    this.emit("errorChange", value);
+  }
+
   setMetadata(metadata?: Record<string, string>): void {
     this._metadata = metadata;
   }
@@ -245,12 +290,34 @@ export abstract class ManagedListState<
    * this fetch: `undefined` (the connect-time load) uses the default `'use'`;
    * a user-initiated or auto refresh passes `'refresh'` to force a
    * cache-bypassing round trip and re-store the fresh aggregate.
+   *
+   * A failure is recorded as observable state (`getError`) AND re-thrown: the
+   * state drives the panel's error rendering, while the rejection is what the
+   * caller's auth-recovery wrapper keys off to detect a 401 and start a
+   * re-authorization. Callers with nobody to await them (the connect-time load,
+   * the `list_changed` auto-refresh) catch it explicitly (#1953).
    */
   async refresh(
     metadata?: Record<string, string>,
     cacheMode?: CacheMode,
   ): Promise<T[]> {
-    const next = await this.fetchItems(metadata, cacheMode);
+    let next: T[] | null;
+    try {
+      next = await this.fetchItems(metadata, cacheMode);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.setError(error);
+      // Attribute the failure to the response it came from, so the Protocol
+      // entry stops rendering a rejected result as a clean success (#1953).
+      // Must happen in this catch, while the correlation window the client
+      // documents is still valid.
+      this.client?.markResponseRejected?.(
+        this.config.listMethod,
+        error.message,
+      );
+      throw err;
+    }
+    this.setError(null);
     // `null` means not connected — leave the current list untouched.
     if (next === null) return this.getItems();
     this.applyItems(next);

--- a/core/mcp/state/managedPromptsState.ts
+++ b/core/mcp/state/managedPromptsState.ts
@@ -8,17 +8,11 @@ import type { Prompt } from "@modelcontextprotocol/client";
 import {
   ManagedListState,
   DEFAULT_LIST_CHANGED_DEBOUNCE_MS,
+  type ManagedListEventMap,
 } from "./managedListState.js";
 
-export interface ManagedPromptsStateEventMap {
+export interface ManagedPromptsStateEventMap extends ManagedListEventMap {
   promptsChange: Prompt[];
-  /**
-   * Fires when the "list changed since last refresh" flag flips. True when a
-   * `prompts/list_changed` arrives (auto-refresh off), false once the user
-   * refreshes or the connection drops. Drives the sidebar list-changed
-   * indicator (#1402).
-   */
-  listChangedChange: boolean;
 }
 
 export class ManagedPromptsState extends ManagedListState<
@@ -30,6 +24,7 @@ export class ManagedPromptsState extends ManagedListState<
     debounceMs = DEFAULT_LIST_CHANGED_DEBOUNCE_MS,
   ) {
     super(client, {
+      listMethod: "prompts/list",
       changeEvent: "promptsChange",
       listChangedEvent: "promptsListChanged",
       capabilityKey: "prompts",

--- a/core/mcp/state/managedResourceTemplatesState.ts
+++ b/core/mcp/state/managedResourceTemplatesState.ts
@@ -15,15 +15,11 @@ import type { ResourceTemplateType as ResourceTemplate } from "@modelcontextprot
 import {
   ManagedListState,
   DEFAULT_LIST_CHANGED_DEBOUNCE_MS,
+  type ManagedListEventMap,
 } from "./managedListState.js";
 
-export interface ManagedResourceTemplatesStateEventMap {
+export interface ManagedResourceTemplatesStateEventMap extends ManagedListEventMap {
   resourceTemplatesChange: ResourceTemplate[];
-  /**
-   * Carried only to satisfy the ManagedListState base; templates have no
-   * indicator, so this never fires.
-   */
-  listChangedChange: boolean;
 }
 
 export class ManagedResourceTemplatesState extends ManagedListState<
@@ -35,6 +31,7 @@ export class ManagedResourceTemplatesState extends ManagedListState<
     debounceMs = DEFAULT_LIST_CHANGED_DEBOUNCE_MS,
   ) {
     super(client, {
+      listMethod: "resources/templates/list",
       changeEvent: "resourceTemplatesChange",
       listChangedEvent: "resourceTemplatesListChanged",
       // Templates are gated on the broader `resources` capability.

--- a/core/mcp/state/managedResourcesState.ts
+++ b/core/mcp/state/managedResourcesState.ts
@@ -8,17 +8,11 @@ import type { Resource } from "@modelcontextprotocol/client";
 import {
   ManagedListState,
   DEFAULT_LIST_CHANGED_DEBOUNCE_MS,
+  type ManagedListEventMap,
 } from "./managedListState.js";
 
-export interface ManagedResourcesStateEventMap {
+export interface ManagedResourcesStateEventMap extends ManagedListEventMap {
   resourcesChange: Resource[];
-  /**
-   * Fires when the "list changed since last refresh" flag flips. True when a
-   * `resources/list_changed` arrives (auto-refresh off), false once the user
-   * refreshes or the connection drops. Drives the list-changed indicator
-   * (#1402).
-   */
-  listChangedChange: boolean;
 }
 
 export class ManagedResourcesState extends ManagedListState<
@@ -30,6 +24,7 @@ export class ManagedResourcesState extends ManagedListState<
     debounceMs = DEFAULT_LIST_CHANGED_DEBOUNCE_MS,
   ) {
     super(client, {
+      listMethod: "resources/list",
       changeEvent: "resourcesChange",
       listChangedEvent: "resourcesListChanged",
       capabilityKey: "resources",

--- a/core/mcp/state/managedToolsState.ts
+++ b/core/mcp/state/managedToolsState.ts
@@ -8,17 +8,11 @@ import type { Tool } from "@modelcontextprotocol/client";
 import {
   ManagedListState,
   DEFAULT_LIST_CHANGED_DEBOUNCE_MS,
+  type ManagedListEventMap,
 } from "./managedListState.js";
 
-export interface ManagedToolsStateEventMap {
+export interface ManagedToolsStateEventMap extends ManagedListEventMap {
   toolsChange: Tool[];
-  /**
-   * Fires when the "list changed since last refresh" flag flips. True when a
-   * `tools/list_changed` arrives (auto-refresh off), false once the user
-   * refreshes or the connection drops. Drives the sidebar list-changed
-   * indicator (#1402).
-   */
-  listChangedChange: boolean;
 }
 
 export class ManagedToolsState extends ManagedListState<
@@ -30,6 +24,7 @@ export class ManagedToolsState extends ManagedListState<
     debounceMs = DEFAULT_LIST_CHANGED_DEBOUNCE_MS,
   ) {
     super(client, {
+      listMethod: "tools/list",
       changeEvent: "toolsChange",
       listChangedEvent: "toolsListChanged",
       capabilityKey: "tools",

--- a/core/mcp/state/messageLogState.ts
+++ b/core/mcp/state/messageLogState.ts
@@ -98,6 +98,31 @@ export class MessageLogState extends TypedEventTarget<MessageLogStateEventMap> {
       pushEntry(entry);
     };
 
+    // A response the client rejected after the fact (the wire frame was valid
+    // JSON-RPC, but the SDK codec refused the result). Annotate the entry that
+    // carries that JSON-RPC id so it stops rendering as a clean success — the
+    // request entry when the response was folded into it, otherwise the
+    // standalone response entry. Searched newest-first: ids are unique within
+    // a session, and the failing exchange is by construction a recent one.
+    const onResponseRejected = (
+      event: TypedEventGeneric<InspectorClientEventMap, "responseRejected">,
+    ): void => {
+      const { id, reason } = event.detail;
+      for (let i = this.messages.length - 1; i >= 0; i--) {
+        const entry = this.messages[i]!;
+        const entryId = (entry.message as { id?: string | number }).id;
+        if (entryId !== id) continue;
+        if (entry.direction === "notification") continue;
+        // A request entry with no response yet isn't the one being rejected —
+        // keep looking for the standalone response frame.
+        if (entry.direction === "request" && !entry.response) continue;
+        entry.clientError = reason;
+        this.dispatchTypedEvent("message", entry);
+        this.dispatchTypedEvent("messagesChange", this.getMessages());
+        return;
+      }
+    };
+
     const onStatusChange = (): void => {
       if (isTerminalStatus(this.client?.getStatus())) {
         this.messages = [];
@@ -106,10 +131,12 @@ export class MessageLogState extends TypedEventTarget<MessageLogStateEventMap> {
       }
     };
     this.client.addEventListener("message", onMessage);
+    this.client.addEventListener("responseRejected", onResponseRejected);
     this.client.addEventListener("statusChange", onStatusChange);
     this.unsubscribe = () => {
       if (this.client) {
         this.client.removeEventListener("message", onMessage);
+        this.client.removeEventListener("responseRejected", onResponseRejected);
         this.client.removeEventListener("statusChange", onStatusChange);
       }
       this.client = null;

--- a/core/mcp/types.ts
+++ b/core/mcp/types.ts
@@ -285,6 +285,14 @@ export interface MessageEntry {
     | JSONRPCErrorResponse;
   response?: JSONRPCResultResponse | JSONRPCErrorResponse;
   duration?: number; // Time between request and response in ms
+  /**
+   * Why the CLIENT rejected an otherwise well-formed response — e.g. the SDK's
+   * era codec refusing a 2026-07-28 `tools/list` result that omits
+   * `ttlMs`/`cacheScope`. Distinct from a JSON-RPC `error` response: the server
+   * answered successfully and the wire frame is valid, so without this the
+   * entry renders as a clean success even though the call failed (#1953).
+   */
+  clientError?: string;
 }
 
 /** Method name for any MessageEntry traffic, plus synthetic "response" for result/error entries. */

--- a/core/react/useManagedListError.ts
+++ b/core/react/useManagedListError.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import type { ManagedListEventMap } from "../mcp/state/managedListState.js";
 import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
 
@@ -30,28 +30,39 @@ export interface ManagedListErrorSource {
  * Shared by the four `useManaged*` hooks so a list load that fails — including
  * the connect-time one, which has no caller to await it — reaches the UI
  * instead of only the console. `null` means the last fetch succeeded.
+ *
+ * Built on `useSyncExternalStore` rather than the `useState` + `useEffect`
+ * subscribe pattern the sibling hooks use. Re-syncing state from the `state`
+ * prop inside an effect would render one frame carrying the PREVIOUS store's
+ * error after `state` changes (switching servers) before the effect corrects
+ * it — the "don't derive state from props in an effect" rule in AGENTS.md.
+ * `useSyncExternalStore` has no such window: the snapshot is read during
+ * render, so a store swap is reflected in the same frame, and it also closes
+ * the gap where an error recorded between render and subscribe would be missed.
+ *
+ * The snapshot must be referentially stable across reads that mean "no change",
+ * which it is: it returns the stored `Error` instance itself (or `null`), never
+ * a fresh object.
  */
 export function useManagedListError(
   state: ManagedListErrorSource | null,
 ): Error | null {
-  const [error, setError] = useState<Error | null>(state?.getError() ?? null);
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!state) return () => {};
+      const listener = () => onStoreChange();
+      state.addEventListener("errorChange", listener);
+      return () => {
+        state.removeEventListener("errorChange", listener);
+      };
+    },
+    [state],
+  );
 
-  useEffect(() => {
-    if (!state) {
-      setError(null);
-      return;
-    }
-    setError(state.getError());
-    const onErrorChange = (
-      event: TypedEventGeneric<ManagedListEventMap, "errorChange">,
-    ) => {
-      setError(event.detail);
-    };
-    state.addEventListener("errorChange", onErrorChange);
-    return () => {
-      state.removeEventListener("errorChange", onErrorChange);
-    };
-  }, [state]);
+  const getSnapshot = useCallback(() => state?.getError() ?? null, [state]);
 
-  return error;
+  // Server snapshot: same read. The stores are browser/Node runtime objects
+  // with no SSR path, and passing the same getter keeps hydration consistent
+  // rather than throwing on a server render.
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/core/react/useManagedListError.ts
+++ b/core/react/useManagedListError.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from "react";
+import type { ManagedListEventMap } from "../mcp/state/managedListState.js";
+import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+
+/**
+ * The slice of a managed list state this hook needs. Declared structurally
+ * rather than as `ManagedListState<T, M>` so the four list hooks can share it
+ * without threading their item type through — the error is the same shape for
+ * all of them.
+ */
+export interface ManagedListErrorSource {
+  getError(): Error | null;
+  addEventListener(
+    type: "errorChange",
+    listener: (
+      event: TypedEventGeneric<ManagedListEventMap, "errorChange">,
+    ) => void,
+  ): void;
+  removeEventListener(
+    type: "errorChange",
+    listener: (
+      event: TypedEventGeneric<ManagedListEventMap, "errorChange">,
+    ) => void,
+  ): void;
+}
+
+/**
+ * Subscribe to a managed list state's last-fetch error (#1953).
+ *
+ * Shared by the four `useManaged*` hooks so a list load that fails — including
+ * the connect-time one, which has no caller to await it — reaches the UI
+ * instead of only the console. `null` means the last fetch succeeded.
+ */
+export function useManagedListError(
+  state: ManagedListErrorSource | null,
+): Error | null {
+  const [error, setError] = useState<Error | null>(state?.getError() ?? null);
+
+  useEffect(() => {
+    if (!state) {
+      setError(null);
+      return;
+    }
+    setError(state.getError());
+    const onErrorChange = (
+      event: TypedEventGeneric<ManagedListEventMap, "errorChange">,
+    ) => {
+      setError(event.detail);
+    };
+    state.addEventListener("errorChange", onErrorChange);
+    return () => {
+      state.removeEventListener("errorChange", onErrorChange);
+    };
+  }, [state]);
+
+  return error;
+}

--- a/core/react/useManagedPrompts.ts
+++ b/core/react/useManagedPrompts.ts
@@ -6,8 +6,15 @@ import type {
 } from "../mcp/state/managedPromptsState.js";
 import type { Prompt } from "@modelcontextprotocol/client";
 import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+import { useManagedListError } from "./useManagedListError.js";
 
 export interface UseManagedPromptsResult {
+  /**
+   * The last fetch's failure (transport error, or a result the SDK codec
+   * rejected), or `null` when it succeeded. Includes the connect-time load,
+   * whose failure has no caller to surface it (#1953).
+   */
+  error: Error | null;
   prompts: Prompt[];
   /** True when a `prompts/list_changed` arrived since the last user refresh. */
   listChanged: boolean;
@@ -65,6 +72,8 @@ export function useManagedPrompts(
     };
   }, [managedPromptsState]);
 
+  const error = useManagedListError(managedPromptsState);
+
   const refresh = useCallback(async (): Promise<Prompt[]> => {
     if (!managedPromptsState || !client) return [];
     // A user-initiated refresh acknowledges the change — clear the indicator
@@ -85,5 +94,5 @@ export function useManagedPrompts(
     managedPromptsState?.clearListChanged();
   }, [managedPromptsState]);
 
-  return { prompts, listChanged, refresh, clearListChanged };
+  return { prompts, error, listChanged, refresh, clearListChanged };
 }

--- a/core/react/useManagedResourceTemplates.ts
+++ b/core/react/useManagedResourceTemplates.ts
@@ -6,8 +6,15 @@ import type {
 } from "../mcp/state/managedResourceTemplatesState.js";
 import type { ResourceTemplateType as ResourceTemplate } from "@modelcontextprotocol/client";
 import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+import { useManagedListError } from "./useManagedListError.js";
 
 export interface UseManagedResourceTemplatesResult {
+  /**
+   * The last fetch's failure (transport error, or a result the SDK codec
+   * rejected), or `null` when it succeeded. Includes the connect-time load,
+   * whose failure has no caller to surface it (#1953).
+   */
+  error: Error | null;
   resourceTemplates: ResourceTemplate[];
   refresh: () => Promise<ResourceTemplate[]>;
 }
@@ -50,6 +57,8 @@ export function useManagedResourceTemplates(
     };
   }, [managedResourceTemplatesState]);
 
+  const error = useManagedListError(managedResourceTemplatesState);
+
   const refresh = useCallback(async (): Promise<ResourceTemplate[]> => {
     if (!managedResourceTemplatesState || !client) return [];
     // A user-initiated refresh forces a cache-bypassing round trip
@@ -63,5 +72,5 @@ export function useManagedResourceTemplates(
     return next;
   }, [client, managedResourceTemplatesState]);
 
-  return { resourceTemplates, refresh };
+  return { resourceTemplates, error, refresh };
 }

--- a/core/react/useManagedResources.ts
+++ b/core/react/useManagedResources.ts
@@ -6,8 +6,15 @@ import type {
 } from "../mcp/state/managedResourcesState.js";
 import type { Resource } from "@modelcontextprotocol/client";
 import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+import { useManagedListError } from "./useManagedListError.js";
 
 export interface UseManagedResourcesResult {
+  /**
+   * The last fetch's failure (transport error, or a result the SDK codec
+   * rejected), or `null` when it succeeded. Includes the connect-time load,
+   * whose failure has no caller to surface it (#1953).
+   */
+  error: Error | null;
   resources: Resource[];
   /**
    * True when a `resources/list_changed` arrived since the last user refresh.
@@ -76,6 +83,8 @@ export function useManagedResources(
     };
   }, [managedResourcesState]);
 
+  const error = useManagedListError(managedResourcesState);
+
   const refresh = useCallback(async (): Promise<Resource[]> => {
     if (!managedResourcesState || !client) return [];
     // A user-initiated refresh acknowledges the change — clear the indicator
@@ -96,5 +105,5 @@ export function useManagedResources(
     managedResourcesState?.clearListChanged();
   }, [managedResourcesState]);
 
-  return { resources, listChanged, refresh, clearListChanged };
+  return { resources, error, listChanged, refresh, clearListChanged };
 }

--- a/core/react/useManagedTools.ts
+++ b/core/react/useManagedTools.ts
@@ -4,8 +4,15 @@ import type { ManagedToolsState } from "../mcp/state/managedToolsState.js";
 import type { ManagedToolsStateEventMap } from "../mcp/state/managedToolsState.js";
 import type { Tool } from "@modelcontextprotocol/client";
 import type { TypedEventGeneric } from "../mcp/typedEventTarget.js";
+import { useManagedListError } from "./useManagedListError.js";
 
 export interface UseManagedToolsResult {
+  /**
+   * The last fetch's failure (transport error, or a result the SDK codec
+   * rejected), or `null` when it succeeded. Includes the connect-time load,
+   * whose failure has no caller to surface it (#1953).
+   */
+  error: Error | null;
   tools: Tool[];
   /** True when a `tools/list_changed` arrived since the last user refresh. */
   listChanged: boolean;
@@ -65,6 +72,8 @@ export function useManagedTools(
     };
   }, [managedToolsState]);
 
+  const error = useManagedListError(managedToolsState);
+
   const refresh = useCallback(async (): Promise<Tool[]> => {
     if (!managedToolsState || !client) return [];
     // A user-initiated refresh acknowledges the change — clear the indicator
@@ -85,5 +94,5 @@ export function useManagedTools(
     managedToolsState?.clearListChanged();
   }, [managedToolsState]);
 
-  return { tools, listChanged, refresh, clearListChanged };
+  return { tools, error, listChanged, refresh, clearListChanged };
 }


### PR DESCRIPTION
Closes #1953

A list load that failed reported nothing. `ManagedListState` fires the connect-time refresh with no caller to await it (`void this.refresh()`), so a rejection became an unhandled rejection — the header said **Connected**, the panel rendered an **empty list** indistinguishable from a server that legitimately has none, and the failed exchange appeared in the Protocol panel as a **clean success**. The only trace was a console error.

That is the bug misreported in #1893 as "replay validates more strictly than the initial call": the two are validated identically, but only the replay path surfaced the error (as a toast).

## What changed

**The panel says what happened.** `ManagedListState` records the failure as observable state (`getError()` + an `errorChange` event) and **still re-throws** — the rejection is what App's auth-recovery wrapper keys off to detect a 401 and start a re-authorization, so swallowing it would have broken OAuth step-up. The callers with nobody to await them (connect-time load, `list_changed` auto-refresh) catch it explicitly now that the state holds it. The four `useManaged*` hooks expose it through a shared `useManagedListError`, and the Tools/Prompts/Resources sidebars render a new `ListLoadError` element with the reason and a **Retry**.

**The Protocol entry stops lying.** A response the client refused is attributed back to its entry — `markResponseRejected` → `responseRejected` → `MessageEntry.clientError` — which now renders an **Error** status and a "Rejected by the Inspector" alert in the expanded detail, instead of the green `resultType` badge alone (that badge was suppressing the status badge, which is why the failed call looked green).

The SDK gives no request id with a decode failure — `SdkError` carries the method and nothing else — so the id is recovered by correlation with the last response received for that method. That's exact rather than approximate: the SDK rejects synchronously while decoding, inside the transport's `onmessage`, and the caller's `catch` runs in the very next microtask; delivering another response for the same method in that window would take a macrotask (a socket read), which cannot interleave there. The reasoning is on the method.

**No more floor-dropping in `listAllTools`.** The excluded-tools walk stays non-fatal but is now logged instead of `.catch(() => {})`, so a failing walk doesn't leave the "Excluded (SEP-2243)" section silently empty.

## Not changed, deliberately

The strictness itself is correct — the 2026-07-28 normative schema declares `ttlMs: number` and `cacheScope: "public" | "private"` as **required** on `ListToolsResult` and its siblings, so the SDK is conformant and nothing here loosens it. (The spec's caching page contradicts its own schema by telling clients to tolerate an absent `ttlMs`; that belongs upstream.)

## Verification

Reproduced with the repo's modern test server behind a proxy that strips `ttlMs`/`cacheScope` from `*/list` results, connected with `protocolEra: "modern"`.

**Before** — "Connected", empty Tools panel, Protocol entry showing a clean `COMPLETE` round-trip:

<!-- attach pr-screenshots/1953-before-tools-empty.png here -->
<img width="1033" height="746" alt="1953-before-tools-empty" src="https://github.com/user-attachments/assets/6dc5dedf-429e-4e49-9b2c-40b61667b9ab" />


**After** — the panel names the failure with the reason and a Retry; the Protocol entry carries an `ERROR` badge alongside the wire's `COMPLETE`, and expands to "Rejected by the Inspector":

<!-- attach pr-screenshots/1953-after-tools-and-protocol.png here -->
<img width="1500" height="950" alt="1953-after-tools-and-protocol" src="https://github.com/user-attachments/assets/05dc8627-97a5-4d13-b32d-d95e7d755598" />

Retry was exercised live: with the proxy switched back to pass-through, clicking **Retry** clears the alert and loads the tools.

## Tests

- `managedToolsState` — 10 cases covering the error lifecycle: recorded **and** re-thrown, `errorChange` dispatch, non-`Error` rejection wrapping, cleared on success, cleared on disconnect, no re-dispatch for the same error, and the two unawaited paths (connect, auto-refresh) landing in state rather than rejecting unobserved.
- The other three managed states pin their `listMethod` string, which is what attributes a failure to the right entry.
- `useManagedListError` — 7 cases (seed, update, clear, null state, unsubscribe).
- `ListLoadError` — 6 cases; plus 4 stories.
- `messageLogState` — 5 cases for `responseRejected`, including the standalone-response and reused-id paths.
- `inspectorClient-response-rejected.test.ts` — a new **integration** file driving a real stdio connection so the id correlation runs against real SDK-assigned ids: latest-response attribution, no cross-method bleed, no-op for an unanswered method.
- `ProtocolEntry` — 4 cases for the rejected-response rendering.
- The three control panels — retry wiring and the default no-error state.

`npm run ci` passes: `validate` → `coverage` (per-file ≥90 held) → `verify:build-gate` → `smoke` (incl. `smoke:web:app`) → Storybook (110 files, 466 tests).

> Note: `npm run coverage` exits 1 on this branch **and on `v2/main`** with 2 pre-existing unhandled `CONNECTION_CLOSED` rejections from `inspectorClient.test.ts`'s disconnect-during-in-flight-progress tests. Verified identical on a stashed tree; unrelated to this change and worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SW1p8E2uiyyLx4RKwrwSrt
