### PR TITLE
test(web): pin the JSON editor's reported escaping reproductions (#1853, #1856, #1885)

### DIFF
--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
@@ -1602,9 +1602,9 @@ describe("JSON editor escaping (#1853, #1856, #1885)", () => {
       },
       required: ["a"],
     };
-    renderWithMantine(
-      <EscapingHarness schema={schema} initial={{ b: null }} />,
-    );
+    // No seeded value: the `null` has to come from the schema's `default`,
+    // which is where the reporter's did.
+    renderWithMantine(<EscapingHarness schema={schema} />);
 
     const b = screen.getByLabelText(/^B$/) as HTMLInputElement;
     expect(b.tagName).toBe("INPUT");
@@ -1632,9 +1632,9 @@ describe("JSON editor escaping (#1853, #1856, #1885)", () => {
         },
       },
     };
-    renderWithMantine(
-      <EscapingHarness schema={schema} initial={{ cfg: null }} />,
-    );
+    // Again unseeded, so the editor's opening `null` is the schema default
+    // being resolved — the state the reporter's recording starts from.
+    renderWithMantine(<EscapingHarness schema={schema} />);
 
     const jsonInput = screen.getByLabelText(/Cfg/) as HTMLTextAreaElement;
     expect(jsonInput.value).toBe("null");

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
@@ -1477,3 +1477,174 @@ describe("SchemaForm draft validity (#2020)", () => {
     expect(screen.getByText(/Not valid JSON/)).toBeInTheDocument();
   });
 });
+
+// Three separate reports of one defect: the JSON editor re-escaping the text
+// being typed. #1853 saw it while typing an array, #1856 on the Backspace that
+// first makes a valid array invalid, and #1885 on a nullable parameter whose
+// default `null` had to be edited in place. All three come from the same
+// mechanism — unparseable draft text stored back as the field's *value*, which
+// the next controlled render re-`JSON.stringify`d, adding a layer of quotes and
+// backslashes per keystroke.
+//
+// The mechanism was removed by the draft/value split in `SchemaJsonField`
+// (#1928/#2007) and the nullable-union collapse that keeps a `T | null` field
+// off this editor entirely (#1928). These lock each report's own reproduction
+// to it, since the fixes were made for differently-framed issues and nothing
+// otherwise pins the reported flows.
+describe("JSON editor escaping (#1853, #1856, #1885)", () => {
+  function EscapingHarness({
+    schema,
+    initial = {},
+  }: {
+    schema: InspectorFormSchema;
+    initial?: Record<string, unknown>;
+  }) {
+    const [values, setValues] = useState<Record<string, unknown>>(initial);
+    return <SchemaForm schema={schema} values={values} onChange={setValues} />;
+  }
+
+  // #1853: `batch_process_items`, typed character by character.
+  it("types a string array through without escaping it (#1853)", async () => {
+    const user = userEvent.setup();
+    const schema: InspectorFormSchema = {
+      type: "object",
+      properties: {
+        itemIds: {
+          type: "array",
+          title: "Item Ids",
+          items: { type: "string" },
+        },
+      },
+      required: ["itemIds"],
+    };
+    renderWithMantine(<EscapingHarness schema={schema} />);
+
+    const jsonInput = screen.getByLabelText(/Item Ids/) as HTMLTextAreaElement;
+    // `[` opens a userEvent keyboard descriptor, so it is escaped as `[[`.
+    await user.type(jsonInput, '[["item-1","item-2"]');
+
+    expect(jsonInput.value).toBe('["item-1","item-2"]');
+    expect(jsonInput.value).not.toContain("\\");
+  });
+
+  // #1853 again, from the comment thread: the caret sitting *outside* the
+  // quotes of a `""` value. One keystroke there made the draft invalid, which
+  // is all it took — `""` + `a` rendered as `"\"\"a"`.
+  it("keeps a keystroke typed outside a string's quotes literal (#1853)", async () => {
+    const user = userEvent.setup();
+    const schema: InspectorFormSchema = {
+      type: "object",
+      // No `type`, so the field lands on the JSON editor holding a string.
+      properties: { note: { title: "Note" } },
+    };
+    renderWithMantine(
+      <EscapingHarness schema={schema} initial={{ note: "" }} />,
+    );
+
+    const jsonInput = screen.getByLabelText(/Note/) as HTMLTextAreaElement;
+    await user.click(jsonInput);
+    await user.keyboard("{End}a");
+
+    expect(jsonInput.value).toBe('""a');
+  });
+
+  // #1856: `sum_numbers`, Backspace with the caret after the closing `]`.
+  it("keeps the draft raw when Backspace invalidates an array (#1856)", async () => {
+    const user = userEvent.setup();
+    const schema: InspectorFormSchema = {
+      type: "object",
+      properties: {
+        numbers: {
+          type: "array",
+          title: "Numbers",
+          items: { type: "number" },
+        },
+      },
+      required: ["numbers"],
+    };
+    renderWithMantine(
+      <EscapingHarness schema={schema} initial={{ numbers: [1, 2] }} />,
+    );
+
+    const jsonInput = screen.getByLabelText(/Numbers/) as HTMLTextAreaElement;
+    await user.click(jsonInput);
+    await user.keyboard("{End}{Backspace}");
+
+    // Exactly the seeded text minus its last character — the draft the reporter
+    // expected, where the field instead showed a quoted, escaped string.
+    expect(jsonInput.value).toBe("[\n  1,\n  2\n");
+
+    // Each further edit compounded the escaping, so keep going.
+    await user.keyboard("{Backspace}{Backspace}");
+    expect(jsonInput.value).not.toContain("\\");
+    expect(jsonInput.value.startsWith('"')).toBe(false);
+
+    // And the draft is still live: closing it back up produces a real array.
+    await user.keyboard("2]");
+    expect(jsonInput.value).toBe("[\n  1,\n  2]");
+  });
+
+  // #1885: FastMCP's `b: int | None = None`, which compiles to an `anyOf` with
+  // a null branch and `default: null`. The reporter was editing the literal
+  // `null` token in a raw JSON box; collapsing the union routes the field to a
+  // real number input, so there is no JSON token to edit in the first place.
+  it("edits a nullable integer as a number input, not a null token (#1885)", async () => {
+    const user = userEvent.setup();
+    const schema: InspectorFormSchema = {
+      type: "object",
+      properties: {
+        a: { type: "integer", title: "A" },
+        b: {
+          title: "B",
+          anyOf: [{ type: "integer" }, { type: "null" }],
+          default: null,
+        },
+      },
+      required: ["a"],
+    };
+    renderWithMantine(
+      <EscapingHarness schema={schema} initial={{ b: null }} />,
+    );
+
+    const b = screen.getByLabelText(/^B$/) as HTMLInputElement;
+    expect(b.tagName).toBe("INPUT");
+    // `null` is rendered as "no value", not as four editable characters.
+    expect(b.value).toBe("");
+
+    await user.click(b);
+    await user.keyboard("42{Backspace}");
+    expect(b.value).toBe("4");
+    expect(b.value).not.toContain("\\");
+  });
+
+  // The same nullable-with-`default: null` shape on a field the collapse still
+  // sends to the JSON editor (an array union). Backspacing the `null` token
+  // there is the exact keystroke sequence from #1885's recording.
+  it("backspaces a null default in the JSON editor without escaping (#1885)", async () => {
+    const user = userEvent.setup();
+    const schema: InspectorFormSchema = {
+      type: "object",
+      properties: {
+        cfg: {
+          title: "Cfg",
+          anyOf: [{ type: "array" }, { type: "null" }],
+          default: null,
+        },
+      },
+    };
+    renderWithMantine(
+      <EscapingHarness schema={schema} initial={{ cfg: null }} />,
+    );
+
+    const jsonInput = screen.getByLabelText(/Cfg/) as HTMLTextAreaElement;
+    expect(jsonInput.value).toBe("null");
+
+    await user.click(jsonInput);
+    await user.keyboard("{End}{Backspace}");
+    expect(jsonInput.value).toBe("nul");
+
+    await user.keyboard("{Backspace}{Backspace}{Backspace}");
+    expect(jsonInput.value).toBe("");
+    expect(jsonInput.value).not.toContain("\\");
+  });
+});


### PR DESCRIPTION
Closes #1853
Closes #1856
Closes #1885

## One defect, reported three ways

All three issues describe the schema form's JSON fallback editor re-escaping the text being typed:

- **#1853** — typing `["item-1","item-2"]` into an array argument; the draft is replaced by a quoted/escaped string mid-entry. Its comment thread adds the sharpest case: with the caret *outside* the quotes of a `""` value, one keystroke gives `"\"\"a"`.
- **#1856** — the Backspace that first makes a valid `[1, 2]` invalid turns the draft into a quoted string, and each further edit adds another layer.
- **#1885** — a nullable parameter (`b: int | None = None`) rendered as a literal `null` token in a raw JSON box; backspacing it walks `null → "nul" → \"nul" → \\\"nul`.

They share one mechanism, which the reporter of #1856 diagnosed correctly: unparseable draft text was stored back as the field's **value**, and the next controlled render `JSON.stringify`'d it — one layer of quotes and backslashes per keystroke.

## Why this PR is tests only

That mechanism is already gone from `v2/main`. It was removed by work done for differently-framed issues, all merged after these reports were filed and none of them referencing them:

- the draft/value split in `SchemaJsonField` — the raw text became the source of truth for what is displayed, while the parent only ever sees parsed JSON (#1928 / #2007),
- the nullable-union collapse, which routes a `T | null` field to a real widget so there is no `null` token to edit in place (#1928, PR #2014),
- the draft-validity channel, so a field holding unsendable text blocks submission instead of silently submitting as absent (#2020, PR #2024).

So nothing in the reported flows is broken today — but nothing pins them either. Each of these three reproductions is a path the existing tests do not walk (a Backspace against a *seeded valid* value, a keystroke outside a string's quotes, a `default: null` in the editor), and each is what a user actually reported. This adds them as regression tests, under the issue numbers, so the fixes cannot be undone without a named failure.

## Verification that these are real regression tests

Checked out `SchemaForm.tsx` from `32d6f80b^` (the commit before "make the JSON fallback typeable") and ran the new block against it — 4 of 5 fail, with exactly the corruption the reporters saw:

```
× types a string array through without escaping it (#1853)
  expected '"\"\\\"\\\\\\\"\\\\\\\\\\\\\\\"\\\\\\…' to be '["item-1","item-2"]'
× keeps a keystroke typed outside a string's quotes literal (#1853)
  expected '"\"\"a"' to be '""a'
× keeps the draft raw when Backspace invalidates an array (#1856)
  expected '"[\n  1,\n  2\n"' to be '[\n  1,\n  2\n'
× backspaces a null default in the JSON editor without escaping (#1885)
  expected '"nul"' to be 'nul'
```

The fifth (#1885's nullable integer rendering as a `NumberInput` rather than a JSON token) passes at that commit because the nullable collapse had already landed on that branch; it is kept as the pin for the reported *shape*, since the reporter's primary ask was that a nullable parameter not be edited as a raw `null` literal at all.

All five pass on `v2/main`.

## Out of scope, noted while verifying

A **number** field carrying a schema `default` (e.g. `b: int = 30`) snaps back to that default when the box is cleared, so the argument cannot be emptied. It is not an escaping defect and not what any of these three issues report — and since sending the default is equivalent to omitting it, nothing is misreported on the wire. Left alone rather than folded in as an unrequested behavior change.

## Screenshots

This PR changes no UI — but since the reports are visual, here is what the tests pin, captured from the real app. "Before" is `SchemaForm.tsx` from `32d6f80b^` (the commit before the fix); "after" is `v2/main` today. Both were driven headlessly through a deep link against a local demo server exposing `batch_process_items` (`itemIds: string[]`), the tool from #1853.

**#1853 — typing `["item-1","item-2"]` one character at a time**

| before | after |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/971c1a04-4387-4cb1-b94f-a3f2c670c5c3) | ![after](https://github.com/user-attachments/assets/9b6f4741-eff6-43ad-ab40-eaab028191f8) |

The "before" box is not a rendering artifact — it is the field's actual content after ~19 keystrokes, each one adding a layer of escaping to the last.

**#1856 — Backspace with the caret after the closing `]` of `[1, 2]`**

| before | after |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/36e2ae18-da91-4bae-aa54-52da125c2d71) | ![after](https://github.com/user-attachments/assets/50c09fa2-ade6-41ad-9553-5c4e99937dff) |

Both "after" shots are caught mid-edit, so the field shows its red "Not valid JSON — this field will be omitted" notice. That is the intended behavior, not a failure: an incomplete draft cannot be sent, so the field says so and the submit gate blocks it (#2020). The point of the pair is what the box *contains* — the user's own raw text, rather than a re-escaped string.

#1885's own reproduction is not shown as a pair: the nullable collapse routes that field to a number input, so there is no JSON token to corrupt and the "before" state no longer exists to photograph.

## Testing

- `npm run ci` from the repo root.


