### PR TITLE
feat: surface and decode the OAuth id_token in Connection Info

### DIFF
--- a/clients/web/src/components/elements/CopyButton/CopyButton.test.tsx
+++ b/clients/web/src/components/elements/CopyButton/CopyButton.test.tsx
@@ -10,6 +10,17 @@ describe("CopyButton", () => {
     expect(screen.getByText("⎘")).toBeInTheDocument();
   });
 
+  it("names itself 'Copy' with no label, and qualifies the name when given one", () => {
+    const { unmount } = renderWithMantine(<CopyButton value="hello" />);
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+    unmount();
+
+    renderWithMantine(<CopyButton value="hello" label="ID Token" />);
+    expect(
+      screen.getByRole("button", { name: "Copy ID Token" }),
+    ).toBeInTheDocument();
+  });
+
   it("triggers a click without throwing when clipboard is unavailable", async () => {
     const user = userEvent.setup();
     renderWithMantine(<CopyButton value="hello" />);

--- a/clients/web/src/components/elements/CopyButton/CopyButton.tsx
+++ b/clients/web/src/components/elements/CopyButton/CopyButton.tsx
@@ -11,6 +11,15 @@ export interface CopyButtonProps {
    * rows (e.g. beside a Code block). Icon size is unchanged.
    */
   flush?: boolean;
+  /**
+   * Names what is being copied, for the accessible label only ("Copy ID
+   * Token"). Set it when more than one CopyButton can appear in the same
+   * region, so button-by-button screen-reader navigation can tell them apart;
+   * a lone control needs no qualifier. The visible tooltip stays "Copy" either
+   * way, and the accessible name keeps "Copy"/"Copied" as its first word so it
+   * still contains the visible text (WCAG 2.5.3).
+   */
+  label?: string;
 }
 
 const CopyActionIcon = ActionIcon.withProps({
@@ -18,7 +27,8 @@ const CopyActionIcon = ActionIcon.withProps({
   fz: 24,
 });
 
-export function CopyButton({ value, flush = false }: CopyButtonProps) {
+export function CopyButton({ value, flush = false, label }: CopyButtonProps) {
+  const qualifier = label ? ` ${label}` : "";
   return (
     <MantineCopyButton value={value}>
       {({ copied, copy }) => (
@@ -26,7 +36,7 @@ export function CopyButton({ value, flush = false }: CopyButtonProps) {
           <CopyActionIcon
             color={copied ? "green" : "var(--inspector-text-primary)"}
             onClick={copy}
-            aria-label={copied ? "Copied" : "Copy"}
+            aria-label={(copied ? "Copied" : "Copy") + qualifier}
             {...(flush && { p: 0, h: "auto", w: "auto" })}
           >
             {copied ? "\u2713" : "\u2398"}

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
@@ -189,7 +189,9 @@ export const WithOAuthIdToken: Story = {
     const canvas = within(canvasElement);
     expect(canvas.getByText("ID Token")).toBeInTheDocument();
     // Only the ID token is a JWT here, so exactly one decode toggle is offered.
-    await userEvent.click(canvas.getByRole("button", { name: "Decode JWT" }));
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Decode JWT for ID Token" }),
+    );
     expect(canvas.getByText(/"sub": "user-42"/)).toBeInTheDocument();
   },
 };

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.stories.tsx
@@ -3,7 +3,7 @@ import type {
   InitializeResult,
 } from "@modelcontextprotocol/client";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, within } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 import {
   ConnectionInfoContent,
   SERVER_INFO_NOT_REPORTED_LABEL,
@@ -159,5 +159,37 @@ export const WithOAuth: Story = {
       scopes: ["read", "write", "admin"],
       accessToken: "eyJhbGciOiJSUzI1NiIs...truncated",
     },
+  },
+};
+
+// An authorization server that also returned an `id_token` (#2019). Shown for
+// inspection only — decoding it is display-only, and it is never used as a
+// credential.
+export const WithOAuthIdToken: Story = {
+  args: {
+    initializeResult: {
+      protocolVersion: "2025-03-26",
+      serverInfo: { name: "OIDC-fronted Server", version: "3.0.0" },
+      capabilities: { tools: { listChanged: true } },
+    },
+    clientCapabilities: { roots: { listChanged: true } },
+    transport: "streamable-http",
+    oauth: {
+      protocol: "standard",
+      authorized: true,
+      authUrl: "https://auth.example.com/oauth2/authorize",
+      scopes: ["openid", "email", "read"],
+      accessToken: "opaque-access-token",
+      // header {"alg":"none"} / payload {"sub":"user-42","email":"a@b.test"}
+      idToken:
+        "eyJhbGciOiJub25lIn0.eyJzdWIiOiJ1c2VyLTQyIiwiZW1haWwiOiJhQGIudGVzdCJ9.",
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText("ID Token")).toBeInTheDocument();
+    // Only the ID token is a JWT here, so exactly one decode toggle is offered.
+    await userEvent.click(canvas.getByRole("button", { name: "Decode JWT" }));
+    expect(canvas.getByText(/"sub": "user-42"/)).toBeInTheDocument();
   },
 };

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
@@ -473,6 +473,60 @@ describe("ConnectionInfoContent", () => {
     expect(screen.queryByText("Auth URL")).not.toBeInTheDocument();
     expect(screen.queryByText("Scopes")).not.toBeInTheDocument();
     expect(screen.queryByText("Access Token")).not.toBeInTheDocument();
+    expect(screen.queryByText("ID Token")).not.toBeInTheDocument();
+  });
+
+  it("renders the ID Token row when the token set carries one", () => {
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={fullResult}
+        clientCapabilities={fullClientCaps}
+        transport="streamable-http"
+        oauth={{
+          protocol: "standard",
+          authorized: true,
+          accessToken: "token-123",
+          idToken: "id-token-456",
+        }}
+      />,
+    );
+    expect(screen.getByText("Access Token")).toBeInTheDocument();
+    expect(screen.getByText("ID Token")).toBeInTheDocument();
+    expect(screen.getByText("id-token-456")).toBeInTheDocument();
+  });
+
+  it("renders the ID Token row on its own when there is no access token", () => {
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={fullResult}
+        clientCapabilities={fullClientCaps}
+        transport="streamable-http"
+        oauth={{
+          protocol: "standard",
+          authorized: true,
+          idToken: "id-token-456",
+        }}
+      />,
+    );
+    expect(screen.queryByText("Access Token")).not.toBeInTheDocument();
+    expect(screen.getByText("ID Token")).toBeInTheDocument();
+  });
+
+  it("omits the ID Token row when only an access token is present", () => {
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={fullResult}
+        clientCapabilities={fullClientCaps}
+        transport="streamable-http"
+        oauth={{
+          protocol: "standard",
+          authorized: true,
+          accessToken: "token-123",
+        }}
+      />,
+    );
+    expect(screen.getByText("Access Token")).toBeInTheDocument();
+    expect(screen.queryByText("ID Token")).not.toBeInTheDocument();
   });
 
   it("does not render OAuth section when oauth prop is omitted", () => {

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.test.tsx
@@ -495,6 +495,41 @@ describe("ConnectionInfoContent", () => {
     expect(screen.getByText("id-token-456")).toBeInTheDocument();
   });
 
+  it("gives the two token rows' controls distinct accessible names", () => {
+    // Both rows carry a copy control, and both tokens here are JWTs so both
+    // carry a decode toggle. Screen-reader button navigation has only the
+    // accessible name to go on, so the four must not collide (#2019 review).
+    const jwt = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJ1c2VyIn0.";
+    renderWithMantine(
+      <ConnectionInfoContent
+        initializeResult={fullResult}
+        clientCapabilities={fullClientCaps}
+        transport="streamable-http"
+        oauth={{
+          protocol: "standard",
+          authorized: true,
+          accessToken: jwt,
+          idToken: jwt,
+        }}
+      />,
+    );
+
+    const names = screen
+      .getAllByRole("button")
+      .map((button) => button.getAttribute("aria-label") ?? button.textContent)
+      .filter((name): name is string => Boolean(name));
+    expect(new Set(names).size).toBe(names.length);
+
+    for (const name of [
+      "Copy Access Token",
+      "Copy ID Token",
+      "Decode JWT for Access Token",
+      "Decode JWT for ID Token",
+    ]) {
+      expect(screen.getByRole("button", { name })).toBeInTheDocument();
+    }
+  });
+
   it("renders the ID Token row on its own when there is no access token", () => {
     renderWithMantine(
       <ConnectionInfoContent

--- a/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/ConnectionInfoContent.tsx
@@ -24,7 +24,7 @@ import {
 import { ContentViewer } from "../../elements/ContentViewer/ContentViewer";
 import { EraBadge } from "../../elements/EraBadge/EraBadge";
 import { isModernEra } from "../../elements/EraBadge/eraUtils";
-import { OAuthAccessTokenField } from "./OAuthAccessTokenField";
+import { OAuthTokenField } from "./OAuthTokenField";
 
 export interface OAuthDetails {
   protocol: "standard" | "ema";
@@ -34,6 +34,13 @@ export interface OAuthDetails {
   authUrl?: string;
   scopes?: string[];
   accessToken?: string;
+  /**
+   * OIDC `id_token` from the stored token set, when the authorization server
+   * returned one. Shown for inspection only — the MCP authorization spec is
+   * plain OAuth 2.1 and the Inspector never treats this as a credential
+   * (#2019). Absent when the token set carries none, so no empty row renders.
+   */
+  idToken?: string;
   /** EMA only — install-level IdP session for legs 1–2. */
   idpSession?: "none" | "logged_in" | "expired";
 }
@@ -370,20 +377,27 @@ export function ConnectionInfoContent({
                 <ValueText>{formatScopes(oauth.scopes)}</ValueText>
               </SimpleGrid>
             )}
-            {oauth.accessToken ? (
-              <OAuthAccessTokenField
-                accessToken={oauth.accessToken}
+            {oauth.accessToken && (
+              <OAuthTokenField
+                label="Access Token"
+                token={oauth.accessToken}
                 onClear={onClearOAuth}
                 clearLabel={CLEAR_OAUTH_STATE_AND_DISCONNECT_LABEL}
               />
-            ) : (
-              onClearOAuth && (
-                <Flex justify="flex-end">
-                  <ClearOAuthButton onClick={onClearOAuth}>
-                    {CLEAR_OAUTH_STATE_AND_DISCONNECT_LABEL}
-                  </ClearOAuthButton>
-                </Flex>
-              )
+            )}
+            {/* Viewer only — an `id_token` the AS happened to return, decoded
+                on request. It carries no clear action: clearing OAuth state is
+                one action for the whole token set, owned by the access-token
+                row (or the standalone button below when there is none). */}
+            {oauth.idToken && (
+              <OAuthTokenField label="ID Token" token={oauth.idToken} />
+            )}
+            {!oauth.accessToken && onClearOAuth && (
+              <Flex justify="flex-end">
+                <ClearOAuthButton onClick={onClearOAuth}>
+                  {CLEAR_OAUTH_STATE_AND_DISCONNECT_LABEL}
+                </ClearOAuthButton>
+              </Flex>
             )}
           </Stack>
         </Stack>

--- a/clients/web/src/components/groups/ConnectionInfoContent/OAuthTokenField.test.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/OAuthTokenField.test.tsx
@@ -12,7 +12,9 @@ describe("OAuthTokenField", () => {
     expect(screen.getByText("Access Token")).toBeInTheDocument();
     expect(screen.getByText(/eyJhbGciOiJub25lIn0/)).toBeInTheDocument();
     expect(screen.getByText(/eyJzdWIiOiJ1c2VyIn0/)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy Access Token" }),
+    ).toBeInTheDocument();
   });
 
   it("replaces raw token with decoded JSON and restores on toggle", async () => {
@@ -20,11 +22,15 @@ describe("OAuthTokenField", () => {
     renderWithMantine(<OAuthTokenField label="Access Token" token={jwt} />);
 
     expect(screen.getByText(/eyJhbGciOiJub25lIn0/)).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Decode JWT" }));
+    await user.click(
+      screen.getByRole("button", { name: "Decode JWT for Access Token" }),
+    );
     expect(screen.getByText(/"sub": "user"/)).toBeInTheDocument();
     expect(screen.queryByText(/eyJhbGciOiJub25lIn0/)).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Show token" }));
+    await user.click(
+      screen.getByRole("button", { name: "Show token for Access Token" }),
+    );
     expect(screen.getByText(/eyJhbGciOiJub25lIn0/)).toBeInTheDocument();
     expect(screen.queryByText(/"sub": "user"/)).not.toBeInTheDocument();
   });
@@ -37,7 +43,7 @@ describe("OAuthTokenField", () => {
       />,
     );
     expect(
-      screen.queryByRole("button", { name: "Decode JWT" }),
+      screen.queryByRole("button", { name: "Decode JWT for Access Token" }),
     ).not.toBeInTheDocument();
   });
 
@@ -50,8 +56,10 @@ describe("OAuthTokenField", () => {
     });
 
     renderWithMantine(<OAuthTokenField label="Access Token" token={jwt} />);
-    await user.click(screen.getByRole("button", { name: "Decode JWT" }));
-    await user.click(screen.getByRole("button", { name: "Copy" }));
+    await user.click(
+      screen.getByRole("button", { name: "Decode JWT for Access Token" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Copy Access Token" }));
 
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('"sub": "user"'),
@@ -68,7 +76,7 @@ describe("OAuthTokenField", () => {
     });
 
     renderWithMantine(<OAuthTokenField label="Access Token" token={jwt} />);
-    await user.click(screen.getByRole("button", { name: "Copy" }));
+    await user.click(screen.getByRole("button", { name: "Copy Access Token" }));
 
     expect(writeText).toHaveBeenCalledWith(jwt);
   });
@@ -101,8 +109,23 @@ describe("OAuthTokenField", () => {
     expect(screen.getByText("ID Token")).toBeInTheDocument();
     expect(screen.queryByText("Access Token")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Decode JWT" }));
+    await user.click(
+      screen.getByRole("button", { name: "Decode JWT for ID Token" }),
+    );
     expect(screen.getByText(/"sub": "user"/)).toBeInTheDocument();
+  });
+
+  it("qualifies the decode and copy accessible names with the row label", () => {
+    // Two rows can render simultaneously (Access Token + ID Token), so the
+    // controls must not share accessible names — see #2019 review.
+    renderWithMantine(<OAuthTokenField label="ID Token" token={jwt} />);
+
+    expect(
+      screen.getByRole("button", { name: "Decode JWT for ID Token" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy ID Token" }),
+    ).toBeInTheDocument();
   });
 
   it("omits the clear action when no handler is given", () => {

--- a/clients/web/src/components/groups/ConnectionInfoContent/OAuthTokenField.test.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/OAuthTokenField.test.tsx
@@ -2,13 +2,13 @@ import { describe, it, expect, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { renderWithMantine, screen } from "../../../test/renderWithMantine";
 import { CLEAR_OAUTH_STATE_AND_DISCONNECT_LABEL } from "./ConnectionInfoContent";
-import { OAuthAccessTokenField } from "./OAuthAccessTokenField";
+import { OAuthTokenField } from "./OAuthTokenField";
 
 const jwt = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJ1c2VyIn0.";
 
-describe("OAuthAccessTokenField", () => {
+describe("OAuthTokenField", () => {
   it("renders token with copy control beside the content", () => {
-    renderWithMantine(<OAuthAccessTokenField accessToken={jwt} />);
+    renderWithMantine(<OAuthTokenField label="Access Token" token={jwt} />);
     expect(screen.getByText("Access Token")).toBeInTheDocument();
     expect(screen.getByText(/eyJhbGciOiJub25lIn0/)).toBeInTheDocument();
     expect(screen.getByText(/eyJzdWIiOiJ1c2VyIn0/)).toBeInTheDocument();
@@ -17,7 +17,7 @@ describe("OAuthAccessTokenField", () => {
 
   it("replaces raw token with decoded JSON and restores on toggle", async () => {
     const user = userEvent.setup();
-    renderWithMantine(<OAuthAccessTokenField accessToken={jwt} />);
+    renderWithMantine(<OAuthTokenField label="Access Token" token={jwt} />);
 
     expect(screen.getByText(/eyJhbGciOiJub25lIn0/)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Decode JWT" }));
@@ -31,7 +31,10 @@ describe("OAuthAccessTokenField", () => {
 
   it("omits decode toggle for opaque tokens", () => {
     renderWithMantine(
-      <OAuthAccessTokenField accessToken="opaque-access-token-value" />,
+      <OAuthTokenField
+        label="Access Token"
+        token="opaque-access-token-value"
+      />,
     );
     expect(
       screen.queryByRole("button", { name: "Decode JWT" }),
@@ -46,7 +49,7 @@ describe("OAuthAccessTokenField", () => {
       configurable: true,
     });
 
-    renderWithMantine(<OAuthAccessTokenField accessToken={jwt} />);
+    renderWithMantine(<OAuthTokenField label="Access Token" token={jwt} />);
     await user.click(screen.getByRole("button", { name: "Decode JWT" }));
     await user.click(screen.getByRole("button", { name: "Copy" }));
 
@@ -64,7 +67,7 @@ describe("OAuthAccessTokenField", () => {
       configurable: true,
     });
 
-    renderWithMantine(<OAuthAccessTokenField accessToken={jwt} />);
+    renderWithMantine(<OAuthTokenField label="Access Token" token={jwt} />);
     await user.click(screen.getByRole("button", { name: "Copy" }));
 
     expect(writeText).toHaveBeenCalledWith(jwt);
@@ -74,8 +77,9 @@ describe("OAuthAccessTokenField", () => {
     const user = userEvent.setup();
     const onClear = vi.fn();
     renderWithMantine(
-      <OAuthAccessTokenField
-        accessToken="opaque-access-token-value"
+      <OAuthTokenField
+        label="Access Token"
+        token="opaque-access-token-value"
         onClear={onClear}
         clearLabel={CLEAR_OAUTH_STATE_AND_DISCONNECT_LABEL}
       />,
@@ -86,5 +90,27 @@ describe("OAuthAccessTokenField", () => {
       }),
     );
     expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("labels the row from the label prop and decodes an ID token", async () => {
+    const user = userEvent.setup();
+    // header {"alg":"none"} / payload {"sub":"user"} — same shape an AS returns
+    // for an `id_token`; the decode path is identical to the access token's.
+    renderWithMantine(<OAuthTokenField label="ID Token" token={jwt} />);
+
+    expect(screen.getByText("ID Token")).toBeInTheDocument();
+    expect(screen.queryByText("Access Token")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Decode JWT" }));
+    expect(screen.getByText(/"sub": "user"/)).toBeInTheDocument();
+  });
+
+  it("omits the clear action when no handler is given", () => {
+    renderWithMantine(<OAuthTokenField label="ID Token" token={jwt} />);
+    expect(
+      screen.queryByRole("button", {
+        name: CLEAR_OAUTH_STATE_AND_DISCONNECT_LABEL,
+      }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/clients/web/src/components/groups/ConnectionInfoContent/OAuthTokenField.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/OAuthTokenField.tsx
@@ -3,8 +3,18 @@ import { Button, Code, Flex, Stack, Text } from "@mantine/core";
 import { decodeJwtPayload, isJwtFormat } from "@inspector/core/auth/ema/jwt.js";
 import { CopyButton } from "../../elements/CopyButton/CopyButton";
 
-export interface OAuthAccessTokenFieldProps {
-  accessToken: string;
+/**
+ * One labelled OAuth token row: the raw value, a copy control, and — when the
+ * value has the three-segment JWT shape — an in-place "Decode JWT" toggle.
+ *
+ * Shared by the Access Token and ID Token rows (#2019). The decode is
+ * display-only (`decodeJwtPayload` does no signature verification), so this is
+ * a viewer: neither token is treated as a credential here.
+ */
+export interface OAuthTokenFieldProps {
+  /** Row caption, e.g. "Access Token" / "ID Token". */
+  label: string;
+  token: string;
   onClear?: () => void;
   clearLabel?: string;
 }
@@ -64,16 +74,17 @@ function JwtTokenText({ token }: { token: string }) {
   );
 }
 
-export function OAuthAccessTokenField({
-  accessToken,
+export function OAuthTokenField({
+  label,
+  token,
   onClear,
   clearLabel = "Clear",
-}: OAuthAccessTokenFieldProps) {
+}: OAuthTokenFieldProps) {
   const [showDecoded, setShowDecoded] = useState(false);
-  const isJwt = isJwtFormat(accessToken);
+  const isJwt = isJwtFormat(token);
   const jwtDecoded = useMemo(
-    () => (isJwt ? decodeJwtPayload(accessToken) : undefined),
-    [accessToken, isJwt],
+    () => (isJwt ? decodeJwtPayload(token) : undefined),
+    [token, isJwt],
   );
 
   const decodedText = useMemo(() => {
@@ -85,12 +96,12 @@ export function OAuthAccessTokenField({
     );
   }, [jwtDecoded]);
 
-  const copyValue = showDecoded && decodedText ? decodedText : accessToken;
+  const copyValue = showDecoded && decodedText ? decodedText : token;
 
   return (
     <Stack gap="xs">
       <CaptionRow>
-        <Caption>Access Token</Caption>
+        <Caption>{label}</Caption>
         <Toolbar>
           {jwtDecoded && (
             <ToolbarButton
@@ -113,9 +124,9 @@ export function OAuthAccessTokenField({
             {showDecoded && decodedText ? (
               decodedText
             ) : isJwt ? (
-              <JwtTokenText token={accessToken} />
+              <JwtTokenText token={token} />
             ) : (
-              accessToken
+              token
             )}
           </TokenCode>
         </TokenColumn>

--- a/clients/web/src/components/groups/ConnectionInfoContent/OAuthTokenField.tsx
+++ b/clients/web/src/components/groups/ConnectionInfoContent/OAuthTokenField.tsx
@@ -107,6 +107,7 @@ export function OAuthTokenField({
             <ToolbarButton
               onClick={() => setShowDecoded((open) => !open)}
               aria-pressed={showDecoded}
+              aria-label={`${showDecoded ? "Show token" : "Decode JWT"} for ${label}`}
             >
               {showDecoded ? "Show token" : "Decode JWT"}
             </ToolbarButton>
@@ -130,7 +131,7 @@ export function OAuthTokenField({
             )}
           </TokenCode>
         </TokenColumn>
-        <CopyButton value={copyValue} flush />
+        <CopyButton value={copyValue} flush label={label} />
       </TokenRow>
     </Stack>
   );

--- a/clients/web/src/components/groups/ConnectionInfoContent/oauthDetailsFromConnectionState.test.ts
+++ b/clients/web/src/components/groups/ConnectionInfoContent/oauthDetailsFromConnectionState.test.ts
@@ -34,6 +34,39 @@ describe("oauthDetailsFromConnectionState", () => {
     });
   });
 
+  it("surfaces an id_token when the token set carries one", () => {
+    const state: OAuthConnectionState = {
+      authorized: true,
+      protocol: "standard",
+      serverUrl: "https://mcp.example.com/mcp",
+      tokens: {
+        access_token: "tok",
+        token_type: "Bearer",
+        id_token: "header.payload.signature",
+      },
+    };
+
+    expect(oauthDetailsFromConnectionState(state)).toEqual({
+      protocol: "standard",
+      authorized: true,
+      accessToken: "tok",
+      idToken: "header.payload.signature",
+    });
+  });
+
+  it("omits idToken when the token set carries none", () => {
+    const state: OAuthConnectionState = {
+      authorized: true,
+      protocol: "standard",
+      serverUrl: "https://mcp.example.com/mcp",
+      tokens: { access_token: "tok", token_type: "Bearer" },
+    };
+
+    expect(oauthDetailsFromConnectionState(state)).not.toHaveProperty(
+      "idToken",
+    );
+  });
+
   it("includes EMA idp session when present", () => {
     const state: OAuthConnectionState = {
       authorized: false,

--- a/clients/web/src/components/groups/ConnectionInfoContent/oauthDetailsFromConnectionState.ts
+++ b/clients/web/src/components/groups/ConnectionInfoContent/oauthDetailsFromConnectionState.ts
@@ -22,6 +22,11 @@ export function oauthDetailsFromConnectionState(
     ...(state.tokens?.access_token && {
       accessToken: state.tokens.access_token,
     }),
+    // Surfaced for inspection when the AS returned one; omitted entirely
+    // otherwise so Connection Info renders no empty row (#2019).
+    ...(state.tokens?.id_token && {
+      idToken: state.tokens.id_token,
+    }),
     ...(state.protocol === "ema" &&
       state.ema?.idpSession && { idpSession: state.ema.idpSession }),
   };

--- a/specification/v2_auth_ema.md
+++ b/specification/v2_auth_ema.md
@@ -334,7 +334,7 @@ When the user connects to a server with `oauth.enterpriseManaged: true` but inst
 - **IdP session** (EMA only) — `none` / `logged_in` / `expired` from `idpSessions[issuer]`
 - **Auth URL** — cached from an in-flight or completed OAuth flow (`OAuthFlowState`), when present
 - **Scopes** — configured vs granted
-- **Access token** — `OAuthAccessTokenField`: copy (raw), decode JWT in place (`core/auth/ema/jwt.ts` helpers); multi-line wrap with segment-aware breaking for JWTs
+- **Access token** (and **ID token**, when the authorization server returned an `id_token`) — `OAuthTokenField`: copy (raw), decode JWT in place (`core/auth/ema/jwt.ts` helpers); multi-line wrap with segment-aware breaking for JWTs. Display only — the `id_token` is never treated as a credential (#2019)
 
 In-flight OAuth flow state uses `OAuthFlowState` / `getOAuthFlowState()` / `getOAuthFlowStep()`. `getOAuthState()` is the persisted connection snapshot; flow state is separate and ephemeral.
 

--- a/specification/v2_ux.md
+++ b/specification/v2_ux.md
@@ -294,7 +294,7 @@ Shown as a modal or dedicated screen after successful connection.
 - Server capabilities: Tools, Resources, Prompts, Logging, Completions, Tasks, Experimental
 - Client capabilities: Sampling, Elicitation, Roots, Tasks, Experimental
 - Display server instructions if provided
-- Show OAuth connection snapshot when applicable (`InspectorClient.getOAuthState()` → `OAuthConnectionState`): protocol, authorization status, client id, EMA IdP session, cached auth URL, scopes, access token with copy and in-place JWT decode (`OAuthAccessTokenField`)
+- Show OAuth connection snapshot when applicable (`InspectorClient.getOAuthState()` → `OAuthConnectionState`): protocol, authorization status, client id, EMA IdP session, cached auth URL, scopes, and the stored tokens — access token, plus the `id_token` when the authorization server returned one — each with copy and in-place JWT decode (`OAuthTokenField`)
 
 ### Feature Screens
 


### PR DESCRIPTION
Closes #2019

## What and why

When an authorization server returns an `id_token` alongside the access token, the Inspector already **persisted** it — and never showed it anywhere. That makes an OIDC-capable server's identity claims invisible during inspection, which is exactly the sort of thing this tool exists to surface. This wires it through to the **Connection Info** panel as a viewer.

## Design decisions

**A viewer, not an OIDC flow.** No OIDC login mode, no signature verification, no treating the `id_token` as a credential anywhere in the connection path. The EMA path is untouched. The value of showing it is that a developer can see what their AS actually issued; validating it is a different feature with a different threat model, and pulling that in here would quietly change what the Inspector *is*.

**No clear action on the ID Token row.** Clearing OAuth state is one action over the whole token set, so `onClear` stays on the Access Token row only. Two clear buttons would imply the tokens can be discarded independently, which is not true.

**Rename, not wrap.** `OAuthAccessTokenField` became `OAuthTokenField` taking `{ label, token, onClear?, clearLabel? }`, done with `git mv` so history follows the file. The ID Token row therefore reuses the existing copy control and "Decode JWT" toggle rather than duplicating them; access-token behavior is unchanged (same props, supplied by the caller).

**Absent, not `undefined`.** `oauthDetailsFromConnectionState` spreads `tokens.id_token` in conditionally, so the `idToken` key is *absent* rather than present-and-undefined when there is no ID token, and `ConnectionInfoContent` renders the row only when present — no empty row.

**Redaction needed no change.** `id_token` is already in `maskSecrets`' `JSON_SENSITIVE_KEYS`, so it stays masked in the Network tab. Verified rather than assumed — there is no new disclosure surface here.

## Tests

7 new tests plus a story, on top of the existing `OAuthAccessTokenField` suite that moved with the rename:

- `OAuthTokenField.test.tsx` — "labels the row from the label prop and decodes an ID token" and "omits the clear action when no handler is given" (the generalized props and the now-optional clear affordance); the pre-existing access-token cases still pass unchanged, which is the regression check on the rename.
- `ConnectionInfoContent.test.tsx` — "renders the ID Token row when the token set carries one", "renders the ID Token row on its own when there is no access token", "omits the ID Token row when only an access token is present".
- `oauthDetailsFromConnectionState.test.ts` — "surfaces an id_token when the token set carries one", "omits idToken when the token set carries none".
- `ConnectionInfoContent.stories.tsx` — a `WithOAuthIdToken` story with a play function.

`npm run ci` green on the post-merge tree (this branch has `v2/main` merged in, including #2017).

## Screenshots

**Before** — no ID Token row:

![Connection Info before](https://github.com/user-attachments/assets/cb34ac6f-17bf-425d-8331-20e48391482c)

**After** — the ID Token row, collapsed:

![Connection Info after](https://github.com/user-attachments/assets/13a01a1d-8d84-41b8-b4d0-1634216289b4)

**After** — "Decode JWT" expanded on the ID Token:

![Connection Info after, decoded](https://github.com/user-attachments/assets/be41793c-f770-40dc-863b-3acfeb6848cb)
