### PR TITLE
fix: add eol=lf policy to .gitattributes so Windows checkouts stay clean

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+* text=auto eol=lf
 package-lock.json linguist-generated=true


### PR DESCRIPTION
Closes #1940

One line: `* text=auto eol=lf`. Windows worktrees now materialize LF, agreeing with prettier's `lf` default, which kills the phantom-modified-files class. The index is already fully LF-normalized, so renormalization was a verified no-op — this PR touches only `.gitattributes` (PNGs auto-detect as binary; nothing in the repo needs CRLF; CI is ubuntu-only and unaffected). Full root-cause in the [issue comment](https://github.com/modelcontextprotocol/inspector/issues/1940#issuecomment-5269182790).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
