### PR TITLE
ci(v1): pin workflow branch filters to v1/main, re-enabling the e2e gate

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,10 +1,14 @@
 name: Playwright Tests
 
+# Pinned to `v1/main`, this branch's own base. These filters read `main`
+# historically, from when the v1 line was itself `main` — which meant they
+# matched nothing here and the suite silently never ran on this branch.
+# See #2065.
 on:
   push:
-    branches: [main]
+    branches: [v1/main]
   pull_request:
-    branches: [main]
+    branches: [v1/main]
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,18 @@
+# `v1/main` is the deprecated maintenance line: it publishes straight from this
+# branch to the `v1-latest` dist-tag and never merges into `main`, which now
+# carries v2. Keep these filters pinned to `v1/main` — a stale `main` entry here
+# describes a topology that no longer exists, and would start matching the moment
+# anything put a v1-shaped tree back on that branch.
+#
+# (For `push`, GitHub runs the workflow file from the pushed commit, so this file
+# is only ever consulted for `v1/main` regardless. The filter states intent.)
 on:
   push:
     branches:
-      - main
       - v1/main
   pull_request:
+    branches:
+      - v1/main
   release:
     types: [published]
 


### PR DESCRIPTION
Closes #2065

Two workflows on this branch still filtered on `main`, left over from when the v1
line *was* `main`. They look like the same defect but differ sharply in
consequence, so they're two commits.

## 1. `main.yml` — stale, but inert (`c7dc8f70`)

- drops the stale `main` entry from the `push` filter
- constrains the previously unfiltered `pull_request` trigger to `v1/main`
- adds a comment recording why, so the next person doesn't re-add `main`

**No behavior change on any path that runs today.** For `push`, GitHub runs the
workflow file **from the pushed commit**, so this file was only ever consulted
when the pushed ref was `v1/main`; the `main` entry could not match unless a
commit on `main` carried a v1-shaped tree, and it doesn't — `origin/main` holds
`claude.yml` plus a `main.yml` that is the v2 workflow. The same rule made the
unfiltered `pull_request` harmless, since a PR's workflow comes from its merge
ref. The value is that the file now states its intent and the stale entry can't
become live later.

The dist-tag hazard people reach for first is already handled independently and
is not what this touches: `publish-all` pins `--tag v1-latest`, with the
reasoning commented in place, and a mis-targeted release is caught by the version
assert on both lines.

## 2. `e2e_tests.yml` — the same leftover, but it had disabled a gate (`95fa9a1c`)

`branches: [main]` on both `push` and `pull_request` matches nothing on this
branch, so **the Playwright suite had never run on `v1/main` at all** — confirmed
against the branch's full run history, which held only
`Run install, format, lint, build, and test on every push` and `CLI Tests`, and
zero `Playwright Tests` runs.

Both filters now point at `v1/main`. Unlike the first commit this **is** a
behavior change — it turns a dead workflow back on — which is why it's separate.

`release` is untouched in both, so publishing is unaffected. `cli_tests.yml`
needs no change: it filters on `paths: cli/**` with no branch filter.

## Verified

The PR's own run is the proof, since the fixed `pull_request` filter is what
makes these execute here at all:

- **`test` (Playwright) — pass, 2m28s: `Running 24 tests using 1 worker` →
  `24 passed (42.8s)`**, Chromium + Firefox. The suite is healthy; the gate had
  simply been switched off.
- `build` — pass, 1m18s
- `publish` / `publish-github-container-registry` — correctly `skipping` on a
  non-release event, confirming the release gating is untouched
- `prettier --check` clean on both files (the repo's `prettier-check` is
  `prettier --check .`, so it covers workflow YAML), and both parse with their
  triggers intact
