### PR TITLE
chore: deny esbuild and fsevents install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,5 +103,9 @@
     "**/*.{js,ts,jsx,tsx,json,md}": [
       "prettier --write"
     ]
+  },
+  "allowScripts": {
+    "esbuild": false,
+    "fsevents": false
   }
 }


### PR DESCRIPTION
Closes #2079


## Problem

npm 11.19 gates dependency lifecycle install scripts behind an `allowScripts` allowlist and warns on every install about packages not yet reviewed:

```
npm warn install-scripts 3 packages have install scripts not yet covered by allowScripts:
npm warn install-scripts   esbuild@0.28.1 (postinstall: node install.js)
npm warn install-scripts   fsevents@2.3.3 (install: (install scripts present))
npm warn install-scripts   fsevents@2.3.2 (install: (install scripts present))
```

## Why deny rather than approve

Neither package needs its install script:

- **esbuild** resolves its platform binary through `optionalDependencies` (`@esbuild/darwin-*` etc.); `install.js` is only a validation / fallback-download step. `node_modules/.bin/esbuild --version` reports correctly with the script skipped.
- **fsevents** (2.3.3 at root, 2.3.2 under `playwright/`) ships a prebuilt `fsevents.node` in the tarball. Its install script is a node-gyp rebuild fallback.

Denying silences the warning without granting a standing "run this package's arbitrary install script" permission that would also apply to future versions.

## Verification

Everything in this repo has been built and tested with these scripts skipped (`npm ci --ignore-scripts`) throughout: `npm run build` and `npm run lint` pass, and all suites pass (539 client + 37 server + 85 CLI). Vite/esbuild bundling works, and the app starts and serves normally. After the change, `npm install-scripts ls` reports `No packages with unreviewed install scripts.`

## Scope note

`AGENTS.md` scopes `v1/main` to security fixes only. This is build-config hygiene rather than a security fix, so it does not have that justification — it is proposed because the warning only affects people building v1, and v1 is where it appears. Opened at the explicit direction of a maintainer (@cliffhall); close it if you would rather v1 not take chores.

**Stacked on #2075** (base is `fix/v1-audit-clear`; GitHub retargets this to `v1/main` automatically as the stack merges). Merge order: #2073 -> #2075 -> #2077.

The change itself is independent of the other two — they touch `overrides` and the lockfile, this touches only a new top-level `allowScripts` key — so it can also be cherry-picked out and landed on its own if the stack is rejected or reordered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gq5jMmxRUphrVbfNbYVmQH