### PR TITLE
fix(deps): clear remaining npm audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1612,9 +1612,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -4538,16 +4538,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -5223,9 +5223,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6785,9 +6785,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -7281,9 +7281,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7494,9 +7494,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -9774,9 +9774,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -10371,9 +10371,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -10391,7 +10391,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11108,16 +11108,16 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/rimraf/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -81,13 +81,20 @@
   "overrides": {
     "get-intrinsic": "1.3.0",
     "shell-quote": "^1.8.4",
-    "hono": "^4.12.25",
+    "hono": "^4.13.3",
     "form-data": "^4.0.6",
     "@babel/core@<=7.29.0": "^7.29.6",
     "esbuild@<0.28.1": "^0.28.1",
     "minimatch@<3.1.4": "3.1.5",
     "js-yaml@<4": "3.15.1",
-    "js-yaml@>=4": "4.3.1"
+    "js-yaml@>=4": "4.3.1",
+    "@hono/node-server@<1.19.15": "^1.19.15",
+    "ip-address@<=10.3.0": "^10.5.0",
+    "fast-uri@<3.1.5": "^3.1.5",
+    "brace-expansion@<2": "^1.1.18",
+    "brace-expansion@>=4": "^5.0.9",
+    "nanoid@<3.3.18": "^3.3.18",
+    "postcss@<=8.5.22": "^8.5.26"
   },
   "engines": {
     "node": ">=22.7.5"


### PR DESCRIPTION
Fixes #2074 — **stacked on #2073** (base is `fix/v1-js-yaml-override-bump`; GitHub will retarget this to `v1/main` automatically once #2073 merges). Both PRs touch the same `overrides` block and lock, so independent branches would conflict.

Together with #2073 this brings `npm audit` from 8 advisories to **0**.

## Triage

Only **one** of the five production-tree advisories is meaningfully reachable. Full analysis in #2074; summary:

**Reachable — `ip-address` <=10.3.0 (high).** `server/src/index.ts:43` builds `sandboxRateLimiter` from `express-rate-limit`, which calls `new Address6(ip)` for IPv6 subnet keying. Two of the three advisories are exactly about CIDR-suffix and IPv4-mapped/NAT64 misclassification. Impact in context is a **rate-limit key bypass on `/sandbox`**, not the SSRF the titles imply — `req.ip` derives from the socket under default trust-proxy settings and the proxy binds localhost.

**Present but unexercised — 4:**

| Package | Why it doesn't bite |
|---|---|
| `hono` <=4.12.33 | All four advisories are in middleware; none of it is wired up. Arrives only beneath `@hono/node-server`. |
| `@hono/node-server` <1.19.15 | Path traversal in `serve-static` on Windows. SDK imports only `getRequestListener`. |
| `fast-uri` 3.0.0-3.1.4 | Reached via `ajv` for `format: "uri"` checks; the result is never trusted for a host decision. |
| `brace-expansion` <=1.1.17 | Via `serve-handler` -> `minimatch@3.1.5`. At `serve-handler/src/index.js:59` the attacker controls the *path*; brace-expansion expands the *pattern*, which comes from config. |

**Dev-only — 2:** `nanoid`, `postcss` (vite/tailwind build chain). Included only so the audit actually reaches zero.

## Change

All patched releases exist **within the current major line** — no majors:

| Package | From | To |
|---|---|---|
| `ip-address` | 10.2.0 | 10.5.0 |
| `hono` | 4.12.30 | 4.13.3 |
| `@hono/node-server` | 1.19.14 | 1.19.17 |
| `fast-uri` | 3.1.3 | 3.1.5 |
| `brace-expansion` | 1.1.16 / 5.0.7 | 1.1.18 / 5.0.9 |
| `nanoid` | 3.3.16 | 3.3.18 |
| `postcss` | 8.5.19 | 8.5.26 |

> `@hono/node-server` is deliberately held at **1.19.17**, not the current 2.1.1 — a major bump has no place on a deprecated branch.

Lock entries were patched **in place** rather than re-resolved: 9 entries, 30 lines. A full re-resolve would instead churn 164 packages including production deps.

## Verification

- `npm audit` -> **0 vulnerabilities**
- `npm run build` and `npm run lint` both pass
- Tests: 539 client + 37 server + 85 CLI, all passing
- App starts; client served through `serve-handler` (the brace-expansion path) `HTTP 200`; proxy auth gates correctly (401 / 200)
- **Rate limiter exercised directly** — the `ip-address` consumer — and observed decrementing: `X-RateLimit-Limit: 100`, `X-RateLimit-Remaining: 89`
- Full MCP `tools/list` + `tools/call` round-trip through the CLI against a live stdio server

## Note on branch policy

`AGENTS.md` directs agents to file an issue rather than open a PR against `v1/main`. Opened at the explicit direction of a maintainer (@cliffhall), with #2074 filed and tracked on the Inspector V1 board alongside it.

## Not included

The `allowScripts` block npm 11.19 writes to `package.json` is unrelated and deliberately left out of both PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gq5jMmxRUphrVbfNbYVmQH
