### PR TITLE
ci: drop the redundant PR-head checkout from claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,6 +40,9 @@ jobs:
       # force-moved tag would be an unreviewed code change inside a
       # secret-holding job. The trailing `# vX.Y.Z` comment is the form
       # Dependabot reads, so pinning costs us no upgrade automation. (#1882)
+
+      # This lookup exists only to answer "is the head in a fork?". The action
+      # below checks out the PR branch itself, so no `sha` is needed here.
       - name: Get PR details
         if: |
           (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
@@ -64,53 +67,52 @@ jobs:
 
             // A fork PR's head lives in a different repository — or in none at
             // all, if the fork was deleted after the PR was opened (`head.repo`
-            // is then null). Neither is ours to check out, so both count as a
+            // is then null). Neither is ours to run against, so both count as a
             // fork here and the steps below decline rather than guess.
             const headRepo = pr.data.head.repo?.full_name ?? null;
             const isFork = headRepo !== `${context.repo.owner}/${context.repo.repo}`;
 
-            core.setOutput('sha', pr.data.head.sha);
             core.setOutput('is_fork', String(isFork));
 
-      # A fork PR's head is untrusted code, and checking it out would put it in
-      # reach of a tool-enabled agent run holding ANTHROPIC_API_KEY. Reviewing
-      # the base tree instead would only trade that for a confident review of
-      # the wrong tree, so decline visibly and leave the reason in the run.
+      # A fork PR's head is untrusted code, and running a tool-enabled agent
+      # holding ANTHROPIC_API_KEY against it is what this declines. The gate is
+      # load-bearing even though we no longer check the head out ourselves:
+      # claude-code-action fetches a cross-repository head via
+      # `refs/pull/N/head` on its own (see `isCrossRepository` in its
+      # src/github/operations/branch.ts), so skipping the action is the only
+      # thing that keeps that code out of the workspace. Reviewing the base tree
+      # instead would only trade the problem for a confident review of the wrong
+      # tree, so decline visibly and leave the reason in the run.
       - name: Decline fork PR
         if: steps.pr.outcome == 'success' && steps.pr.outputs.is_fork == 'true'
         run: |
           {
             echo "### Claude Code declined this pull request"
             echo
-            echo "The head branch lives in a fork, so its code is not checked out and Claude is not run."
+            echo "The head branch lives in a fork, so Claude is not run against it."
             echo "Push the branch to this repository and re-trigger if a review is needed."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # No `repository:` — a same-repo head is all that reaches this step, and
-      # checkout defaults to `github.repository`, which no PR can influence.
-      - name: Checkout PR branch
-        if: steps.pr.outcome == 'success' && steps.pr.outputs.is_fork == 'false'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ steps.pr.outputs.sha }}
-          fetch-depth: 0
-
-      # `skipped` means the trigger was an issue or a non-PR comment, so there
-      # is no head to check out and the base tree is the right one. The lookup
-      # having *failed* is deliberately not included: this condition carries no
-      # status-check function, so GitHub applies an implicit `success()` and
-      # skips the step after a failed prior step anyway. Spelling out `skipped`
-      # keeps that from having to be re-derived by the next reader.
+      # Base ref only — no `ref:` input, so nothing a PR controls selects what
+      # is checked out. On a PR, claude-code-action then fetches and checks out
+      # the PR branch itself, which is why a second PR-head checkout here would
+      # be redundant. It was also the one thing keeping CodeQL's
+      # `actions/untrusted-checkout` alert open: the rule is syntactic and
+      # cannot see the `is_fork` gate, the job-level `author_association` check,
+      # or the repo's `collaborators_only` fork-PR policy. (#2069)
       - name: Checkout repository
-        if: steps.pr.outcome == 'skipped'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Run Claude Code
-        # Runs only against a tree this workflow actually checked out: the base
-        # repo (non-PR trigger) or a same-repo PR head. A fork PR reaches here
-        # with `is_fork == 'true'` and both disjuncts false, so it is skipped.
+        # `skipped` means the trigger was an issue or a non-PR comment. A
+        # same-repo PR gives `is_fork == 'false'`. A fork PR reaches here with
+        # `is_fork == 'true'` and both disjuncts false, so it is skipped — and
+        # so the action never fetches its head. A *failed* lookup is excluded
+        # too: this condition carries no status-check function, so GitHub
+        # applies an implicit `success()` and skips the step after a failed
+        # prior step regardless of what the comparisons say.
         if: steps.pr.outcome == 'skipped' || steps.pr.outputs.is_fork == 'false'
         id: claude
         uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc # v1.0.190


### PR DESCRIPTION
Closes #2069

Code scanning alert [#71](https://github.com/modelcontextprotocol/inspector/security/code-scanning/71) (`actions/untrusted-checkout/high`) has stayed open against `main` at `.github/workflows/claude.yml:91` — the `Checkout PR branch` step, i.e. the step #1966 added the `is_fork == 'false'` guard to. The alert is current, not a stale pre-#1966 instance:

```
ref:  refs/heads/main @ 86d5f58e     (current head)
path: .github/workflows/claude.yml:91
```

## Why it can't be argued away

The rule is syntactic: privileged trigger (`issue_comment`) + `actions/checkout` with a `ref:` derived from PR data ⇒ high. It does not evaluate `steps.pr.outputs.is_fork` (a runtime step output), the job-level `author_association` gate, or the repo's `pull_request_creation_policy: collaborators_only` (verified against the API). All three of #1966's mitigations are invisible to it, so no further hardening *around* the step clears the alert while the step exists. The choice was dismiss-as-false-positive or remove the step.

## The step was redundant

`anthropics/claude-code-action` checks out the PR branch itself. From `src/github/operations/branch.ts` at the pinned v1.0.190:

```ts
// Handle open PR: Checkout the PR branch
execGit(["fetch", "origin", ...depthArgs, branchName]);
execGit(["checkout", branchName, "--"]);
```

Its own `docs/security.md` names a bare base-ref checkout (no `ref:`) as the **preferred** pattern, and upstream's own `.github/workflows/claude.yml` is exactly that — one `actions/checkout`, no PR lookup, no head checkout. Our `Get PR details` → `Checkout PR branch` pair is vestigial from the v1 example workflow inherited in #1869; the action re-checked-out the same branch moments later on every PR run.

So this removes the alert legitimately rather than by dismissal, and drops one redundant checkout plus one `github-script` round trip per PR run.

## What changed

- **Deleted** `Checkout PR branch` (the flagged step).
- **`Checkout repository` is now unconditional** — base ref, no `ref:` input, so nothing a PR controls selects what is checked out. (It still carries an implicit `success()`, so a failed lookup skips it, same as before.)
- **Dropped** the now-unused `sha` output from `Get PR details`; `is_fork` is its only consumer.
- **Kept** `Get PR details`, `Decline fork PR`, and the `is_fork` gate on `Run Claude Code`, unchanged.

Resolved conditions:

| Trigger | `steps.pr.outcome` | `is_fork` | Checkout | Claude |
| --- | --- | --- | --- | --- |
| Issue / non-PR comment | `skipped` | — | base ref | runs |
| Same-repo PR | `success` | `false` | base ref, then action checks out PR branch | runs |
| Fork PR | `success` | `true` | base ref | **skipped**, reason in step summary |
| PR lookup failed | `failure` | — | skipped (implicit `success()`) | skipped |

## The gate that must not go

Keeping the `is_fork` gate is load-bearing, and more so after this change, not less. The action fetches a cross-repository head **on its own** via `refs/pull/N/head`:

```ts
if (prData.isCrossRepository) {
  execGit(["fetch", "origin", ...depthArgs, `pull/${entityNumber}/head:${branchName}`]);
}
```

So skipping `Run Claude Code` is now the only thing keeping fork code out of the workspace. The comment on `Decline fork PR` says this explicitly so nobody removes it as dead weight once the visible checkout is gone.

## Testing

No test surface — workflow file only. Workflows run from the default branch, so this is inert until `v2/main` reaches `main` at the next milestone merge; alert 71 clears on the CodeQL run after that.

- `npm run ci` passes.
- YAML parses; every step's resolved condition checked against the table above.
- Action SHA pins are untouched (`checkout` v7.0.1, `github-script` v9.0.0, `claude-code-action` v1.0.190).

No UI change, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTHVxSu8AUgHRLvo1ntZ8H
