### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CLI for the Model Context Protocol inspector",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Model Context Protocol a Series of LF Projects, LLC.",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Client-side application for the Model Context Protocol inspector",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Model Context Protocol a Series of LF Projects, LLC.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/inspector",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "SEE LICENSE IN LICENSE",
       "workspaces": [
         "client",
@@ -14,9 +14,9 @@
         "cli"
       ],
       "dependencies": {
-        "@modelcontextprotocol/inspector-cli": "^1.0.1",
-        "@modelcontextprotocol/inspector-client": "^1.0.1",
-        "@modelcontextprotocol/inspector-server": "^1.0.1",
+        "@modelcontextprotocol/inspector-cli": "^1.0.2",
+        "@modelcontextprotocol/inspector-client": "^1.0.2",
+        "@modelcontextprotocol/inspector-server": "^1.0.2",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "concurrently": "^9.2.0",
         "node-fetch": "^3.3.2",
@@ -48,7 +48,7 @@
     },
     "cli": {
       "name": "@modelcontextprotocol/inspector-cli",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
@@ -74,7 +74,7 @@
     },
     "client": {
       "name": "@modelcontextprotocol/inspector-client",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@mcp-ui/client": "^6.0.0",
@@ -13254,7 +13254,7 @@
     },
     "server": {
       "name": "@modelcontextprotocol/inspector-server",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Model Context Protocol inspector",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Model Context Protocol a Series of LF Projects, LLC.",
@@ -53,9 +53,9 @@
     "check-version": "node scripts/check-version-consistency.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/inspector-cli": "^1.0.1",
-    "@modelcontextprotocol/inspector-client": "^1.0.1",
-    "@modelcontextprotocol/inspector-server": "^1.0.1",
+    "@modelcontextprotocol/inspector-cli": "^1.0.2",
+    "@modelcontextprotocol/inspector-client": "^1.0.2",
+    "@modelcontextprotocol/inspector-server": "^1.0.2",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "concurrently": "^9.2.0",
     "node-fetch": "^3.3.2",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector-server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Server-side application for the Model Context Protocol inspector",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Model Context Protocol a Series of LF Projects, LLC.",


### PR DESCRIPTION
Fixes #2080 — **stacked on #2077** (base is `chore/v1-allowscripts`, the tip of the stack). GitHub retargets this to `v1/main` automatically as the stack lands.

Merge order: **#2073 -> #2075 -> #2077 -> #2081**.

Basing this on the stack rather than on `v1/main` directly is deliberate: it makes 1.0.2 provably contain the three fixes it is meant to release, instead of relying on merge order being remembered.

## Change

Version fields only — no functional change.

- `version` bumped 1.0.1 -> 1.0.2 in `package.json`, `client/`, `server/`, `cli/`
- the three `@modelcontextprotocol/inspector-*` workspace dependency ranges in the root `package.json` (`^1.0.1` -> `^1.0.2`)
- the matching `version` fields in `package-lock.json`

15 insertions, 15 deletions across 5 files.

## What this releases

| Issue | PR | Change |
|---|---|---|
| #2072 | #2073 | `js-yaml` overrides bumped to patched 3.15.1 / 4.3.1 |
| #2074 | #2075 | Remaining audit advisories cleared (`ip-address`, `hono`, `@hono/node-server`, `fast-uri`, `brace-expansion`, + dev-only `nanoid`, `postcss`) |
| #2079 | #2077 | `allowScripts` denials for `esbuild` / `fsevents` |

`npm audit` goes from 8 advisories to **0**, with no install-script warning.

Only `ip-address` was assessed as genuinely reachable in production code (rate-limit key bypass on `/sandbox`); the rest were present-but-unexercised or dev-only. Hygiene release, not a response to an actively exploitable defect — see #2074.

## Note on `npm run update-version`

That script performs the right `package.json` edits but finishes with a bare `npm install`, re-resolving the entire tree. On this branch that yields a ~2450-line lockfile diff touching 164 packages, including production deps (`@modelcontextprotocol/sdk`, `hono`, `@hono/node-server` 1.x -> 2.x **major**, `jose`, `ws`) — precisely the churn #2073 and #2075 were careful to avoid.

The lockfile `version` fields were therefore edited directly, keeping the diff to the 8 fields that actually change. Worth fixing in the script for v2; out of scope here.

## Verification

- `node scripts/check-version-consistency.js` — passes (all 4 packages at 1.0.2, workspace ranges and lock version consistent)
- `npm ci` accepts the lockfile and leaves it unmodified
- `npm audit` -> **0 vulnerabilities**; `npm install-scripts ls` -> no unreviewed scripts
- `npm run build` passes; prettier clean
- Tests: 539 client + 37 server + 85 CLI, all passing
- App starts, serves the client (`HTTP 200`), proxy auth gates correctly (401 / 200)

## Post-merge

Tag `v1.0.2`, then `npm run publish-all` — which publishes to the **`v1-latest`** dist-tag (npm rejects `v1` as version-like; see #1829).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gq5jMmxRUphrVbfNbYVmQH
