### PR TITLE
fix(web): keep the text being typed in a schema number field (#1888)

### DIFF
--- a/clients/web/src/components/groups/AppDetailPanel/AppDetailPanel.test.tsx
+++ b/clients/web/src/components/groups/AppDetailPanel/AppDetailPanel.test.tsx
@@ -149,4 +149,28 @@ describe("AppDetailPanel", () => {
     await user.click(screen.getByRole("button", { name: /open app/i }));
     expect(onOpenApp).toHaveBeenCalledTimes(1);
   });
+
+  it("drops a previous app's in-progress number text when the app changes", async () => {
+    const user = userEvent.setup();
+    // AppsScreen swaps selectedAppName + formValues in place rather than
+    // remounting this panel, so two apps exposing a same-named number field
+    // share the field component. Both values here are undefined, which the
+    // draft/value re-sync cannot distinguish — only the resetKey identity can.
+    const numberFieldTool = (name: string): Tool => ({
+      name,
+      title: name,
+      inputSchema: {
+        type: "object",
+        properties: { scale: { type: "number", title: "Scale" } },
+      },
+    });
+    const { rerender } = renderWithMantine(
+      <AppDetailPanel {...baseProps} tool={numberFieldTool("app_a")} />,
+    );
+    const input = () => screen.getByLabelText(/Scale/) as HTMLInputElement;
+    await user.type(input(), "-");
+    expect(input().value).toBe("-");
+    rerender(<AppDetailPanel {...baseProps} tool={numberFieldTool("app_b")} />);
+    expect(input().value).toBe("");
+  });
 });

--- a/clients/web/src/components/groups/AppDetailPanel/AppDetailPanel.tsx
+++ b/clients/web/src/components/groups/AppDetailPanel/AppDetailPanel.tsx
@@ -76,6 +76,12 @@ export function AppDetailPanel({
           values={formValues}
           onChange={onFormChange}
           disabled={isOpening}
+          // Like ToolDetailPanel, this panel is reused across app selections
+          // rather than remounted (AppsScreen.handleSelect swaps
+          // selectedAppName + formValues in place), so the form needs the app
+          // tool's name to drop another app's in-progress field text. See
+          // SchemaFormProps.resetKey.
+          resetKey={tool.name}
         />
 
         <OpenAppButton

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
@@ -336,6 +336,34 @@ describe("SchemaForm", () => {
       expect(onChange).toHaveBeenLastCalledWith({ count: 15 });
     });
 
+    it("reports no value for a magnitude JS cannot hold exactly", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderWithMantine(
+        <ControlledSchemaForm schema={numberSchema} onChange={onChange} />,
+      );
+      const input = screen.getByLabelText(/Divisor/) as HTMLInputElement;
+      // Past Number.MAX_SAFE_INTEGER, Mantine stops emitting a number and hands
+      // back the raw string to avoid destroying precision. Number() would round
+      // this to ...904, so parsing it would send a value the user never typed.
+      await user.type(input, "90071992547409910");
+      expect(input.value).toBe("90071992547409910");
+      expect(onChange).toHaveBeenLastCalledWith({ divisor: undefined });
+    });
+
+    it("still parses a long decimal, which stays exactly representable", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderWithMantine(
+        <ControlledSchemaForm schema={numberSchema} onChange={onChange} />,
+      );
+      const input = screen.getByLabelText(/Divisor/) as HTMLInputElement;
+      // Guards the safe-integer check against over-rejecting: the fractional
+      // digits are not what overflows, so this must not be dropped.
+      await user.type(input, "3.14159265358979");
+      expect(onChange).toHaveBeenLastCalledWith({ divisor: 3.14159265358979 });
+    });
+
     it("drops in-progress text when resetKey moves the form to another entity", async () => {
       const user = userEvent.setup();
       // Both "tools" expose the same-named number field with no default, so the

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
@@ -2,7 +2,11 @@ import { useState } from "react";
 import { describe, it, expect, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import type { InspectorFormSchema } from "../../../utils/jsonUtils";
-import { renderWithMantine, screen } from "../../../test/renderWithMantine";
+import {
+  fireEvent,
+  renderWithMantine,
+  screen,
+} from "../../../test/renderWithMantine";
 import { SchemaForm } from "./SchemaForm";
 
 describe("SchemaForm", () => {
@@ -330,6 +334,76 @@ describe("SchemaForm", () => {
       await user.type(input, "1.5");
       expect(input.value).toBe("15");
       expect(onChange).toHaveBeenLastCalledWith({ count: 15 });
+    });
+
+    it("drops in-progress text when resetKey moves the form to another entity", async () => {
+      const user = userEvent.setup();
+      // Both "tools" expose the same-named number field with no default, so the
+      // value is `undefined` before and after the switch. The value comparison
+      // sees no divergence, and only resetKey can tell the field to start over.
+      const schema: InspectorFormSchema = {
+        type: "object",
+        properties: { divisor: { type: "number", title: "Divisor" } },
+      };
+      function Harness() {
+        const [tool, setTool] = useState("tool-a");
+        const [values, setValues] = useState<Record<string, unknown>>({});
+        return (
+          <>
+            <button
+              type="button"
+              onClick={() => {
+                setTool("tool-b");
+                // What ToolsScreen does on select: replace the form values.
+                setValues({});
+              }}
+            >
+              Switch tool
+            </button>
+            <SchemaForm
+              schema={schema}
+              values={values}
+              onChange={setValues}
+              resetKey={tool}
+            />
+          </>
+        );
+      }
+      renderWithMantine(<Harness />);
+      const input = () => screen.getByLabelText(/Divisor/) as HTMLInputElement;
+      await user.type(input(), "-");
+      expect(input().value).toBe("-");
+      // fireEvent, not user.click: a real click also blurs the input, and
+      // Mantine sanitizes an incomplete value on blur — which would mask
+      // whether the switch itself cleared the draft. This drives the state
+      // change without the blur, isolating the reset to resetKey.
+      fireEvent.click(screen.getByRole("button", { name: "Switch tool" }));
+      expect(input().value).toBe("");
+    });
+
+    it("keeps in-progress text across re-renders of the same entity", async () => {
+      const user = userEvent.setup();
+      // The counterpart to the test above: a stable resetKey must NOT remount
+      // the field, or every keystroke would wipe the draft and reinstate #1888.
+      const schema: InspectorFormSchema = {
+        type: "object",
+        properties: { divisor: { type: "number", title: "Divisor" } },
+      };
+      function Harness() {
+        const [values, setValues] = useState<Record<string, unknown>>({});
+        return (
+          <SchemaForm
+            schema={schema}
+            values={values}
+            onChange={setValues}
+            resetKey="tool-a"
+          />
+        );
+      }
+      renderWithMantine(<Harness />);
+      const input = screen.getByLabelText(/Divisor/) as HTMLInputElement;
+      await user.type(input, "1.5");
+      expect(input.value).toBe("1.5");
     });
 
     it("re-syncs the displayed text when the value changes externally", async () => {

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { describe, it, expect, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import type { InspectorFormSchema } from "../../../utils/jsonUtils";
@@ -226,6 +227,140 @@ describe("SchemaForm", () => {
     expect(onChange).toHaveBeenCalled();
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
     expect(lastCall.count).toBeUndefined();
+  });
+
+  describe("number fields (#1888)", () => {
+    // The real callers keep the form values in state and feed them back in, so
+    // the bug only reproduces against a genuinely controlled SchemaForm: an
+    // uncontrolled render never rewrites the box and would pass either way.
+    function ControlledSchemaForm({
+      schema,
+      initialValues = {},
+      onChange,
+    }: {
+      schema: InspectorFormSchema;
+      initialValues?: Record<string, unknown>;
+      onChange: (values: Record<string, unknown>) => void;
+    }) {
+      const [values, setValues] =
+        useState<Record<string, unknown>>(initialValues);
+      return (
+        <SchemaForm
+          schema={schema}
+          values={values}
+          onChange={(next) => {
+            setValues(next);
+            onChange(next);
+          }}
+        />
+      );
+    }
+
+    const numberSchema: InspectorFormSchema = {
+      type: "object",
+      properties: {
+        divisor: { type: "number", title: "Divisor" },
+      },
+    };
+
+    it("lets a decimal be typed all the way through", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderWithMantine(
+        <ControlledSchemaForm schema={numberSchema} onChange={onChange} />,
+      );
+      const input = screen.getByLabelText(/Divisor/) as HTMLInputElement;
+      await user.type(input, "1.5");
+      expect(input.value).toBe("1.5");
+      expect(onChange).toHaveBeenLastCalledWith({ divisor: 1.5 });
+    });
+
+    it("keeps the trailing decimal point visible mid-entry", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderWithMantine(
+        <ControlledSchemaForm schema={numberSchema} onChange={onChange} />,
+      );
+      const input = screen.getByLabelText(/Divisor/) as HTMLInputElement;
+      await user.type(input, "1.");
+      // The point survives on screen even though "1." parses to plain 1.
+      expect(input.value).toBe("1.");
+      expect(onChange).toHaveBeenLastCalledWith({ divisor: 1 });
+    });
+
+    it("keeps a trailing zero after the decimal point", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderWithMantine(
+        <ControlledSchemaForm schema={numberSchema} onChange={onChange} />,
+      );
+      const input = screen.getByLabelText(/Divisor/) as HTMLInputElement;
+      await user.type(input, "1.50");
+      expect(input.value).toBe("1.50");
+      expect(onChange).toHaveBeenLastCalledWith({ divisor: 1.5 });
+    });
+
+    it("reports a lone minus sign as no value while leaving it typed", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderWithMantine(
+        <ControlledSchemaForm schema={numberSchema} onChange={onChange} />,
+      );
+      const input = screen.getByLabelText(/Divisor/) as HTMLInputElement;
+      await user.type(input, "-");
+      expect(input.value).toBe("-");
+      expect(onChange).toHaveBeenLastCalledWith({ divisor: undefined });
+      await user.type(input, "2.5");
+      expect(onChange).toHaveBeenLastCalledWith({ divisor: -2.5 });
+    });
+
+    it("rejects a decimal point in an integer field", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      const schema: InspectorFormSchema = {
+        type: "object",
+        properties: {
+          count: { type: "integer", title: "Count" },
+        },
+      };
+      renderWithMantine(
+        <ControlledSchemaForm schema={schema} onChange={onChange} />,
+      );
+      const input = screen.getByLabelText(/Count/) as HTMLInputElement;
+      await user.type(input, "1.5");
+      expect(input.value).toBe("15");
+      expect(onChange).toHaveBeenLastCalledWith({ count: 15 });
+    });
+
+    it("re-syncs the displayed text when the value changes externally", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      function Harness() {
+        const [values, setValues] = useState<Record<string, unknown>>({
+          divisor: 1.5,
+        });
+        return (
+          <>
+            <button type="button" onClick={() => setValues({ divisor: 42 })}>
+              Load example
+            </button>
+            <SchemaForm
+              schema={numberSchema}
+              values={values}
+              onChange={(next) => {
+                setValues(next);
+                onChange(next);
+              }}
+            />
+          </>
+        );
+      }
+      renderWithMantine(<Harness />);
+      const input = screen.getByLabelText(/Divisor/) as HTMLInputElement;
+      expect(input.value).toBe("1.5");
+      await user.click(screen.getByRole("button", { name: "Load example" }));
+      expect(input.value).toBe("42");
+    });
   });
 
   it("falls back to empty/const labels for oneOf items missing const and title", () => {

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
@@ -53,10 +53,26 @@ function toEnumData(
 
 /**
  * Interpret whatever Mantine's `NumberInput` reported as the JSON value for the
- * field. It emits a `number` once the text parses cleanly, and the **raw string**
- * while it does not — `""` when cleared, but also the in-progress `"1."`, `"-"`,
- * and `"1e"`. Anything that is not a finite number becomes `undefined`, which is
- * how an absent optional argument is represented everywhere else in this form.
+ * field. Anything that is not a finite number becomes `undefined`, which is how
+ * an absent optional argument is represented everywhere else in this form.
+ *
+ * `NumberInput` emits a `number` only when the text both parses *and* is exactly
+ * representable; otherwise it hands back the **raw string** (see its
+ * `isValidNumber` guard). Two quite different situations produce a string, and
+ * they are treated differently here:
+ *
+ * 1. **Mid-entry text** — `""` when cleared, plus `"1."`, `"1.50"`, and a lone
+ *    `"-"`. These are parsed: `"1."` really does mean `1`. (Note that an
+ *    exponent is *not* in this set — `NumberInput` masks input through
+ *    `NumericFormat`, which rejects `e` outright, so `"1e"` can never be typed.)
+ * 2. **Values JS cannot hold exactly** — anything at or beyond
+ *    `Number.MAX_SAFE_INTEGER`. `Number("90071992547409910")` silently yields
+ *    `90071992547409904`, so parsing here would send the server a number the
+ *    user never entered. An inspector must not misreport what it transmits, so
+ *    these report no value instead — which is also what this field did with such
+ *    input before #1888, making it no regression. Preserving them properly needs
+ *    an exact-serialization path down the whole `tools/call` chain, which is a
+ *    separate concern from being able to type a decimal.
  */
 function toNumericValue(raw: string | number): number | undefined {
   if (typeof raw === "number") {
@@ -66,7 +82,12 @@ function toNumericValue(raw: string | number): number | undefined {
     return undefined;
   }
   const parsed = Number(raw);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+  // Case 2 above. The integer part is what overflows exact representation; the
+  // fractional digits are bounded by the same guard and stay lossless.
+  return Number.isSafeInteger(Math.trunc(parsed)) ? parsed : undefined;
 }
 
 interface SchemaNumberInputProps {

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
@@ -98,6 +98,11 @@ interface SchemaNumberInputProps {
  * parses to, which leaves an external reset (a cleared form, a loaded example)
  * working while an in-progress `"1."` — whose parse is `1`, matching the value we
  * just emitted — is left alone.
+ *
+ * That value comparison cannot see a reset to an *equal* value, so the caller is
+ * additionally expected to vary this component's React key via `SchemaForm`'s
+ * `resetKey` when it switches which entity the form edits. See the note on that
+ * prop for the case it covers.
  */
 function SchemaNumberInput({
   value,
@@ -129,6 +134,25 @@ export interface SchemaFormProps {
   values: Record<string, unknown>;
   onChange: (values: Record<string, unknown>) => void;
   disabled?: boolean;
+  /**
+   * Stable identity of whatever this form is editing — a tool name, a request
+   * id. Pass it whenever the same mounted form is reused for a *different*
+   * entity, which is the case for the Tools tab: `ToolDetailPanel` is not keyed
+   * by tool, so selecting another tool re-renders the same field components.
+   *
+   * It exists because the number field's draft/value re-sync compares parsed
+   * numbers, and so cannot detect a reset to an equal value. Type `-` (draft
+   * `"-"`, value `undefined`), then switch to a tool with a same-named number
+   * field and no default: the value is `undefined` on both sides, no divergence
+   * is seen, and the stale `-` would otherwise be left in the box for the new
+   * tool to continue from. Varying `resetKey` remounts the field instead, so no
+   * in-progress text can outlive the entity it was typed into.
+   *
+   * Omit it when the form is mounted fresh per entity (the elicitation panels),
+   * where unmounting already discards the draft. The schema object itself is no
+   * substitute — callers rebuild it every render, so its identity is unstable.
+   */
+  resetKey?: string;
 }
 
 function getDefaultValue(fieldSchema: InspectorFormSchema): unknown {
@@ -153,6 +177,7 @@ export function SchemaForm({
   values,
   onChange,
   disabled = false,
+  resetKey,
 }: SchemaFormProps) {
   const properties = schema.properties ?? {};
   const requiredFields = schema.required ?? [];
@@ -232,7 +257,9 @@ export function SchemaForm({
     if (fieldSchema.type === "number" || fieldSchema.type === "integer") {
       return (
         <SchemaNumberInput
-          key={fieldName}
+          // The only field holding local state, so the only one that has to be
+          // remounted when `resetKey` says the form moved to another entity.
+          key={resetKey === undefined ? fieldName : `${resetKey}:${fieldName}`}
           label={label}
           description={description}
           withAsterisk={isRequired}
@@ -318,6 +345,8 @@ export function SchemaForm({
                 handleFieldChange(fieldName, nestedValues)
               }
               disabled={disabled}
+              // Sub-fields belong to the same entity, so they reset with it.
+              resetKey={resetKey}
             />
           </IndentedStack>
         </Stack>

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
@@ -8,7 +8,9 @@ import {
   Text,
   TextInput,
 } from "@mantine/core";
+import { useState } from "react";
 import { ClearButton } from "../../elements/ClearButton/ClearButton";
+import { useValueChange } from "../../../hooks/useValueChange";
 import type { InspectorFormSchema } from "../../../utils/jsonUtils";
 
 const FieldLabel = Text.withProps({
@@ -47,6 +49,79 @@ function toEnumData(
     return values.map((value, index) => ({ value, label: names[index] }));
   }
   return values;
+}
+
+/**
+ * Interpret whatever Mantine's `NumberInput` reported as the JSON value for the
+ * field. It emits a `number` once the text parses cleanly, and the **raw string**
+ * while it does not — `""` when cleared, but also the in-progress `"1."`, `"-"`,
+ * and `"1e"`. Anything that is not a finite number becomes `undefined`, which is
+ * how an absent optional argument is represented everywhere else in this form.
+ */
+function toNumericValue(raw: string | number): number | undefined {
+  if (typeof raw === "number") {
+    return Number.isFinite(raw) ? raw : undefined;
+  }
+  if (raw.trim() === "") {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+interface SchemaNumberInputProps {
+  label: string;
+  description?: string;
+  withAsterisk: boolean;
+  disabled: boolean;
+  value: number | undefined;
+  min?: number;
+  max?: number;
+  allowDecimal: boolean;
+  onChange: (value: number | undefined) => void;
+}
+
+/**
+ * A `NumberInput` that keeps the text the user is typing, not just the number it
+ * currently parses to.
+ *
+ * Driving `NumberInput` directly off the parent's numeric value makes a decimal
+ * impossible to enter (#1888): typing `.` after `1` produces the unparseable
+ * string `"1."`, the numeric value stays `1`, and the controlled `value` prop
+ * immediately rewrites the box back to `"1"` — so the `.` vanishes and `1.5` can
+ * never be reached. Trailing zeros (`"1.50"`) and a lone leading `"-"` fail the
+ * same way.
+ *
+ * So the raw text is held here as the source of truth for what is *displayed*,
+ * while the parent still only ever sees a `number | undefined`. The two are
+ * re-synced only when the parent's value genuinely diverges from what the draft
+ * parses to, which leaves an external reset (a cleared form, a loaded example)
+ * working while an in-progress `"1."` — whose parse is `1`, matching the value we
+ * just emitted — is left alone.
+ */
+function SchemaNumberInput({
+  value,
+  onChange,
+  ...inputProps
+}: SchemaNumberInputProps) {
+  const [draft, setDraft] = useState<string | number>(value ?? "");
+
+  useValueChange(value, (next) => {
+    if (!Object.is(toNumericValue(draft), next)) {
+      setDraft(next ?? "");
+    }
+  });
+
+  return (
+    <NumberInput
+      {...inputProps}
+      value={draft}
+      onChange={(next) => {
+        setDraft(next);
+        onChange(toNumericValue(next));
+      }}
+    />
+  );
 }
 
 export interface SchemaFormProps {
@@ -156,19 +231,19 @@ export function SchemaForm({
     // number or integer
     if (fieldSchema.type === "number" || fieldSchema.type === "integer") {
       return (
-        <NumberInput
+        <SchemaNumberInput
           key={fieldName}
           label={label}
           description={description}
           withAsterisk={isRequired}
           disabled={disabled}
-          value={(rawValue as number) ?? ""}
+          value={rawValue as number | undefined}
           min={fieldSchema.minimum}
           max={fieldSchema.maximum}
-          onChange={(val) => {
-            const numericValue = typeof val === "string" ? undefined : val;
-            handleFieldChange(fieldName, numericValue);
-          }}
+          // An `integer` field rejects the decimal point outright rather than
+          // accepting a value the schema forbids.
+          allowDecimal={fieldSchema.type === "number"}
+          onChange={(val) => handleFieldChange(fieldName, val)}
         />
       );
     }

--- a/clients/web/src/components/groups/ToolDetailPanel/ToolDetailPanel.tsx
+++ b/clients/web/src/components/groups/ToolDetailPanel/ToolDetailPanel.tsx
@@ -317,6 +317,10 @@ export function ToolDetailPanel({
             values={formValues}
             onChange={onFormChange}
             disabled={isExecuting}
+            // This panel is reused across tool selections rather than remounted,
+            // so the form needs the tool name to drop another tool's
+            // in-progress field text. See SchemaFormProps.resetKey.
+            resetKey={name}
           />
 
           {progress && <ProgressDisplay params={progress} />}


### PR DESCRIPTION
Closes #1888

## The bug

A float parameter cannot be typed. Entering `1.5` in a `number` field leaves `5` in the box — the decimal point is swallowed the moment it is pressed, so `1.5` is unreachable and any tool taking a non-integer number is uncallable from the web UI.

## Cause

`SchemaForm` drove Mantine's `NumberInput` directly off the parent's **numeric** value:

```tsx
value={(rawValue as number) ?? ""}
onChange={(val) => {
  const numericValue = typeof val === "string" ? undefined : val;
  handleFieldChange(fieldName, numericValue);
}}
```

`NumberInput` reports a `number` once the text parses cleanly and the **raw string** while it does not. Typing `.` after `1` produces the string `"1."`, which the handler collapsed to `undefined` — and because the control is fully controlled from parent state, the `value` prop immediately rewrote the box. The keystroke was thrown away before it could become part of a longer number.

The same shape breaks two other entries: a trailing zero (`1.50`) and a lone leading `-`. (Not an exponent — `NumberInput` masks input through `NumericFormat`, which rejects `e` outright, so `1e` can never be typed in the first place.)

## Fix

`clients/web/src/components/groups/SchemaForm/SchemaForm.tsx` grows a small `SchemaNumberInput` that keeps the **text being typed** as the source of truth for what is displayed, while the parent still only ever sees a `number | undefined`:

- `toNumericValue()` parses whatever `NumberInput` reported; anything not a finite number becomes `undefined`, matching how an absent optional argument is represented elsewhere in the form. It deliberately does **not** parse a value at or beyond `Number.MAX_SAFE_INTEGER` — `NumberInput` hands those back as a string precisely because JS cannot hold them, and `Number("90071992547409910")` would silently become `…904`. An inspector must not misreport what it sends, so those report no value (unchanged from before this PR).
- `resetKey` — a stable identity for whatever the form is editing — varies the number field's React key. `ToolDetailPanel` and `AppDetailPanel` are reused across selections rather than remounted, so without it an in-progress `-` could outlive the tool/app it was typed into whenever the old and new values are both `undefined` (a case the parsed-number comparison cannot see). The elicitation panels omit it: they mount fresh per request, so unmounting already discards the draft.
- The draft text and the parent value are re-synced only when they genuinely diverge — via `useValueChange` (adjust-state-during-render), never a `useEffect`, per the project rule. An in-progress `"1."` parses to `1`, which matches the value just emitted, so it is left alone; an external reset (cleared form, loaded example) still rewrites the box.
- `allowDecimal={fieldSchema.type === "number"}` makes an `integer` field reject the decimal point outright instead of accepting a value its schema forbids. This matches what the TUI already does (`clients/tui/src/utils/schemaToForm.ts` maps `integer` → ink `integer`, `number` → ink `float`).

All four `SchemaForm` consumers inherit the fix: the Tools tab, both elicitation panels, and the Apps detail panel. Nested object sub-forms inherit `resetKey` from their parent.

## Tests

Ten new cases in `SchemaForm.test.tsx` under a `number fields (#1888)` block, plus one in `AppDetailPanel.test.tsx`. They render through a **controlled** harness that feeds values back — an uncontrolled render never rewrites the box and would pass either way, so the bug only reproduces against the real usage shape.

| Case | Asserts |
| --- | --- |
| `1.5` typed | box shows `1.5`, parent gets `1.5` |
| `1.` typed | point stays visible, parent gets `1` |
| `1.50` typed | trailing zero stays visible, parent gets `1.5` |
| `-` then `2.5` | lone `-` reports `undefined` while staying typed; result is `-2.5` |
| `1.5` into an `integer` | point rejected → `15` |
| `90071992547409910` typed | reports `undefined` rather than the rounded `…904` |
| `3.14159265358979` typed | still parsed — fractional digits are not what overflows |
| external value change | draft re-syncs to the new value |
| `resetKey` changes | draft is dropped |
| `resetKey` stable | draft is **kept** across re-renders |
| app switch (`AppDetailPanel`) | draft is dropped |

That last "stable `resetKey`" case is the guard that matters: a `resetKey` that changed every render would remount on each keystroke, wiping the draft and silently reinstating #1888 while the reset test stayed green.

The existing "cleared number field passes `undefined`" test is unchanged and still green.

## Proof of functionality

Captured against the **prod** web build (`clients/web/dist`) driven headlessly, connected over streamable HTTP to the composable test server's `add` tool (two `z.number()` arguments). Both runs type the exact same keystrokes: `1.5` into `a`, `2.25` into `b`.

### Before — the decimal point is swallowed

`1.5` typed into `a` leaves **`5`**; `2.25` typed into `b` leaves **`25`**.

<img width="1440" alt="Tools tab before the fix: the add tool's a field shows 5 and b shows 25 after typing 1.5 and 2.25" src="https://github.com/user-attachments/assets/9e1218cb-5c00-4e77-af67-f93d285f1fd7">

Executing it confirms the wrong values reached the server — `5 + 25 = 30`:

<img width="1440" alt="Result panel before the fix showing result 30" src="https://github.com/user-attachments/assets/8b3225eb-d5d9-4429-83a3-d34508e0c9a3">

### After — the decimals survive

`a` holds **`1.5`**, `b` holds **`2.25`**.

<img width="1440" alt="Tools tab after the fix: the add tool's a field shows 1.5 and b shows 2.25" src="https://github.com/user-attachments/assets/64c8b352-e2c9-4a27-b093-e55515c0b283">

And the executed result is the correct `1.5 + 2.25 = 3.75`, so the parsed floats — not the display text — are what went over the wire:

<img width="1440" alt="Result panel after the fix showing result 3.75" src="https://github.com/user-attachments/assets/a0a819d8-fb74-4389-82f5-edf288d7e425">

## Verification

`npm run ci` from the repo root — `validate` → `coverage` (per-file ≥90 gate) → `verify:build-gate` → `smoke` → Storybook. All green, with `SchemaForm.tsx` at **100 / 97.75 / 100 / 100** (statements / branches / functions / lines).

Two caveats, both pre-existing on `v2/main` and unrelated to this web-only change:

- `clients/tui` `__tests__/App.test.tsx > completes a standard step-up authorize when OAuth succeeds` flaked once (the known poll-based Ink flake) and passed on re-run.
- `clients/web` `src/test/integration/mcp/inspectorClient.test.ts` reproducibly emits two unhandled `CONNECTION_CLOSED` rejections from `InspectorClient.disconnect` during transport teardown, which makes `vitest` exit non-zero even though all 4887 tests pass. It reproduces running that integration file alone, in a file this PR never touches. Filed separately as #1973.
