### PR TITLE
ci: gate claude.yml on same-repo PRs and pin actions to commit SHAs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,13 +35,18 @@ jobs:
       id-token: write
       actions: read
     steps:
+      # Actions are pinned to full commit SHAs rather than mutable major tags:
+      # this job holds ANTHROPIC_API_KEY and grants the agent Bash, so a
+      # force-moved tag would be an unreviewed code change inside a
+      # secret-holding job. The trailing `# vX.Y.Z` comment is the form
+      # Dependabot reads, so pinning costs us no upgrade automation. (#1882)
       - name: Get PR details
         if: |
           (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
           github.event_name == 'pull_request_review_comment' ||
           github.event_name == 'pull_request_review'
         id: pr
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             let prNumber;
@@ -57,26 +62,58 @@ jobs:
               pull_number: prNumber
             });
 
-            core.setOutput('sha', pr.data.head.sha);
-            core.setOutput('repo', pr.data.head.repo.full_name);
+            // A fork PR's head lives in a different repository — or in none at
+            // all, if the fork was deleted after the PR was opened (`head.repo`
+            // is then null). Neither is ours to check out, so both count as a
+            // fork here and the steps below decline rather than guess.
+            const headRepo = pr.data.head.repo?.full_name ?? null;
+            const isFork = headRepo !== `${context.repo.owner}/${context.repo.repo}`;
 
+            core.setOutput('sha', pr.data.head.sha);
+            core.setOutput('is_fork', String(isFork));
+
+      # A fork PR's head is untrusted code, and checking it out would put it in
+      # reach of a tool-enabled agent run holding ANTHROPIC_API_KEY. Reviewing
+      # the base tree instead would only trade that for a confident review of
+      # the wrong tree, so decline visibly and leave the reason in the run.
+      - name: Decline fork PR
+        if: steps.pr.outcome == 'success' && steps.pr.outputs.is_fork == 'true'
+        run: |
+          {
+            echo "### Claude Code declined this pull request"
+            echo
+            echo "The head branch lives in a fork, so its code is not checked out and Claude is not run."
+            echo "Push the branch to this repository and re-trigger if a review is needed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # No `repository:` — a same-repo head is all that reaches this step, and
+      # checkout defaults to `github.repository`, which no PR can influence.
       - name: Checkout PR branch
-        if: steps.pr.outcome == 'success'
-        uses: actions/checkout@v6
+        if: steps.pr.outcome == 'success' && steps.pr.outputs.is_fork == 'false'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.pr.outputs.sha }}
-          repository: ${{ steps.pr.outputs.repo }}
           fetch-depth: 0
 
+      # `skipped` means the trigger was an issue or a non-PR comment, so there
+      # is no head to check out and the base tree is the right one. The lookup
+      # having *failed* is deliberately not included: this condition carries no
+      # status-check function, so GitHub applies an implicit `success()` and
+      # skips the step after a failed prior step anyway. Spelling out `skipped`
+      # keeps that from having to be re-derived by the next reader.
       - name: Checkout repository
-        if: steps.pr.outcome != 'success'
-        uses: actions/checkout@v6
+        if: steps.pr.outcome == 'skipped'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Run Claude Code
+        # Runs only against a tree this workflow actually checked out: the base
+        # repo (non-PR trigger) or a same-repo PR head. A fork PR reaches here
+        # with `is_fork == 'true'` and both disjuncts false, so it is skipped.
+        if: steps.pr.outcome == 'skipped' || steps.pr.outputs.is_fork == 'false'
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc # v1.0.190
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 


### PR DESCRIPTION
Closes #1882

Hardens `.github/workflows/claude.yml` in two ways, and documents a third finding that turned out to need no code change.

The issue was originally filed as a fork-PR concern raised by Copilot on #1869. The repo runs `pull_request_creation_policy: collaborators_only` (verified against the API), which retires most of that threat model — so this is defense in depth, not remediation, and #1882 was re-scored **Low** to match. It is still worth landing: the mitigation currently lives entirely in a repo **setting**, flippable from a UI with no review and no diff, rather than in the file.

## 1. Same-repo gating

`Get PR details` now emits an `is_fork` output, and both the PR-head checkout and `Run Claude Code` are gated on it:

| Trigger | `steps.pr.outcome` | `is_fork` | Behavior |
| --- | --- | --- | --- |
| Issue / non-PR comment | `skipped` | — | Check out base repo, run Claude |
| Same-repo PR | `success` | `false` | Check out PR head, run Claude |
| Fork PR | `success` | `true` | **No checkout, no Claude**, reason in the step summary |
| PR lookup failed | `failure` | — | No checkout, no Claude |

Declining a fork PR outright is deliberate. The alternative floated in the issue — fall through to a "metadata-only" review against the base tree — trades an untrusted-code problem for a wrong-tree one, which is the *other* half of what Copilot flagged. Better to decline visibly than to post a confident review of a tree that isn't the one under review.

A deleted fork counts as a fork: `head.repo` is `null` in that case, so the comparison treats it as not-ours rather than throwing.

The head checkout also **drops its `repository:` input**. Only a same-repo head reaches that step now, and checkout's default is `github.repository` — a value no PR can influence. That is a stronger position than passing a PR-derived repo name that happens to have been checked.

## 2. Actions pinned to commit SHAs

`actions/checkout`, `actions/github-script`, and `anthropics/claude-code-action` were all on mutable major tags, in a job that holds `ANTHROPIC_API_KEY` and grants the agent `Bash`. A force-moved tag on any of the three is an unreviewed code change inside a secret-holding job.

Each is now pinned to a full commit SHA with the trailing `# vX.Y.Z` comment Dependabot reads, so pinning costs no upgrade automation:

| Action | Pin | Version |
| --- | --- | --- |
| `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 |
| `actions/github-script` | `3a2844b7e9c422d3c10d287c895573f7108da1b3` | v9.0.0 |
| `anthropics/claude-code-action` | `5ef2e550a465a721f4f45e4a7d3c340c873e1dcc` | v1.0.190 (== `v1`) |

> **Interaction with #1922.** The open Dependabot PR bumps `checkout` v6→v7 and `github-script` v8→v9 in this same file. The pins above are the **v7 / v9** SHAs, so this does not regress those bumps — Dependabot will rebase #1922 and drop its now-redundant `claude.yml` hunks, leaving its `main.yml` changes intact.

## 3. The failure fallback — no change needed

Copilot's mirror-image finding was that a *failed* PR lookup falls back to the base checkout but still runs Claude, reviewing the wrong tree while spending secrets and minutes. On inspection this doesn't happen: `Checkout repository` was guarded by `if: steps.pr.outcome != 'success'`, which contains no status-check function, so GitHub applies an implicit `success()` and skips the step after a failed prior step regardless of the `outcome` comparison.

The condition is now the explicit `steps.pr.outcome == 'skipped'`, with a comment saying why the failure case is excluded — so the next reader doesn't have to re-derive it.

## Out of scope

Copilot's other comment on #1869 — that `issues: read` / `pull-requests: read` prevents `@claude` from posting — is incorrect and is untouched here. `claude-code-action` mints its own GitHub App token via `id-token: write`; the `permissions:` block scopes `GITHUB_TOKEN`, not that app token. `claude[bot]` posted on #1825 under exactly these permissions. The read-only grants are correct and **must not be widened**.

## Testing

No test surface — this is a workflow file, and workflows only run from the default branch, so the change isn't exercised until `v2/main` reaches `main` at the next milestone merge.

- YAML parses; every step's resolved condition was checked against the table above.
- `npm run verify:format-coverage` passes (939 tracked source files gated; `.yml` is outside the format globs, so nothing else in the gate applies to this diff).
- Every pinned SHA was resolved from the upstream tag via the GitHub API (annotated tags dereferenced to their commit), not copied from a third party.

After it reaches `main`: verify with a real `@claude` invocation on a same-repo PR (must still check out the PR head and review it), and confirm a fork PR is declined with the summary message rather than silently reviewing the wrong tree.

No UI change, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SW1p8E2uiyyLx4RKwrwSrt
