### PR TITLE
fix(web): state the expected shape when dropping a CSP source (#2064)

### DIFF
--- a/clients/web/src/utils/sandbox-csp.test.ts
+++ b/clients/web/src/utils/sandbox-csp.test.ts
@@ -67,6 +67,29 @@ describe("approveCspSources", () => {
     warn.mockRestore();
   });
 
+  it("names the offending field and states the expected shape, without calling the value unsafe", () => {
+    // #2064: the filter screens for injection safety only, so the message must
+    // not read as a verdict on the value. These four fields are origin lists,
+    // so the real cause is almost always "not an origin" — a CSP keyword has
+    // no field in the contract to be requested through. Naming the key also
+    // tells an app declaring several lists which one the bad entry was in.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    approveCspSources({
+      connectDomains: ["'unsafe-eval'"],
+      frameDomains: ["<script>"],
+    });
+    const messages = warn.mock.calls.map(([message]) => String(message));
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toContain('"connectDomains"');
+    expect(messages[1]).toContain('"frameDomains"');
+    for (const message of messages) {
+      expect(message).toContain("expected an origin");
+      expect(message).not.toContain("unsafe");
+    }
+    expect(warn.mock.calls[0]?.[1]).toBe("'unsafe-eval'");
+    warn.mockRestore();
+  });
+
   it("omits a key when every entry is rejected", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(approveCspSources({ connectDomains: ['"; x'] })).toEqual({});

--- a/clients/web/src/utils/sandbox-csp.ts
+++ b/clients/web/src/utils/sandbox-csp.ts
@@ -41,11 +41,11 @@ const CSP_KEYS = exhaustiveCspKeys([
 
 /**
  * Filter an app-supplied {@link McpUiResourceCsp} down to the entries the host
- * will actually enforce. Unsafe values are dropped (and warned), and the
- * resulting object contains only keys with at least one accepted source. The
- * return value is what the host echoes back to the view via
- * `hostCapabilities.sandbox.csp` so the app sees what was granted, not what it
- * asked for.
+ * will actually enforce. Entries that don't parse as a source expression are
+ * dropped (and warned), and the resulting object contains only keys with at
+ * least one accepted source. The return value is what the host echoes back to
+ * the view via `hostCapabilities.sandbox.csp` so the app sees what was granted,
+ * not what it asked for.
  *
  * NOTE: this screens each source for *injection safety* only — it does NOT
  * bound the *breadth* of a grant. A bare `*` (and a scheme-wildcard host) is a
@@ -56,6 +56,14 @@ const CSP_KEYS = exhaustiveCspKeys([
  * ambient credentials and nothing to exfiltrate beyond what the app already
  * received; "approved" therefore means "cannot break out of the meta
  * attribute," not "restrictive."
+ *
+ * The drop warning is worded accordingly: it names the field the entry came
+ * from and states the shape expected, and makes no claim about the *safety* of
+ * the value. These four fields are origin lists, so the usual cause of a drop
+ * is an entry that simply isn't an origin — a CSP keyword such as
+ * `'unsafe-eval'` has no field in the contract to be requested through. Saying
+ * "unsafe" instead read as a security verdict this check never makes, and sent
+ * #2012 chasing an XSS regression that wasn't one (#2064).
  */
 export function approveCspSources(
   csp: McpUiResourceCsp | undefined,
@@ -70,7 +78,12 @@ export function approveCspSources(
       if (typeof entry === "string" && SAFE_CSP_SOURCE.test(entry)) {
         accepted.push(entry);
       } else {
-        console.warn("[mcp-app sandbox] dropping unsafe CSP source:", entry);
+        console.warn(
+          `[mcp-app sandbox] dropping "${key}" entry (expected an origin such ` +
+            `as https://example.com or https://*.example.com, a scheme such as ` +
+            `data:, or *):`,
+          entry,
+        );
       }
     }
     if (accepted.length > 0) approved[key] = accepted;

--- a/clients/web/src/utils/sandbox-csp.ts
+++ b/clients/web/src/utils/sandbox-csp.ts
@@ -41,11 +41,15 @@ const CSP_KEYS = exhaustiveCspKeys([
 
 /**
  * Filter an app-supplied {@link McpUiResourceCsp} down to the entries the host
- * will actually enforce. Entries that don't parse as a source expression are
- * dropped (and warned), and the resulting object contains only keys with at
- * least one accepted source. The return value is what the host echoes back to
- * the view via `hostCapabilities.sandbox.csp` so the app sees what was granted,
- * not what it asked for.
+ * will actually enforce. The accepted subset is the origin forms
+ * {@link SAFE_CSP_SOURCE} matches — `scheme://host[:port][/path]`, a bare or
+ * wildcard host, a scheme such as `data:`, and `*`. Anything outside it is
+ * dropped (and warned) — including a CSP keyword like `'unsafe-eval'`, which
+ * is a perfectly valid source expression in CSP but not something these
+ * origin-list fields can express. The resulting object contains only keys with
+ * at least one accepted source, and is what the host echoes back to the view
+ * via `hostCapabilities.sandbox.csp` so the app sees what was granted, not what
+ * it asked for.
  *
  * NOTE: this screens each source for *injection safety* only — it does NOT
  * bound the *breadth* of a grant. A bare `*` (and a scheme-wildcard host) is a
@@ -59,11 +63,9 @@ const CSP_KEYS = exhaustiveCspKeys([
  *
  * The drop warning is worded accordingly: it names the field the entry came
  * from and states the shape expected, and makes no claim about the *safety* of
- * the value. These four fields are origin lists, so the usual cause of a drop
- * is an entry that simply isn't an origin — a CSP keyword such as
- * `'unsafe-eval'` has no field in the contract to be requested through. Saying
- * "unsafe" instead read as a security verdict this check never makes, and sent
- * #2012 chasing an XSS regression that wasn't one (#2064).
+ * the value. Saying "unsafe" instead read as a security verdict this check
+ * never makes, and sent #2012 chasing an XSS regression that wasn't one, when
+ * the entry had merely been the wrong kind of thing for the field (#2064).
  */
 export function approveCspSources(
   csp: McpUiResourceCsp | undefined,


### PR DESCRIPTION
Closes #2064

`approveCspSources` warned:

```
[mcp-app sandbox] dropping unsafe CSP source: 'unsafe-eval'
```

The word **"unsafe"** states a security verdict the check never makes. `SAFE_CSP_SOURCE` screens each entry for *injection safety* only — whether it can break out of the `<meta content="…">` attribute or inject a second directive with `;` — and deliberately does not bound how broad a grant is (`resourceDomains: ["*"]` passes the filter and yields `script-src 'unsafe-inline' *`).

The four `_meta.ui.csp` fields are **origin lists**, so the real cause of a drop is almost always that the entry simply isn't an origin: a CSP keyword such as `'unsafe-eval'`, `'wasm-unsafe-eval'` or `'strict-dynamic'` has no field in the contract to be requested through. Reading the old message as a safety verdict is what sent #2012 chasing an XSS regression that wasn't one, and what made "widen the regex" look like the fix.

## What changed

The warning now names the field the entry came from and states the shape expected, with no claim about the value's safety:

```
[mcp-app sandbox] dropping "connectDomains" entry (expected an origin such as https://example.com or https://*.example.com, a scheme such as data:, or *): 'unsafe-eval'
```

Naming the key is the second half of the issue: an app declaring several lists previously got identical messages with no way to tell which list held the bad entry. The loop already had `key` in scope.

`SAFE_CSP_SOURCE` itself is **unchanged** — see #2012 for why the regex is behaving as designed, and [ext-apps#605](https://github.com/modelcontextprotocol/ext-apps/issues/605) for the upstream work on letting apps request CSP keywords at all.

The doc comment on `approveCspSources` records why the wording is what it is, so the next person to touch it doesn't reintroduce a verdict the function can't back.

## Tests

New case in `sandbox-csp.test.ts` asserting the message names the offending field, states the expected shape, and contains no "unsafe" — and that the dropped value is still passed through as the second argument.

No UI surface changed (console warning only), so there are no screenshots.
