### PR TITLE
fix: settle the deliberately in-flight tool calls in the progress tests

### DIFF
--- a/clients/web/src/test/integration/mcp/inspectorClient.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient.test.ts
@@ -95,6 +95,29 @@ async function getTool(client: InspectorClient, name: string): Promise<Tool> {
   throw new Error(`Tool ${name} not found`);
 }
 
+/**
+ * Hold a deliberately un-awaited in-flight call so its rejection is handled.
+ *
+ * A few tests start a tool call, assert on the notifications it streams, and
+ * then tear the connection down while the call is still in flight. That is a
+ * legitimate thing to exercise, but `disconnect()` closes the SDK client, which
+ * rejects every pending request with "Connection closed" — and a floating
+ * promise makes that an *unhandled* rejection, which vitest counts as a run
+ * error and fails `npm run ci` even though every test passes (#1947).
+ *
+ * Attach the handler at call time (not after the assertions) so there is no
+ * window in which the rejection can escape, and `await` the returned promise
+ * after `disconnect()` so teardown stays ordered. The call may legitimately
+ * either settle before the teardown or reject with it, so neither outcome is
+ * asserted here.
+ */
+function settleInFlight(call: Promise<unknown>): Promise<void> {
+  return call.then(
+    () => undefined,
+    () => undefined,
+  );
+}
+
 /** Get all resources from the client via listResources() (paginates if needed). */
 async function getAllResources(
   client: InspectorClient,
@@ -2221,16 +2244,18 @@ describe("InspectorClient", () => {
       const progressToken = 12345;
 
       const sendProgressTool = await getTool(client, "send_progress");
-      client.callTool(
-        sendProgressTool,
-        {
-          units: 3,
-          delayMs: 50,
-          total: 3,
-          message: "Test progress",
-        },
-        undefined, // generalMetadata
-        { progressToken: progressToken.toString() }, // toolSpecificMetadata
+      const inFlight = settleInFlight(
+        client.callTool(
+          sendProgressTool,
+          {
+            units: 3,
+            delayMs: 50,
+            total: 3,
+            message: "Test progress",
+          },
+          undefined, // generalMetadata
+          { progressToken: progressToken.toString() }, // toolSpecificMetadata
+        ),
       );
 
       const progressEvents = await waitForProgressCount(client, 3, {
@@ -2262,6 +2287,7 @@ describe("InspectorClient", () => {
       });
 
       await client!.disconnect();
+      await inFlight;
       await server.stop();
     });
 
@@ -2349,15 +2375,17 @@ describe("InspectorClient", () => {
       const progressToken = 67890;
 
       const sendProgressTool2 = await getTool(client, "send_progress");
-      client.callTool(
-        sendProgressTool2,
-        {
-          units: 2,
-          delayMs: 50,
-          message: "Indeterminate progress",
-        },
-        undefined, // generalMetadata
-        { progressToken: progressToken.toString() }, // toolSpecificMetadata
+      const inFlight = settleInFlight(
+        client.callTool(
+          sendProgressTool2,
+          {
+            units: 2,
+            delayMs: 50,
+            message: "Indeterminate progress",
+          },
+          undefined, // generalMetadata
+          { progressToken: progressToken.toString() }, // toolSpecificMetadata
+        ),
       );
 
       const progressEvents = await waitForProgressCount(client, 2, {
@@ -2380,6 +2408,7 @@ describe("InspectorClient", () => {
       expect((progressEvents[1] as { total?: number }).total).toBeUndefined();
 
       await client!.disconnect();
+      await inFlight;
       await server.stop();
     });
 

--- a/clients/web/src/test/integration/mcp/inspectorClient.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient.test.ts
@@ -117,7 +117,7 @@ async function getTool(client: InspectorClient, name: string): Promise<Tool> {
  * notifications it managed to emit first.
  */
 function settleInFlight(call: Promise<unknown>): Promise<void> {
-  return call.then(
+  const settled = call.then(
     () => undefined,
     (error: unknown) => {
       if (
@@ -129,6 +129,15 @@ function settleInFlight(call: Promise<unknown>): Promise<void> {
       throw error;
     },
   );
+  // `then` returns a *derived* promise, and the re-throw above rejects that one
+  // — not `call`. The caller does not await it until after `disconnect()`, so an
+  // unexpected rejection arriving while the test is still waiting on progress
+  // notifications would sit unobserved for seconds and be reported as an
+  // unhandled rejection: precisely the failure this helper exists to prevent.
+  // Observe it the moment it exists. This does not swallow anything — `settled`
+  // stays rejected, so the caller's `await` still fails the test.
+  settled.catch(() => undefined);
+  return settled;
 }
 
 /** Get all resources from the client via listResources() (paginates if needed). */

--- a/clients/web/src/test/integration/mcp/inspectorClient.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient.test.ts
@@ -106,21 +106,33 @@ async function getTool(client: InspectorClient, name: string): Promise<Tool> {
  * error and fails `npm run ci` even though every test passes (#1947).
  *
  * Attach the handler at call time (not after the assertions) so there is no
- * window in which the rejection can escape, and `await` the returned promise
- * after `disconnect()` so teardown stays ordered.
+ * window in which the rejection can escape, then finish through
+ * `disconnectAndSettle()`, which tears down and awaits the call in one step.
  *
- * Only the teardown's own `CONNECTION_CLOSED` rejection is absorbed. Plain
+ * Only a `CONNECTION_CLOSED` raised *by that teardown* is absorbed. Plain
  * fulfillment is fine too — whether the call beats the teardown is a race, so
- * asserting either outcome would turn this straight back into a flake. Any
- * *other* rejection is re-thrown, so a call that fails for a real reason still
- * fails the test instead of passing on the strength of the progress
- * notifications it managed to emit first.
+ * asserting either outcome would turn this straight back into a flake. Every
+ * other rejection is re-thrown, including a `CONNECTION_CLOSED` that arrives
+ * before teardown begins: a transport that drops on its own after emitting the
+ * progress notifications is a real regression, and absorbing it would let these
+ * tests pass on the strength of the notifications alone.
+ *
+ * The teardown flag is owned by the helper and set inside `disconnectAndSettle`
+ * rather than by the caller, so the flag cannot be raised too early (which would
+ * reopen the hole) and the await cannot be forgotten.
  */
-function settleInFlight(call: Promise<unknown>): Promise<void> {
+interface InFlightCall {
+  /** Disconnect, then await the call — absorbing only this teardown's close. */
+  disconnectAndSettle(client: InspectorClient): Promise<void>;
+}
+
+function settleInFlight(call: Promise<unknown>): InFlightCall {
+  let tearingDown = false;
   const settled = call.then(
     () => undefined,
     (error: unknown) => {
       if (
+        tearingDown &&
         error instanceof SdkError &&
         error.code === SdkErrorCode.ConnectionClosed
       ) {
@@ -135,9 +147,15 @@ function settleInFlight(call: Promise<unknown>): Promise<void> {
   // notifications would sit unobserved for seconds and be reported as an
   // unhandled rejection: precisely the failure this helper exists to prevent.
   // Observe it the moment it exists. This does not swallow anything — `settled`
-  // stays rejected, so the caller's `await` still fails the test.
+  // stays rejected, so the caller's `await` below still fails the test.
   settled.catch(() => undefined);
-  return settled;
+  return {
+    async disconnectAndSettle(client: InspectorClient): Promise<void> {
+      tearingDown = true;
+      await client.disconnect();
+      await settled;
+    },
+  };
 }
 
 /** Get all resources from the client via listResources() (paginates if needed). */
@@ -2308,8 +2326,7 @@ describe("InspectorClient", () => {
         progressToken: progressToken.toString(),
       });
 
-      await client!.disconnect();
-      await inFlight;
+      await inFlight.disconnectAndSettle(client!);
       await server.stop();
     });
 
@@ -2429,8 +2446,7 @@ describe("InspectorClient", () => {
       });
       expect((progressEvents[1] as { total?: number }).total).toBeUndefined();
 
-      await client!.disconnect();
-      await inFlight;
+      await inFlight.disconnectAndSettle(client!);
       await server.stop();
     });
 

--- a/clients/web/src/test/integration/mcp/inspectorClient.test.ts
+++ b/clients/web/src/test/integration/mcp/inspectorClient.test.ts
@@ -107,14 +107,27 @@ async function getTool(client: InspectorClient, name: string): Promise<Tool> {
  *
  * Attach the handler at call time (not after the assertions) so there is no
  * window in which the rejection can escape, and `await` the returned promise
- * after `disconnect()` so teardown stays ordered. The call may legitimately
- * either settle before the teardown or reject with it, so neither outcome is
- * asserted here.
+ * after `disconnect()` so teardown stays ordered.
+ *
+ * Only the teardown's own `CONNECTION_CLOSED` rejection is absorbed. Plain
+ * fulfillment is fine too — whether the call beats the teardown is a race, so
+ * asserting either outcome would turn this straight back into a flake. Any
+ * *other* rejection is re-thrown, so a call that fails for a real reason still
+ * fails the test instead of passing on the strength of the progress
+ * notifications it managed to emit first.
  */
 function settleInFlight(call: Promise<unknown>): Promise<void> {
   return call.then(
     () => undefined,
-    () => undefined,
+    (error: unknown) => {
+      if (
+        error instanceof SdkError &&
+        error.code === SdkErrorCode.ConnectionClosed
+      ) {
+        return;
+      }
+      throw error;
+    },
   );
 }
 


### PR DESCRIPTION
Closes #1947

## Cause

Not a teardown race in `InspectorClient.disconnect()` — that path already `try`/`catch`es `client.close()`.

Two tests in `inspectorClient.test.ts` fire `client.callTool(...)` **without holding the promise** (`:2224` and `:2352`), deliberately: they assert on the progress notifications the call streams while it is still in flight. `disconnect()` then closes the SDK client, which rejects every pending request with `Connection closed`. With nothing holding the promise, that lands as an unhandled rejection — which vitest counts as a run error, so the run exits 1 with every test passing, aborting `ci` at `coverage` and silently skipping `verify:build-gate`, `smoke`, and Storybook.

This also explains the environment sensitivity the issue flagged as worth establishing: on a slower machine the tool call completes before the assertions finish, so there is no pending request left for the close to reject and the run is green. Nothing platform-specific about it — just a timing window this machine loses and the GitHub runners happen to win. It is latent on CI, not absent.

## Fix

A `settleInFlight()` helper that attaches the handler **at call time** — not after the assertions, which would leave a window the rejection can escape through — and returns a promise each test awaits after `disconnect()` so teardown stays ordered. It asserts neither outcome, since the call may legitimately complete before the teardown or reject with it; asserting either way would reintroduce the same race as a flake.

Per the issue's note, this is not vitest-config-level swallowing: the rejection is handled at the exact call that produced it, and the runtime path is unchanged.

## Verification

- `clients/web` integration file standalone: **140 passed, 0 errors** (was 140 passed / 2 errors).
- Full `npm run ci` from the root: **exit 0**, all five stages reached — the chain is `&&` and the final Storybook stage ran (110 files / 466 tests). That is the first clean end-to-end run of the gate.

No UI or TUI change, so no screenshots.

## Note

Nothing structurally prevents the next fire-and-forget call from reintroducing this. `@typescript-eslint/no-floating-promises` would catch the class, but it needs type-aware linting turned on for the test globs — worth a separate issue rather than folding into this fix.