### PR TITLE
fix(web): stop a schema default from reverting the edit in progress

### DIFF
--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
@@ -1742,6 +1742,25 @@ describe("SchemaForm defaulted fields (#2026)", () => {
     expect(n.value).toBe("");
   });
 
+  // An explicit `null` is a value, not an absent one, so a non-null default
+  // must not be substituted for it. Reachable for a nullable number field the
+  // user cleared, or one the server sent as null.
+  it("shows an explicit null as empty, not as the default", () => {
+    const schema: InspectorFormSchema = {
+      type: "object",
+      properties: {
+        n: {
+          title: "N",
+          anyOf: [{ type: "integer" }, { type: "null" }],
+          default: 30,
+        },
+      },
+    };
+    renderWithMantine(<DefaultHarness schema={schema} initial={{ n: null }} />);
+
+    expect((screen.getByLabelText(/^N$/) as HTMLInputElement).value).toBe("");
+  });
+
   it("still re-syncs a defaulted field when the value changes externally", async () => {
     function ExternalHarness() {
       const [values, setValues] = useState<Record<string, unknown>>({

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
@@ -1743,8 +1743,11 @@ describe("SchemaForm defaulted fields (#2026)", () => {
   });
 
   // An explicit `null` is a value, not an absent one, so a non-null default
-  // must not be substituted for it. Reachable for a nullable number field the
-  // user cleared, or one the server sent as null.
+  // must not be substituted for it. Note the field itself never emits `null` —
+  // clearing it reports `undefined` (pinned by "passes undefined to onChange
+  // when a number field is cleared") — so this arrives from parent state: a
+  // value received from the server, restored from a deep link, or written by a
+  // caller for a nullable schema.
   it("shows an explicit null as empty, not as the default", () => {
     const schema: InspectorFormSchema = {
       type: "object",

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
@@ -1648,3 +1648,108 @@ describe("JSON editor escaping (#1853, #1856, #1885)", () => {
     expect(jsonInput.value).not.toContain("\\");
   });
 });
+
+// A schema `default` is what a field *opens* with, not a value re-imposed on
+// every unsendable draft. Unsendable text reports `undefined` by design, and
+// `resolveValue` used to turn that straight back into the default — a real
+// change from the previous value, so the draft/value re-sync rewrote the box
+// and reverted the keystroke. Almost every edit passes through an unsendable
+// state, which left a defaulted array or object argument uneditable.
+describe("SchemaForm defaulted fields (#2026)", () => {
+  function DefaultHarness({
+    schema,
+    initial = {},
+  }: {
+    schema: InspectorFormSchema;
+    initial?: Record<string, unknown>;
+  }) {
+    const [values, setValues] = useState<Record<string, unknown>>(initial);
+    return <SchemaForm schema={schema} values={values} onChange={setValues} />;
+  }
+
+  const arrayWithDefault: InspectorFormSchema = {
+    type: "object",
+    properties: { tags: { type: "array", title: "Tags", default: ["a"] } },
+  };
+
+  it("opens the JSON editor on the schema default", () => {
+    renderWithMantine(<DefaultHarness schema={arrayWithDefault} />);
+    expect((screen.getByLabelText(/Tags/) as HTMLTextAreaElement).value).toBe(
+      '[\n  "a"\n]',
+    );
+  });
+
+  it("keeps a keystroke typed into a defaulted JSON field", async () => {
+    const user = userEvent.setup();
+    // Seeded the way the Tools tab seeds it — from the schema's defaults, as a
+    // separate value than the schema's own. Sharing one reference hid this.
+    renderWithMantine(
+      <DefaultHarness schema={arrayWithDefault} initial={{ tags: ["a"] }} />,
+    );
+
+    const jsonInput = screen.getByLabelText(/Tags/) as HTMLTextAreaElement;
+    await user.click(jsonInput);
+    await user.keyboard("{End}x");
+
+    // The invalid draft is the user's, not the default reasserting itself.
+    expect(jsonInput.value).toBe('[\n  "a"\n]x');
+  });
+
+  it("lets a defaulted JSON field be edited to a new value", async () => {
+    const user = userEvent.setup();
+    renderWithMantine(
+      <DefaultHarness schema={arrayWithDefault} initial={{ tags: ["a"] }} />,
+    );
+
+    const jsonInput = screen.getByLabelText(/Tags/) as HTMLTextAreaElement;
+    await user.clear(jsonInput);
+    await user.type(jsonInput, '[["b"]');
+
+    expect(jsonInput.value).toBe('["b"]');
+    expect(screen.queryByText(/Not valid JSON/)).not.toBeInTheDocument();
+  });
+
+  it("lets a defaulted number field be emptied", async () => {
+    const user = userEvent.setup();
+    const schema: InspectorFormSchema = {
+      type: "object",
+      properties: { n: { type: "integer", title: "N", default: 30 } },
+    };
+    renderWithMantine(<DefaultHarness schema={schema} initial={{ n: 30 }} />);
+
+    const n = screen.getByLabelText(/N/) as HTMLInputElement;
+    expect(n.value).toBe("30");
+
+    await user.click(n);
+    await user.keyboard("{End}{Backspace}{Backspace}");
+
+    // The box stays empty instead of refilling itself with the default.
+    expect(n.value).toBe("");
+  });
+
+  it("still re-syncs a defaulted field when the value changes externally", async () => {
+    function ExternalHarness() {
+      const [values, setValues] = useState<Record<string, unknown>>({
+        tags: ["a"],
+      });
+      return (
+        <>
+          <SchemaForm
+            schema={arrayWithDefault}
+            values={values}
+            onChange={setValues}
+          />
+          <button type="button" onClick={() => setValues({ tags: ["z"] })}>
+            load example
+          </button>
+        </>
+      );
+    }
+    const user = userEvent.setup();
+    renderWithMantine(<ExternalHarness />);
+
+    const jsonInput = screen.getByLabelText(/Tags/) as HTMLTextAreaElement;
+    await user.click(screen.getByRole("button", { name: "load example" }));
+    expect(jsonInput.value).toBe('[\n  "z"\n]');
+  });
+});

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.test.tsx
@@ -1651,10 +1651,22 @@ describe("JSON editor escaping (#1853, #1856, #1885)", () => {
 
 // A schema `default` is what a field *opens* with, not a value re-imposed on
 // every unsendable draft. Unsendable text reports `undefined` by design, and
-// `resolveValue` used to turn that straight back into the default — a real
-// change from the previous value, so the draft/value re-sync rewrote the box
-// and reverted the keystroke. Almost every edit passes through an unsendable
-// state, which left a defaulted array or object argument uneditable.
+// `resolveValue` used to turn that straight back into the default — a change
+// from the previous value, so the draft/value re-sync rewrote the box and
+// reverted the keystroke.
+//
+// The two halves differed in how reachable they were, which the tests below
+// mirror deliberately:
+//
+// - **The number field reverted in the app.** Numbers compare by value, so
+//   clearing a defaulted box (value `3` → resolved default `30`) always fired
+//   the re-sync and refilled itself.
+// - **The JSON field was latent.** `collectSchemaDefaults` assigns
+//   `fieldSchema.default` itself, so a field seeded from the schema holds the
+//   *same reference* the substitution returns and nothing fires. It needs a
+//   structurally-equal but distinct value object to become observable — which
+//   is what parsed wire/deep-link values and rebuilt nested-object defaults
+//   produce, and what these tests construct.
 describe("SchemaForm defaulted fields (#2026)", () => {
   function DefaultHarness({
     schema,
@@ -1681,8 +1693,10 @@ describe("SchemaForm defaulted fields (#2026)", () => {
 
   it("keeps a keystroke typed into a defaulted JSON field", async () => {
     const user = userEvent.setup();
-    // Seeded the way the Tools tab seeds it — from the schema's defaults, as a
-    // separate value than the schema's own. Sharing one reference hid this.
+    // Seeded with a value that is equal to the schema default but is not the
+    // same object — how values parsed off the wire or out of a deep link
+    // arrive. Sharing the reference (what `collectSchemaDefaults` produces) is
+    // what keeps this latent rather than what makes it safe.
     renderWithMantine(
       <DefaultHarness schema={arrayWithDefault} initial={{ tags: ["a"] }} />,
     );
@@ -1697,6 +1711,7 @@ describe("SchemaForm defaulted fields (#2026)", () => {
 
   it("lets a defaulted JSON field be edited to a new value", async () => {
     const user = userEvent.setup();
+    // Distinct-object seed again, for the reason above.
     renderWithMantine(
       <DefaultHarness schema={arrayWithDefault} initial={{ tags: ["a"] }} />,
     );

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
@@ -341,9 +341,9 @@ interface SchemaNumberInputProps {
    * Raw, not `resolveValue`-substituted — see `SchemaJsonFieldProps.value`.
    *
    * `null` is admitted alongside `undefined` because a nullable number schema
-   * produces it, and the two are not interchangeable here: `undefined` means
-   * "no value supplied" and takes `defaultValue`, while `null` is a value and
-   * displays as an empty box.
+   * produces it — by way of parent state, never by clearing the box — and the
+   * two are not interchangeable here: `undefined` means "no value supplied"
+   * and takes `defaultValue`, while `null` is a value and displays empty.
    */
   value: number | null | undefined;
   /** The schema `default`, used to seed the draft only (#2026). May be `null`. */
@@ -387,10 +387,15 @@ function SchemaNumberInput({
   ...inputProps
 }: SchemaNumberInputProps) {
   // `undefined` means "no value supplied", which is what the default is for.
-  // An explicit `null` is a value — a nullable number the user cleared, or one
-  // the server sent — so it must not be overwritten by a non-null default; it
-  // displays as the empty box `resolveValue` produced before. Hence the
-  // `undefined` test rather than `??`, matching `SchemaJsonField`.
+  // An explicit `null` is a value, so it must not be overwritten by a non-null
+  // default; it displays as the empty box `resolveValue` produced before.
+  // Hence the `undefined` test rather than `??`, matching `SchemaJsonField`.
+  //
+  // Clearing the box does *not* produce that `null` — `toNumericValue("")`
+  // reports `undefined`, which is the behavior the "passes undefined to
+  // onChange when a number field is cleared" test pins. A `null` reaches this
+  // field only from parent state: a value received from the server, restored
+  // from a deep link, or written by a caller for a nullable schema.
   const [draft, setDraft] = useState<string | number>(
     (value === undefined ? defaultValue : value) ?? "",
   );

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
@@ -337,10 +337,17 @@ interface SchemaNumberInputProps {
   description?: string;
   withAsterisk: boolean;
   disabled: boolean;
-  /** Raw, not `resolveValue`-substituted — see `SchemaJsonFieldProps.value`. */
-  value: number | undefined;
-  /** The schema `default`, used to seed the draft only (#2026). */
-  defaultValue: number | undefined;
+  /**
+   * Raw, not `resolveValue`-substituted — see `SchemaJsonFieldProps.value`.
+   *
+   * `null` is admitted alongside `undefined` because a nullable number schema
+   * produces it, and the two are not interchangeable here: `undefined` means
+   * "no value supplied" and takes `defaultValue`, while `null` is a value and
+   * displays as an empty box.
+   */
+  value: number | null | undefined;
+  /** The schema `default`, used to seed the draft only (#2026). May be `null`. */
+  defaultValue: number | null | undefined;
   min?: number;
   max?: number;
   allowDecimal: boolean;
@@ -627,9 +634,12 @@ export function SchemaForm({
           description={description}
           withAsterisk={isRequired}
           disabled={disabled}
-          // Raw and default kept apart, not pre-resolved (#2026).
-          value={values[fieldName] as number | undefined}
-          defaultValue={getDefaultValue(fieldSchema) as number | undefined}
+          // Raw and default kept apart, not pre-resolved (#2026). Both admit
+          // `null`, which a nullable number schema really produces.
+          value={values[fieldName] as number | null | undefined}
+          defaultValue={
+            getDefaultValue(fieldSchema) as number | null | undefined
+          }
           min={fieldSchema.minimum}
           max={fieldSchema.maximum}
           // An `integer` field rejects the decimal point outright rather than

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
@@ -207,7 +207,14 @@ interface SchemaJsonFieldProps {
   description?: string;
   withAsterisk: boolean;
   disabled: boolean;
+  /**
+   * The field's own entry in the form's values — **not** run through
+   * `resolveValue`. A draft-holding field is handed the raw value and the
+   * schema default separately; see `defaultValue` for why.
+   */
   value: unknown;
+  /** The schema `default`, used to seed the draft only. See `defaultValue`. */
+  defaultValue: unknown;
   onChange: (value: unknown) => void;
   onValidityChange: DraftValidityReporter;
 }
@@ -244,18 +251,29 @@ interface SchemaJsonFieldProps {
 function SchemaJsonField({
   fieldName,
   value,
+  defaultValue,
   onChange,
   onValidityChange,
   ...inputProps
 }: SchemaJsonFieldProps) {
-  const [draft, setDraft] = useState(() =>
-    value === undefined ? "" : serializeJson(value),
-  );
+  const [draft, setDraft] = useState(() => {
+    const initial = value === undefined ? defaultValue : value;
+    return initial === undefined ? "" : serializeJson(initial);
+  });
 
   // Re-sync only when the parent's value genuinely diverges from what the draft
   // parses to, which leaves an external reset (a cleared form, a loaded
   // example) working while an in-progress `[` — whose parse is `undefined`,
   // matching the `undefined` we just emitted — is left alone.
+  //
+  // The value compared here is the field's *raw* entry, never `resolveValue`'s
+  // default substitution (#2026). Unsendable text reports `undefined`, and a
+  // defaulted field resolves that straight back to its default — a real change
+  // from the previous value, so this would rewrite the draft to the default and
+  // revert the keystroke. Almost every edit passes through an unsendable state,
+  // which made a defaulted array or object argument uneditable. The default
+  // belongs to what the field *opens* with, seeded above, not to what is
+  // re-imposed while it is being typed into.
   useValueChange(value, (next) => {
     if (!isSameJson(parseJsonDraft(draft), next)) {
       setDraft(next === undefined ? "" : serializeJson(next));
@@ -309,7 +327,10 @@ interface SchemaNumberInputProps {
   description?: string;
   withAsterisk: boolean;
   disabled: boolean;
+  /** Raw, not `resolveValue`-substituted — see `SchemaJsonFieldProps.value`. */
   value: number | undefined;
+  /** The schema `default`, used to seed the draft only (#2026). */
+  defaultValue: number | undefined;
   min?: number;
   max?: number;
   allowDecimal: boolean;
@@ -343,12 +364,19 @@ interface SchemaNumberInputProps {
 function SchemaNumberInput({
   fieldName,
   value,
+  defaultValue,
   onChange,
   onValidityChange,
   ...inputProps
 }: SchemaNumberInputProps) {
-  const [draft, setDraft] = useState<string | number>(value ?? "");
+  const [draft, setDraft] = useState<string | number>(
+    value ?? defaultValue ?? "",
+  );
 
+  // Compared against the raw value, never the default-substituted one, for the
+  // reason spelled out on `SchemaJsonField` (#2026): clearing this box reports
+  // no value, which a defaulted field resolved straight back to its default —
+  // so the box refilled itself and the argument could not be emptied.
   useValueChange(value, (next) => {
     if (!Object.is(toNumericValue(draft), next)) {
       setDraft(next ?? "");
@@ -584,7 +612,9 @@ export function SchemaForm({
           description={description}
           withAsterisk={isRequired}
           disabled={disabled}
-          value={rawValue as number | undefined}
+          // Raw and default kept apart, not pre-resolved (#2026).
+          value={values[fieldName] as number | undefined}
+          defaultValue={getDefaultValue(fieldSchema) as number | undefined}
           min={fieldSchema.minimum}
           max={fieldSchema.maximum}
           // An `integer` field rejects the decimal point outright rather than
@@ -692,7 +722,9 @@ export function SchemaForm({
         description={description}
         withAsterisk={isRequired}
         disabled={disabled}
-        value={rawValue}
+        // Raw and default kept apart, not pre-resolved (#2026).
+        value={values[fieldName]}
+        defaultValue={getDefaultValue(fieldSchema)}
         onChange={(val) => handleFieldChange(fieldName, val)}
         onValidityChange={reportFieldValidity}
       />

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
@@ -379,8 +379,13 @@ function SchemaNumberInput({
   onValidityChange,
   ...inputProps
 }: SchemaNumberInputProps) {
+  // `undefined` means "no value supplied", which is what the default is for.
+  // An explicit `null` is a value — a nullable number the user cleared, or one
+  // the server sent — so it must not be overwritten by a non-null default; it
+  // displays as the empty box `resolveValue` produced before. Hence the
+  // `undefined` test rather than `??`, matching `SchemaJsonField`.
   const [draft, setDraft] = useState<string | number>(
-    value ?? defaultValue ?? "",
+    (value === undefined ? defaultValue : value) ?? "",
   );
 
   // Compared against the raw value, never the default-substituted one, for the

--- a/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
+++ b/clients/web/src/components/groups/SchemaForm/SchemaForm.tsx
@@ -268,12 +268,22 @@ function SchemaJsonField({
   //
   // The value compared here is the field's *raw* entry, never `resolveValue`'s
   // default substitution (#2026). Unsendable text reports `undefined`, and a
-  // defaulted field resolves that straight back to its default — a real change
-  // from the previous value, so this would rewrite the draft to the default and
-  // revert the keystroke. Almost every edit passes through an unsendable state,
-  // which made a defaulted array or object argument uneditable. The default
-  // belongs to what the field *opens* with, seeded above, not to what is
-  // re-imposed while it is being typed into.
+  // defaulted field resolves that straight back to its default — a change from
+  // the previous value, so comparing against the resolved one would rewrite the
+  // draft to the default and revert the keystroke. Almost every edit passes
+  // through an unsendable state, so a defaulted array or object argument would
+  // be uneditable.
+  //
+  // Would be, not was: this is latent under today's seeding, where
+  // `collectSchemaDefaults` assigns `fieldSchema.default` itself, so the
+  // substitution returns the *same reference* and `useValueChange` never fires.
+  // It goes live as soon as the value is a structurally-equal but distinct
+  // object — parsed from the wire or a deep link, or a nested-object default,
+  // which `collectSchemaDefaults` rebuilds per call. `SchemaNumberInput` has no
+  // such accidental protection, since a number compares by value.
+  //
+  // Either way the default belongs to what the field *opens* with, seeded
+  // above, not to what is re-imposed while it is being typed into.
   useValueChange(value, (next) => {
     if (!isSameJson(parseJsonDraft(draft), next)) {
       setDraft(next === undefined ? "" : serializeJson(next));


### PR DESCRIPTION
Closes #2026

## Problem

A field whose schema declares a `default` can have the edit in progress reverted. Unsendable draft text reports `undefined` by design — an inspector must not report a value it cannot send — and `resolveValue` turns that straight back into the schema `default`. That is a change from the previous value, so the draft/value re-sync in `SchemaJsonField` / `SchemaNumberInput` rewrites the box to the default and the keystroke is lost.

**Reproducible today: number fields.** With `n: { "type": "integer", "default": 30 }`, clearing the box refills it with `30` — the argument cannot be emptied.

| before — cleared, refills itself with `30` | after — stays empty |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/7829c375-9ce3-4b5c-b87e-df0aad459562) | ![after](https://github.com/user-attachments/assets/8299618b-0730-42fa-8cde-55993dc3f7c8) |

**Latent: the JSON editor.** The same mechanism applies to an array or object argument, where it would be worse — almost every edit passes through an invalid intermediate state, so the field would be uneditable. It does **not** reproduce through today's seeding path, because `collectSchemaDefaults` seeds the value with the *same object reference* as the schema default, so the substitution returns an identical reference and `useValueChange` never fires. It becomes live the moment the value is a structurally-equal but *distinct* object — values parsed from the wire or a deep link, or a nested-object default (`collectSchemaDefaults` builds a fresh object for that case). Numbers have no such protection, being primitives.

Verified in the real app, which is what the pair below shows: the field opens on its valid default `["a"]`, and editing it to a different valid value `["b"]` works identically before and after. No error state on either side — the array half of this defect is latent, so there is nothing here for the fix to change.

The field as it opens, on the schema default:

![opens on the default](https://github.com/user-attachments/assets/d9b3ddbc-fe92-4c2b-bf0c-72a47565691d)

Then edited to `["b"]`:

| before — `v2/main` | after — this PR |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/109d8bed-ce8a-4c20-9970-fd8bf98811b4) | ![after](https://github.com/user-attachments/assets/c66f876a-ad0a-4dcd-9f6f-f0dc43c4872a) |

## Fix

Hand the two draft-holding fields the **raw** value and the schema **default** separately, and compare only against the raw one:

- the default seeds what the field *opens* with, which is what a `default` means;
- the re-sync no longer sees a change when the user's own unsendable text round-trips as `undefined`;
- an external reset (a cleared form, a loaded example) still re-syncs, because that changes the raw value.

Every other field keeps resolving through `resolveValue` unchanged — only the two fields holding local draft state needed the split. The JSON half is fixed alongside the number half deliberately: it is the same defect, one distinct object away from being reachable, and cheaper to close now than to rediscover from a bug report.

## Testing

Five tests in a new `SchemaForm defaulted fields (#2026)` block. Three fail on `v2/main`:

```
× keeps a keystroke typed into a defaulted JSON field
  expected '[\n  "a"\n]' to be '[\n  "a"\n]x'
× lets a defaulted JSON field be edited to a new value
  expected '[\n  "a"\n]["b"]' to be '["b"]'
× lets a defaulted number field be emptied
  expected '30' to be ''
```

The first two seed the field with a value distinct from the schema default, which is what makes the latent JSON case observable. The other two tests pin what must not regress: the editor still *opens* on the schema default, and an external value change still re-syncs a defaulted field.

`npm run ci` green.

## Screenshots

Captured headlessly against the dev server and a local demo server exposing `save_tags` (`array`, `default ["a"]`) and `set_limit` (`integer`, `default 30`), driven by Playwright through a deep link. "Before" shots were taken by swapping in `SchemaForm.tsx` from `v2/main`.

## Provenance

Found while verifying #1853 / #1856 / #1885 and noted as out of scope in #2025 — the same "the editor fights you" family, with reversion rather than escaping as the symptom, and not covered by those fixes.

