### PR TITLE
chore: bump version to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/inspector",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "The Model Context Protocol Inspector",
   "keywords": [
     "MCP",


### PR DESCRIPTION
Closes #2013

Step 1 of the v2.3.0 release: bump the root `package.json` version **2.2.0 → 2.3.0 on `v2/main`**, before the milestone merge.

This is the first release cut through the procedure established in #2010 / #2011. Doing the bump on the milestone-merge branch instead is what left `v2/main` stranded at `2.0.0` through two releases — the bump only existed downstream of the develop branch, and nothing carried it back.

## The change

Applied with `npm version minor --no-git-tag-version` — exactly the expected two files, three lines:

```
package.json      | 2 +-    "version": "2.2.0" → "2.3.0"
package-lock.json | 4 ++--   top-level `version` AND packages[""].version
```

`--no-git-tag-version` is load-bearing: a bare `npm version` would also create a tag, and it would land on a `v2/main` commit. The release is cut from `main`, so the tag belongs on the merge commit there (step 3). It would also be `v`-prefixed, which does not match this repo's bare `x.y.z` release tags.

## Verification

- `npm run ci` passes end to end in a clean worktree with a real install — `validate` → `coverage` → `verify:build-gate` → `smoke` → Storybook (113 story files, 478 tests). Exit 0.
- Nothing in the repo asserts a specific version value: a grep for `2.2.0` across all tracked `.ts`/`.tsx`/`.mjs`/`.json` (excluding the lockfile) returns nothing. Every Node client reads the version at runtime through `readInspectorVersion()` from the root manifest, and the browser gets it via `GET /api/config`.

No UI or TUI surface changes, so there are no screenshots to attach.

## Not this PR

2. Merge `v2/main` → `main` through the usual milestone-merge branch — it now carries this bump.
3. Tag `origin/main` (bare `2.3.0`, not a local `HEAD`) and draft the Release.

Between step 1 and step 2 the two branches legitimately differ — `v2/main` on the version being built, `main` on the released one. Ahead is expected; behind means something went wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTHVxSu8AUgHRLvo1ntZ8H