### PR TITLE
fix: forward the negotiated Mcp-Protocol-Version through the remote proxy

### DIFF
--- a/clients/web/src/test/core/mcp/remote/remoteClientTransport.test.ts
+++ b/clients/web/src/test/core/mcp/remote/remoteClientTransport.test.ts
@@ -542,10 +542,7 @@ describe("RemoteClientTransport", () => {
         return new Response("not found", { status: 404 });
       });
 
-    const transport = new RemoteClientTransport(
-      { baseUrl, fetchFn: fetchFn as unknown as typeof fetch },
-      config,
-    );
+    const transport = new RemoteClientTransport({ baseUrl, fetchFn }, config);
     await transport.start();
 
     // Pre-initialize sends carry no version (none negotiated yet).

--- a/clients/web/src/test/core/mcp/remote/remoteClientTransport.test.ts
+++ b/clients/web/src/test/core/mcp/remote/remoteClientTransport.test.ts
@@ -515,4 +515,61 @@ describe("RemoteClientTransport", () => {
       reason: "token_expired",
     });
   });
+
+  // #1935: the SDK Client calls setProtocolVersion() on this transport, but the
+  // real HTTP transport lives on the backend — so the version has to ride the
+  // send envelope or the backend drops `Mcp-Protocol-Version` upstream.
+  it("forwards the negotiated protocol version on every send after setProtocolVersion", async () => {
+    const seenBodies: string[] = [];
+    let sse = createPushableSseStream();
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url.endsWith("/api/mcp/connect")) {
+          return new Response(JSON.stringify({ sessionId: "abc" }), {
+            status: 200,
+          });
+        }
+        if (url.includes("/api/mcp/events")) {
+          sse = createPushableSseStream();
+          return sse.response;
+        }
+        if (url.endsWith("/api/mcp/send")) {
+          seenBodies.push(String(init?.body));
+          return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+    const transport = new RemoteClientTransport(
+      { baseUrl, fetchFn: fetchFn as unknown as typeof fetch },
+      config,
+    );
+    await transport.start();
+
+    // Pre-initialize sends carry no version (none negotiated yet).
+    await transport.send({ jsonrpc: "2.0", method: "notifications/cancelled" });
+    expect(JSON.parse(seenBodies[0]!)).not.toHaveProperty("protocolVersion");
+
+    transport.setProtocolVersion("2025-11-25");
+
+    // The first post-initialize send is `notifications/initialized` — the one
+    // the reporting server rejected for a missing header.
+    await transport.send({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+    await transport.send({ jsonrpc: "2.0", method: "notifications/cancelled" });
+
+    expect(JSON.parse(seenBodies[1]!)).toMatchObject({
+      protocolVersion: "2025-11-25",
+      message: { method: "notifications/initialized" },
+    });
+    expect(JSON.parse(seenBodies[2]!)).toMatchObject({
+      protocolVersion: "2025-11-25",
+    });
+
+    await transport.close();
+  });
 });

--- a/clients/web/src/test/integration/mcp/remote/remote-session.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/remote-session.test.ts
@@ -120,6 +120,40 @@ describe("RemoteSession", () => {
     expect(session.transport).toBe(transport);
   });
 
+  // #1935: the browser's Client negotiates the version, so the backend has to
+  // be told before it can stamp `Mcp-Protocol-Version` on upstream requests.
+  it("applyProtocolVersion forwards a new version to the transport once", () => {
+    const session = new RemoteSession("s8a");
+    const setProtocolVersion = vi.fn();
+    session.setTransport({ setProtocolVersion } as unknown as Transport);
+
+    session.applyProtocolVersion("2025-11-25");
+    session.applyProtocolVersion("2025-11-25");
+    expect(setProtocolVersion.mock.calls).toEqual([["2025-11-25"]]);
+
+    // A renegotiated version (e.g. after a reconnect) is re-applied.
+    session.applyProtocolVersion("2026-07-28");
+    expect(setProtocolVersion).toHaveBeenLastCalledWith("2026-07-28");
+  });
+
+  it("applyProtocolVersion ignores an absent or non-token version", () => {
+    const session = new RemoteSession("s8b");
+    const setProtocolVersion = vi.fn();
+    session.setTransport({ setProtocolVersion } as unknown as Transport);
+
+    session.applyProtocolVersion(undefined);
+    // Header injection attempt — must never reach the upstream transport.
+    session.applyProtocolVersion("2025-11-25\r\nX-Evil: 1");
+    session.applyProtocolVersion("");
+    expect(setProtocolVersion).not.toHaveBeenCalled();
+  });
+
+  it("applyProtocolVersion is a no-op on a transport without setProtocolVersion (stdio)", () => {
+    const session = new RemoteSession("s8c");
+    session.setTransport({} as unknown as Transport);
+    expect(() => session.applyProtocolVersion("2025-11-25")).not.toThrow();
+  });
+
   it("hasEventConsumer reflects whether a consumer is attached", () => {
     const session = new RemoteSession("s9");
     expect(session.hasEventConsumer()).toBe(false);

--- a/clients/web/src/test/integration/mcp/remote/remote-session.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/remote-session.test.ts
@@ -25,6 +25,16 @@ function makeFetchEntry(
   };
 }
 
+/** A structurally valid `Transport`, so a fixture needs no cast. */
+function makeTransport(overrides: Partial<Transport> = {}): Transport {
+  return {
+    start: async () => {},
+    send: async () => {},
+    close: async () => {},
+    ...overrides,
+  };
+}
+
 describe("RemoteSession", () => {
   it("queues events before a consumer attaches and drains them on attach", () => {
     const session = new RemoteSession("s1");
@@ -125,7 +135,7 @@ describe("RemoteSession", () => {
   it("applyProtocolVersion forwards a new version to the transport once", () => {
     const session = new RemoteSession("s8a");
     const setProtocolVersion = vi.fn();
-    session.setTransport({ setProtocolVersion } as unknown as Transport);
+    session.setTransport(makeTransport({ setProtocolVersion }));
 
     session.applyProtocolVersion("2025-11-25");
     session.applyProtocolVersion("2025-11-25");
@@ -136,21 +146,26 @@ describe("RemoteSession", () => {
     expect(setProtocolVersion).toHaveBeenLastCalledWith("2026-07-28");
   });
 
-  it("applyProtocolVersion ignores an absent or non-token version", () => {
+  it("applyProtocolVersion ignores an absent, non-token, or non-string version", () => {
     const session = new RemoteSession("s8b");
     const setProtocolVersion = vi.fn();
-    session.setTransport({ setProtocolVersion } as unknown as Transport);
+    session.setTransport(makeTransport({ setProtocolVersion }));
 
     session.applyProtocolVersion(undefined);
     // Header injection attempt — must never reach the upstream transport.
     session.applyProtocolVersion("2025-11-25\r\nX-Evil: 1");
     session.applyProtocolVersion("");
+    // The value arrives from an unvalidated JSON body, so a non-string must be
+    // rejected on its type — `RegExp.test` would coerce these into a match.
+    session.applyProtocolVersion(123);
+    session.applyProtocolVersion(true);
+    session.applyProtocolVersion(null);
     expect(setProtocolVersion).not.toHaveBeenCalled();
   });
 
   it("applyProtocolVersion is a no-op on a transport without setProtocolVersion (stdio)", () => {
     const session = new RemoteSession("s8c");
-    session.setTransport({} as unknown as Transport);
+    session.setTransport(makeTransport());
     expect(() => session.applyProtocolVersion("2025-11-25")).not.toThrow();
   });
 

--- a/clients/web/src/test/integration/mcp/remote/transport.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/transport.test.ts
@@ -452,6 +452,58 @@ describe("Remote transport e2e", () => {
       }
     });
 
+    it("end-to-end: the negotiated Mcp-Protocol-Version reaches the upstream server after initialize (#1935)", async () => {
+      // The browser's SDK Client owns the initialize handshake, so its
+      // setProtocolVersion() lands on the *remote* transport. Without the
+      // forward to the backend, the backend's real streamable-HTTP transport
+      // never learns the version and every post-initialize request — starting
+      // with `notifications/initialized` — goes out without the header, which
+      // a stateful server may reject outright.
+      mcpHttpServer = createTestServerHttp({
+        serverInfo: createTestServerInfo(),
+        tools: [createEchoTool()],
+        serverType: "streamable-http",
+      });
+      await mcpHttpServer.start();
+
+      const config: MCPServerConfig = {
+        type: "streamable-http",
+        url: mcpHttpServer.url,
+      };
+
+      const { client, fetchRequestLogState } =
+        await setupRemoteAndConnect(config);
+
+      try {
+        await client.listTools();
+
+        const protocolVersion = client.getProtocolVersion();
+        expect(protocolVersion).toBeDefined();
+
+        const posts = fetchRequestLogState
+          .getFetchRequests()
+          .filter((r) => r.method === "POST");
+        const headerFor = (body: string): string | undefined => {
+          const entry = posts.find((r) => (r.requestBody ?? "").includes(body));
+          expect(entry).toBeDefined();
+          for (const [k, v] of Object.entries(entry?.requestHeaders ?? {})) {
+            if (k.toLowerCase() === "mcp-protocol-version") return v;
+          }
+          return undefined;
+        };
+
+        // The initialize POST itself predates negotiation and carries none.
+        expect(headerFor('"method":"initialize"')).toBeUndefined();
+        // Everything after it does.
+        expect(headerFor('"method":"notifications/initialized"')).toBe(
+          protocolVersion,
+        );
+        expect(headerFor('"method":"tools/list"')).toBe(protocolVersion);
+      } finally {
+        await client.disconnect();
+      }
+    });
+
     it("end-to-end: SEP-2243 Mcp-Param-* mirroring reaches the upstream modern server (#1846)", async () => {
       // A modern (2026-07-28) server whose `get_weather` tool annotates `city`
       // with `x-mcp-header: "City"`. The SDK's modern handler validates the

--- a/core/mcp/remote/node/remote-session.ts
+++ b/core/mcp/remote/node/remote-session.ts
@@ -37,6 +37,9 @@ export class RemoteSession {
   static readonly AUTH_HTTP_ECHO_SUPPRESS_MS = 30_000;
   private readonly requestWaits = new Map<string | number, RequestWait>();
   private authProviderHandle: RemoteAuthProviderHandle | null = null;
+  private appliedProtocolVersion: string | undefined;
+  /** A protocol version is a dated token (`2025-11-25`, `2026-07-28`, …). */
+  private static readonly PROTOCOL_VERSION_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
 
   constructor(sessionId: string) {
     this.sessionId = sessionId;
@@ -55,6 +58,29 @@ export class RemoteSession {
 
   setTransport(transport: Transport): void {
     this.transport = transport;
+  }
+
+  /**
+   * Apply the client's negotiated protocol version to the upstream transport
+   * (#1935). The browser's SDK Client owns the `initialize` handshake, so the
+   * `setProtocolVersion` call it makes lands on the *remote* transport; without
+   * this the backend's real HTTP transport never learns the version and drops
+   * `Mcp-Protocol-Version` from every subsequent request.
+   *
+   * Ignores anything that isn't a plausible version token so a client can't
+   * push arbitrary bytes into an upstream header, and re-applies only on
+   * change (the value rides every `/api/mcp/send`).
+   */
+  applyProtocolVersion(version: string | undefined): void {
+    if (
+      version === undefined ||
+      version === this.appliedProtocolVersion ||
+      !RemoteSession.PROTOCOL_VERSION_PATTERN.test(version)
+    ) {
+      return;
+    }
+    this.appliedProtocolVersion = version;
+    this.transport.setProtocolVersion?.(version);
   }
 
   setEventConsumer(consumer: (event: SessionEvent) => void): void {

--- a/core/mcp/remote/node/remote-session.ts
+++ b/core/mcp/remote/node/remote-session.ts
@@ -69,11 +69,14 @@ export class RemoteSession {
    *
    * Ignores anything that isn't a plausible version token so a client can't
    * push arbitrary bytes into an upstream header, and re-applies only on
-   * change (the value rides every `/api/mcp/send`).
+   * change (the value rides every `/api/mcp/send`). The value arrives from an
+   * unvalidated JSON body, so the type is checked rather than assumed —
+   * `RegExp.test` would otherwise coerce a `123` or `true` into a "matching"
+   * string and hand the wrong type to the transport.
    */
-  applyProtocolVersion(version: string | undefined): void {
+  applyProtocolVersion(version: unknown): void {
     if (
-      version === undefined ||
+      typeof version !== "string" ||
       version === this.appliedProtocolVersion ||
       !RemoteSession.PROTOCOL_VERSION_PATTERN.test(version)
     ) {

--- a/core/mcp/remote/node/server.ts
+++ b/core/mcp/remote/node/server.ts
@@ -728,7 +728,8 @@ export function createRemoteApp(
       return c.json({ error: "Invalid JSON body" }, 400);
     }
 
-    const { sessionId, message, relatedRequestId, headers } = body;
+    const { sessionId, message, relatedRequestId, headers, protocolVersion } =
+      body;
     if (!sessionId || !message) {
       return c.json({ error: "Missing sessionId or message" }, 400);
     }
@@ -743,6 +744,11 @@ export function createRemoteApp(
       const errorMsg = session.getTransportError() || "Transport closed";
       return c.json({ ok: false, kind: "transport_error", error: errorMsg });
     }
+
+    // The browser's SDK Client negotiated the version; hand it to the real
+    // upstream transport before the send so `Mcp-Protocol-Version` is stamped
+    // on this request and everything after it (#1935).
+    session.applyProtocolVersion(protocolVersion);
 
     session.beginSend();
     const requestId = requestIdForSendWait(message);

--- a/core/mcp/remote/remoteClientTransport.ts
+++ b/core/mcp/remote/remoteClientTransport.ts
@@ -221,6 +221,7 @@ async function* parseSSE(
  */
 export class RemoteClientTransport implements Transport {
   private _sessionId: string | undefined = undefined;
+  private _protocolVersion: string | undefined = undefined;
   private eventStreamReader: ReadableStreamDefaultReader<Uint8Array> | null =
     null;
   private eventStreamAbort: AbortController | null = null;
@@ -248,6 +249,22 @@ export class RemoteClientTransport implements Transport {
   /** Remote Hono session id (distinct from MCP protocol session). */
   getRemoteBackendSessionId(): string | undefined {
     return this._sessionId;
+  }
+
+  /**
+   * The SDK Client calls this with the negotiated protocol version as soon as
+   * `initialize` resolves — before it sends `notifications/initialized` — so an
+   * HTTP transport can stamp `Mcp-Protocol-Version` on every later request.
+   *
+   * Here the real upstream transport lives on the backend, so we can only
+   * record the version and forward it on the next `/api/mcp/send`, which
+   * applies it to the upstream transport *before* sending. Because
+   * `notifications/initialized` is that next send, it and everything after it
+   * (including the standalone SSE GET and the session DELETE, both issued by
+   * the upstream transport itself) carry the header (#1935).
+   */
+  setProtocolVersion(version: string): void {
+    this._protocolVersion = version;
   }
 
   /**
@@ -707,6 +724,11 @@ export class RemoteClientTransport implements Transport {
       // Forward per-send `Mcp-Param-*` headers (SEP-2243) for the backend to
       // apply to the upstream send; the browser can't set them cross-origin.
       ...(options?.headers != null && { headers: options.headers }),
+      // Forward the negotiated protocol version so the backend's transport can
+      // stamp `Mcp-Protocol-Version` on this and every later request (#1935).
+      ...(this._protocolVersion !== undefined && {
+        protocolVersion: this._protocolVersion,
+      }),
     };
 
     const res = await this.fetchFn(`${this.baseUrl}/api/mcp/send`, {

--- a/core/mcp/remote/types.ts
+++ b/core/mcp/remote/types.ts
@@ -125,6 +125,12 @@ export interface RemoteSendRequest {
    * them to the upstream `transport.send`, filtered to the `Mcp-Param-` prefix.
    */
   headers?: Record<string, string>;
+  /**
+   * MCP protocol version negotiated by the client's `initialize`. The backend
+   * applies it to the upstream transport before the send so HTTP transports
+   * stamp `Mcp-Protocol-Version` on this and every later request (#1935).
+   */
+  protocolVersion?: string;
 }
 
 export type RemoteEventType =


### PR DESCRIPTION
Closes #1935

## The bug

In the web client the SDK `Client` runs in the **browser**, so the `setProtocolVersion()` it calls right after `initialize` lands on `RemoteClientTransport` — a pass-through to the Node backend, not the transport that actually talks to the MCP server. `RemoteClientTransport` had no `setProtocolVersion`, so the version was dropped on the floor and the backend's `StreamableHTTPClientTransport` never learned it.

Result: every request after `initialize` went upstream without `Mcp-Protocol-Version` — starting with `notifications/initialized`, which the reporter's stateful server rejects with:

```json
{ "code": -32001, "message": "Mcp-Protocol-Version is required for a session" }
```

The CLI and TUI were never affected — they drive the real transport directly, so the SDK stamps the header itself.

## The fix

- `RemoteClientTransport.setProtocolVersion()` records the negotiated version and rides it on the body of every `POST /api/mcp/send`.
- The `/api/mcp/send` route applies it to the session's upstream transport **before** the send, so that request and everything the transport issues afterwards (the standalone SSE `GET`, the session `DELETE`) carry the header.

Piggybacking on the send rather than adding a dedicated endpoint is deliberate: the SDK calls `setProtocolVersion()` synchronously before `notifications/initialized`, so the very next send is the one that needed the header — no extra round-trip and no ordering race.

`RemoteSession.applyProtocolVersion()` re-applies only on change and validates the value against a token pattern, so a client can't push `\r\n`-bearing bytes into an upstream header.

## Screenshot

<img width="587" height="779" alt="Screenshot 2026-08-10 at 10 17 45 PM" src="https://github.com/user-attachments/assets/91c9d121-5a24-4d49-b8aa-dc627c0ce631" />

<img width="536" height="643" alt="Screenshot 2026-08-10 at 10 20 25 PM" src="https://github.com/user-attachments/assets/17b23e2b-8504-416d-907e-bd785d52bc49" />

## Tests

- `remoteClientTransport.test.ts` — pre-initialize sends carry no `protocolVersion`; every send after `setProtocolVersion()` does.
- `remote-session.test.ts` — applied once per distinct version, re-applied on renegotiation, ignored when absent/malformed, no-op on a transport without the method (stdio).
- `transport.test.ts` — end-to-end over the remote backend against a real streamable-HTTP server, asserting on the **backend's upstream fetch tracking** that `initialize` carries no header while `notifications/initialized` and `tools/list` both carry the negotiated version. Verified to fail on `v2/main` and pass with the fix.

## Gate

`npm run ci`: validate, coverage (per-file ≥90 held), `verify:build-gate`, all smokes, and the Storybook play functions pass. The run does surface two pre-existing `Connection closed` unhandled rejections from `inspectorClient.test.ts` — reproduced on a pristine `origin/v2/main` checkout in the same environment, unrelated to this change.
