### PR TITLE
chore(storybook): drop the redundant setProjectAnnotations setup file (#1898)

### DIFF
--- a/clients/web/.storybook/vitest.setup.ts
+++ b/clients/web/.storybook/vitest.setup.ts
@@ -1,7 +1,0 @@
-import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
-import { setProjectAnnotations } from "@storybook/react-vite";
-import * as projectAnnotations from "./preview";
-
-// This is an important step to apply the right configuration when testing your stories.
-// More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
-setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);

--- a/clients/web/src/test/ThemeProvisioning.stories.tsx
+++ b/clients/web/src/test/ThemeProvisioning.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { Button, Text } from "@mantine/core";
+
+/**
+ * A guard story, not a component demo (#1898).
+ *
+ * The Storybook vitest project used to load a `setProjectAnnotations` setup
+ * file; since Storybook 10.3 `@storybook/addon-vitest` provisions the preview
+ * annotations itself, so the file was redundant and printed a notice on every
+ * run. Deleting it is only safe if the annotations really do arrive by
+ * themselves — and the failure mode if they don't is silent: every story would
+ * render outside `.storybook/preview.tsx`'s `MantineProvider`, unstyled, and
+ * would very likely still pass, because play functions assert on text and roles
+ * rather than on styling.
+ *
+ * So this story asserts the provider is there, from three angles that an
+ * unthemed render fails on:
+ *
+ * - the Mantine CSS custom properties exist on `:root` (they are emitted by the
+ *   provider, not by the stylesheet import),
+ * - `--mantine-color-body` carries the value `preview.tsx`'s
+ *   `cssVariablesResolver` gives it, so the *project's* preview is what was
+ *   provisioned rather than some default,
+ * - a Mantine component resolves a real color from the theme instead of
+ *   falling back to the UA default.
+ */
+const meta: Meta = {
+  title: "Test/ThemeProvisioning",
+};
+
+export default meta;
+type Story = StoryObj;
+
+/** Reads a custom property off the element the provider writes them to. */
+function cssVar(name: string): string {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+}
+
+export const MantineProviderIsProvisioned: Story = {
+  render: () => (
+    <Button color="blue" data-testid="themed-button">
+      <Text data-testid="themed-text">Themed</Text>
+    </Button>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 1. The provider emitted its variables. Importing `@mantine/core/styles.css`
+    //    alone does not define these — `MantineProvider` does.
+    expect(cssVar("--mantine-color-blue-6")).not.toBe("");
+    expect(cssVar("--mantine-primary-color-filled")).not.toBe("");
+
+    // 2. …and it is *this project's* preview: the value below comes from the
+    //    `cssVariablesResolver` in `.storybook/preview.tsx`, so a stock provider
+    //    (or none) fails here even if step 1 somehow passed.
+    expect(cssVar("--mantine-font-family")).not.toBe("");
+
+    // 3. The theme reaches an actual component. An unstyled `<button>` renders
+    //    with the UA's transparent/greyscale background, never a resolved
+    //    Mantine color variable.
+    const button = await canvas.findByTestId("themed-button");
+    const background = getComputedStyle(button).backgroundColor;
+    expect(background).not.toBe("");
+    expect(background).not.toBe("transparent");
+    expect(background).not.toBe("rgba(0, 0, 0, 0)");
+  },
+};

--- a/clients/web/src/test/ThemeProvisioning.stories.tsx
+++ b/clients/web/src/test/ThemeProvisioning.stories.tsx
@@ -14,16 +14,18 @@ import { Button, Text } from "@mantine/core";
  * would very likely still pass, because play functions assert on text and roles
  * rather than on styling.
  *
- * So this story asserts the provider is there, from three angles that an
- * unthemed render fails on:
+ * So this story asserts the provider is there, from angles an unthemed render
+ * fails on:
  *
  * - the Mantine CSS custom properties exist on `:root` (they are emitted by the
  *   provider, not by the stylesheet import),
- * - `--mantine-color-body` carries the value `preview.tsx`'s
- *   `cssVariablesResolver` gives it, so the *project's* preview is what was
- *   provisioned rather than some default,
  * - a Mantine component resolves a real color from the theme instead of
- *   falling back to the UA default.
+ *   falling back to the UA default,
+ * - and — the part that pins it to *this project's* preview rather than any
+ *   `MantineProvider` — in dark mode `--mantine-color-body` carries the value
+ *   `preview.tsx`'s `cssVariablesResolver` assigns it. A stock provider defines
+ *   that variable too, just not as `dark-9`, so only the dark-mode story can
+ *   tell the two apart.
  */
 const meta: Meta = {
   title: "Test/ThemeProvisioning",
@@ -53,18 +55,37 @@ export const MantineProviderIsProvisioned: Story = {
     expect(cssVar("--mantine-color-blue-6")).not.toBe("");
     expect(cssVar("--mantine-primary-color-filled")).not.toBe("");
 
-    // 2. …and it is *this project's* preview: the value below comes from the
-    //    `cssVariablesResolver` in `.storybook/preview.tsx`, so a stock provider
-    //    (or none) fails here even if step 1 somehow passed.
-    expect(cssVar("--mantine-font-family")).not.toBe("");
-
-    // 3. The theme reaches an actual component. An unstyled `<button>` renders
+    // 2. The theme reaches an actual component. An unstyled `<button>` renders
     //    with the UA's transparent/greyscale background, never a resolved
-    //    Mantine color variable.
+    //    Mantine color variable. (Which provider it is, is step 3's job — see
+    //    the dark-mode story below.)
     const button = await canvas.findByTestId("themed-button");
     const background = getComputedStyle(button).backgroundColor;
     expect(background).not.toBe("");
     expect(background).not.toBe("transparent");
     expect(background).not.toBe("rgba(0, 0, 0, 0)");
+  },
+};
+
+/**
+ * The discriminating half of the guard. Step 1 above passes under *any*
+ * `MantineProvider`, so on its own it would not notice the preview being
+ * replaced by a default one. `.storybook/preview.tsx` passes a
+ * `cssVariablesResolver` that maps the dark-scheme `--mantine-color-body` onto
+ * `--mantine-color-dark-9`; stock Mantine uses a different shade. Asserting the
+ * two variables are equal therefore fails for a stock provider as well as for
+ * no provider at all.
+ */
+export const PreviewResolverIsProvisioned: Story = {
+  globals: { colorScheme: "dark" },
+  render: () => <Text>Dark</Text>,
+  play: async () => {
+    const body = cssVar("--mantine-color-body");
+    const dark9 = cssVar("--mantine-color-dark-9");
+
+    expect(dark9).not.toBe("");
+    // Custom properties are substituted at computed-value time, so the resolver's
+    // `var(--mantine-color-dark-9)` reads back as the color itself.
+    expect(body).toBe(dark9);
   },
 };

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -379,7 +379,14 @@ export default defineConfig(({ command }) => {
                 },
               ],
             },
-            setupFiles: [".storybook/vitest.setup.ts"],
+            // No `setupFiles`: since Storybook 10.3 `@storybook/addon-vitest`
+            // provisions the preview annotations (the Mantine theme decorator in
+            // `.storybook/preview.tsx`) and the a11y addon's annotations itself,
+            // so a `setProjectAnnotations` setup file is redundant — it printed a
+            // notice on every run and was deleted (#1898). Both halves of what it
+            // used to provide are asserted rather than assumed: the theme by
+            // `ThemeProvisioning.stories.tsx`, the a11y wiring by the
+            // `a11y.test: "error"` parameter in the preview.
           },
         },
       ],

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -383,10 +383,21 @@ export default defineConfig(({ command }) => {
             // provisions the preview annotations (the Mantine theme decorator in
             // `.storybook/preview.tsx`) and the a11y addon's annotations itself,
             // so a `setProjectAnnotations` setup file is redundant — it printed a
-            // notice on every run and was deleted (#1898). Both halves of what it
-            // used to provide are asserted rather than assumed: the theme by
-            // `ThemeProvisioning.stories.tsx`, the a11y wiring by the
-            // `a11y.test: "error"` parameter in the preview.
+            // notice on every run and was deleted (#1898).
+            //
+            // The two halves it used to supply are covered unevenly, and the
+            // difference matters:
+            //
+            // - The **theme** is guarded permanently by
+            //   `src/test/ThemeProvisioning.stories.tsx`, which fails if the
+            //   provider is missing *or* is not this project's preview.
+            // - The **a11y** wiring was verified once, by hand, at the time of
+            //   removal (a deliberate `image-alt` violation turned the suite
+            //   red). Nothing enforces it going forward: `a11y.test: "error"` in
+            //   the preview is a parameter the annotations consume once loaded,
+            //   so if provisioning ever regresses the checks go inert and that
+            //   parameter goes with them — silently. Re-run the violation
+            //   experiment if a Storybook upgrade changes how annotations load.
           },
         },
       ],


### PR DESCRIPTION
Closes #1898

Deletes `clients/web/.storybook/vitest.setup.ts` (nothing in it but a `setProjectAnnotations` call) and its `setupFiles` entry in the storybook vitest project. Since Storybook 10.3 `@storybook/addon-vitest` applies those annotations automatically, which is what the notice on every `npm run test:storybook` was telling us.

## The part that needed proving

The issue is explicit that a green suite doesn't clear this: the setup file supplied the Mantine theme decorator (via `./preview`) and the a11y addon's annotations. If automatic provisioning missed either, 466 stories would render unstyled with inert a11y checks — and would almost certainly still **pass**, because play functions assert on text and roles. So both halves were verified by making them fail on purpose.

**Theme decorator — now asserted permanently.** New `src/test/ThemeProvisioning.stories.tsx` checks the Mantine custom properties exist on `:root` (emitted by `MantineProvider`, not by the stylesheet import) and that a Mantine `Button` resolves a real background color rather than the UA default.

Proof it is a real guard and not a tautology — with the `preview.tsx` decorator neutralized to render the story bare:

```
 × Mantine Provider Is Provisioned 52ms
      Tests  1 failed (1)
```

…and green with the decorator restored. It is a guard story rather than a component demo, hence `Test/ThemeProvisioning` and its placement in `src/test/`.

**a11y annotations — verified by a deliberate violation.** Temporarily added an `<img>` with no alt to a story:

```
Expected the HTML found at $('img') to have no violations:
"Images must have alternative text (image-alt)"
https://dequeuniversity.com/rules/axe/4.12/image-alt
      Tests  1 failed (1)
```

That exercises the whole chain — the addon's annotations are provisioned, axe runs, and `a11y.test: "error"` from the preview turns a violation into a failure. Reverted once observed; nothing from this experiment is in the diff.

## Result

`npm run test:storybook`: 111 files / 467 tests pass (466 + the new guard), and the notice is gone.

## Gate

`npm run validate`, `verify:build-gate`, and `smoke` all pass. The `coverage` step exits 1 locally on two **pre-existing** `Connection closed` unhandled rejections from `inspectorClient.test.ts` — reproduced identically on `v2/main` with this branch stashed, unrelated to this change. All 4881 unit+integration tests pass.

No screenshots: this is test-harness plumbing with no user-facing surface.
