### PR TITLE
fix(test): wait for the dead transport instead of sleeping 300ms

### DIFF
--- a/clients/web/src/test/integration/mcp/remote/remote-auth-branches.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/remote-auth-branches.test.ts
@@ -79,17 +79,31 @@ async function startUnauthorizedUpstream(): Promise<{
 /**
  * Poll until the server reports the session's transport as dead (#1985).
  *
- * The probe is a **notification** — a `method` with no `id` — which matters:
- * `requestIdForSendWait` returns `undefined` for it, so `/api/mcp/send` never
- * awaits a response and cannot hang. Probing with a *request* would reproduce
- * the very failure this guards against, since a request sent before the
- * transport is marked dead waits forever for a reply the dead child will never
- * send.
+ * The probe is `/api/mcp/auth-state`, chosen because for a session connected
+ * *without* an authState it answers `kind: "transport_error"` from exactly one
+ * place — the `isTransportDead()` short-circuit. Every other outcome is a 400
+ * from `setAuthState` ("Session has no OAuth auth provider"), so a
+ * `transport_error` here is proof that `onclose` has already run
+ * `markTransportDead()`, not merely that some write failed.
  *
- * Either terminal branch of the route answers `kind: "transport_error"` — the
- * `isTransportDead()` short-circuit, and the `catch` around a `send()` that
- * threw on the dead pipe. Both are fine as a stop condition: each one proves the
- * subsequent real send also cannot reach the hanging path.
+ * That single source is the point. `/api/mcp/send` looks like the obvious probe
+ * but answers `transport_error` from *two* branches: the dead-transport
+ * short-circuit, and the `catch` around a `send()` that rejected. Only the first
+ * implies the transport is marked dead, so a stop condition keyed on the
+ * response cannot tell them apart. It happens to be safe today —
+ * `StdioClientTransport.send` rejects only when `_process` is undefined, and the
+ * transport clears `_process` and calls `onclose` in one synchronous block, so
+ * the `catch` branch cannot be observed before `markTransportDead()` has run —
+ * but that is an SDK-internal ordering detail, not something this test states or
+ * controls. If it ever changed, an early return here would hand each call site a
+ * live session: the send test would quietly exercise the `catch` branch instead
+ * of the short-circuit it names, and the auth-state test would fall through to
+ * `setAuthState` and fail on a 400. Probing a single-source route costs nothing
+ * and does not depend on the ordering holding.
+ *
+ * The route also cannot hang: it never awaits a response from the transport, so
+ * unlike a *request* through `/api/mcp/send` there is nothing here to wait
+ * forever on a reply the dead child will never send.
  *
  * Deliberately not `/api/mcp/events`: opening that stream on a dead transport
  * calls `sessions.delete(sessionId)`, so the send under test would then answer
@@ -103,12 +117,14 @@ async function waitForDeadTransport(
   const deadline = Date.now() + timeoutMs;
   let last = "(no response)";
   while (Date.now() < deadline) {
-    const res = await fetch(`${h.baseUrl}/api/mcp/send`, {
+    const res = await fetch(`${h.baseUrl}/api/mcp/auth-state`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sessionId,
-        message: { jsonrpc: "2.0", method: "notifications/initialized" },
+        authState: {
+          oauthTokens: { access_token: "probe", token_type: "Bearer" },
+        },
       }),
     });
     const body = (await res.json()) as { kind?: string };

--- a/clients/web/src/test/integration/mcp/remote/remote-auth-branches.test.ts
+++ b/clients/web/src/test/integration/mcp/remote/remote-auth-branches.test.ts
@@ -76,8 +76,63 @@ async function startUnauthorizedUpstream(): Promise<{
   return { url: `http://127.0.0.1:${port}/mcp`, server };
 }
 
-/** Connect a stdio session whose process crashes almost immediately, then
- * give the onclose handler time to mark the session's transport dead. */
+/**
+ * Poll until the server reports the session's transport as dead (#1985).
+ *
+ * The probe is a **notification** — a `method` with no `id` — which matters:
+ * `requestIdForSendWait` returns `undefined` for it, so `/api/mcp/send` never
+ * awaits a response and cannot hang. Probing with a *request* would reproduce
+ * the very failure this guards against, since a request sent before the
+ * transport is marked dead waits forever for a reply the dead child will never
+ * send.
+ *
+ * Either terminal branch of the route answers `kind: "transport_error"` — the
+ * `isTransportDead()` short-circuit, and the `catch` around a `send()` that
+ * threw on the dead pipe. Both are fine as a stop condition: each one proves the
+ * subsequent real send also cannot reach the hanging path.
+ *
+ * Deliberately not `/api/mcp/events`: opening that stream on a dead transport
+ * calls `sessions.delete(sessionId)`, so the send under test would then answer
+ * 404 instead of the `transport_error` it is asserting.
+ */
+async function waitForDeadTransport(
+  h: Harness,
+  sessionId: string,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let last = "(no response)";
+  while (Date.now() < deadline) {
+    const res = await fetch(`${h.baseUrl}/api/mcp/send`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId,
+        message: { jsonrpc: "2.0", method: "notifications/initialized" },
+      }),
+    });
+    const body = (await res.json()) as { kind?: string };
+    if (body.kind === "transport_error") return;
+    last = `HTTP ${res.status} ${JSON.stringify(body)}`;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(
+    `transport was never reported dead within ${timeoutMs}ms; last probe: ${last}`,
+  );
+}
+
+/**
+ * Connect a stdio session whose process crashes almost immediately, then wait
+ * until the transport is actually marked dead.
+ *
+ * This used to sleep a flat 300ms, which had to cover a cold `spawn()`, node's
+ * startup, its exit, the parent observing the close, and `onclose` marking the
+ * session dead. Comfortable on an idle machine; not under CI contention. When
+ * the budget was missed the session was still live, so the send under test was
+ * dispatched to a transport whose child was gone and hung for the project's full
+ * 30s timeout (#1985). Waiting on the observable condition costs latency on a
+ * slow machine instead of a false failure.
+ */
 async function connectDeadSession(h: Harness): Promise<string> {
   const config: MCPServerConfig = {
     type: "stdio",
@@ -87,9 +142,7 @@ async function connectDeadSession(h: Harness): Promise<string> {
   const res = await connect(h, config);
   expect(res.status).toBe(200);
   const { sessionId } = (await res.json()) as { sessionId: string };
-  // Give the subprocess time to exit and the transport's onclose handler
-  // to mark the session dead (mirrors connect-crash.test.ts's technique).
-  await new Promise((resolve) => setTimeout(resolve, 300));
+  await waitForDeadTransport(h, sessionId);
   return sessionId;
 }
 


### PR DESCRIPTION
Closes #1985

`connectDeadSession` spawned a real node subprocess whose only job is to die, then slept a flat **300 ms** for the death to propagate:

```ts
args: ["-e", "process.stderr.write('dying\\n'); process.exit(1);"],
// ...
await new Promise((resolve) => setTimeout(resolve, 300));
```

That budget has to cover a cold `spawn()`, node's startup, its exit, the parent observing the close, and `onclose` marking the session dead. Comfortable on an idle box; not under CI contention.

## Why it presents as a timeout rather than a failure

When the budget is missed, `isTransportDead()` is still false, so `/api/mcp/send` does not short-circuit. It falls through to `await responseWait` for a `tools/list` reply the dead child can never send — and nothing bounds that wait. The test hangs to the integration project's full 30 s ceiling. **The timeout is the symptom of losing the race**, which is why it never showed up as a clean assertion failure and read as unrelated to whatever PR it landed on.

Observed three times across unrelated branches, plus independently by another agent.

## The fix: poll the observable condition

`waitForDeadTransport` polls until the server reports the transport dead, replacing the fixed sleep. Which route it polls is the whole design, and two of the three plausible choices are wrong:

- **The probe is `/api/mcp/auth-state`.** For a session connected *without* an authState, `createRemoteAuthProvider` returns `undefined`, so `authProviderHandle` is null and `setAuthState` always throws — meaning `transport_error` on that route has exactly **one** source, the `isTransportDead()` short-circuit, and every other outcome is a `400`. The stop condition is therefore proof that `onclose` has run `markTransportDead()`, not an inference. The route also never awaits anything from the transport, so it cannot hang.
- **Not `/api/mcp/send`**, the obvious choice. It answers `transport_error` from **two** branches — the dead-transport short-circuit and the `catch` around a rejected `send()` — and only the first implies the transport is marked dead, so a stop condition keyed on its response can't distinguish them. It happens to be safe today (see below), but on an SDK-internal ordering this test neither states nor controls. Probing a single-source route costs nothing and doesn't depend on that holding.
- **Not `/api/mcp/events`**, which looks like the natural "transport died" signal. Opening that stream on a dead transport calls `sessions.delete(sessionId)`, so the send under test would then answer `404` instead of the `transport_error` it asserts.

### Why the `/api/mcp/send` ambiguity is currently harmless

Raised in review, and worth recording because it also explains the hang. `StdioClientTransport.send` rejects **only** when `_process?.stdin` is falsy — a `write()` to a pipe whose child is gone returns `false` or emits an async `'error'`, and that promise ignores both. And the one thing that clears `_process` does so in the same synchronous block as marking dead:

```js
this._process.on("close", (_code) => {
  this._process = void 0;
  this.onclose?.();     // → server.ts onclose → session.markTransportDead(...)
});
```

No HTTP request can interleave between those two statements, so `send()` rejecting while `isTransportDead()` is still `false` is not an observable state (checked empirically too: 0/25 old-probe iterations returned before the transport was marked dead). That same code is why the original failure was a **30 s hang** rather than an assertion failure — `send()` *resolves* on a dead pipe, so the route proceeds to the unbounded `await responseWait`.

## Verification — the bug reproduced deterministically

Rather than assume the diagnosis, I forced the race to always lose (wait reduced to `0`) and compared:

| Scenario | Result |
| --- | --- |
| Old behavior, budget always missed | **times out at 30 s** — reproduces CI exactly |
| New poll | **passes, 10/10** |

Three consecutive runs of the fixed file also pass, with visible spread in how long the death actually takes (537 ms, 512 ms, 2.38 s) — the variance the fixed sleep was gambling against.

Those numbers were measured against the first poll implementation (the notification through `/api/mcp/send`). After switching the probe to `/api/mcp/auth-state`, re-verified: the file's 10 tests pass, the whole `mcp/remote` integration folder passes (12 files, 336 tests), and full `npm run ci` → `EXIT=0` with every stage running, `smoke:tui` and `smoke:web:app` included.

## Blast radius was wider than the failure reports showed

`connectDeadSession` has **two** call sites — the send test at line 184 (the one that has been failing) and the auth-state test at line 264. The second sits on the identical race and simply had not lost it yet. Fixing the helper rather than the failing test covers both.

## `connect-crash.test.ts:147` deliberately left alone

#1985 proposed giving its 200 ms sleep the same treatment. That suggestion was written before I read `readSseEvents`, which stops at `transport_error` — an event that arrives whenever the child dies, whether or not the sleep was sufficient. So that sleep cannot hang, and changing it would add risk for no gain.

## Out of scope, worth recording

`/api/mcp/send` has **no response timeout**. The hang here is `await responseWait` with nothing bounding it, so a user pointing the Inspector at a stdio process that accepts input but never replies would hang the same way. That is a product robustness question rather than a test one, and is not touched here.

No screenshots — test infrastructure, no web-UI or TUI surface.

> Sibling: #1984 / #1986 is a different flake with the same consequence (a red run on an innocent PR) — a leaked Mantine timer in the *unit* project. Unrelated cause, separate PR.

