### PR TITLE
chore: bump version to 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/inspector",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "The Model Context Protocol Inspector",
   "keywords": [
     "MCP",


### PR DESCRIPTION
Closes #2141

Step 1 of the **v2.4.0** release: bump the root `package.json` from `2.3.0` to `2.4.0` on `v2/main`, *before* the milestone merge.

## Why here and not on the merge branch

This is the procedure #2010 / #2011 established and #2013 / #2052 first exercised. The milestone-merge branch is cut from `main`, so a bump made there exists only downstream of `v2/main` and nothing carries it back — which is how `v2/main` sat at `2.0.0` through both the 2.1.0 and 2.2.0 releases, and how an unrelated PR came to carry a `2.0.0 → 2.2.0` diff. Bumping here means the version arrives on `main` as part of the milestone payload and the two branches converge on merge.

Between now and that merge, `v2/main` reads `2.4.0` and `main` reads `2.3.0`. That difference is the expected in-flight state, not drift.

## Minor, not patch

The v2.4.0 payload carries new user-facing capability, not only fixes — the dedicated MCP App origin for `_meta.ui.domain` (#2100), app-rendered form elicitations (#2083), the file-backed secret store for hosts with no keychain (#2076), tool-schema portability lint across all three clients (#2121), a per-server `refresh_token` opt-out (#2114), and complex JSON values in request `_meta` (#2094).

## Diff

Two files, three lines — `npm version minor --no-git-tag-version`:

```
package.json      | 2 +-      "version": "2.3.0" → "2.4.0"
package-lock.json | 4 ++--     top-level `version` AND packages[""].version
```

`--no-git-tag-version` is load-bearing: a bare `npm version` would also tag, and the tag belongs on the `main` merge commit (step 3), not on a `v2/main` commit that is never released. It would also be `v`-prefixed, which does not match this repo's bare `x.y.z` tags.

## Verification

`npm run ci` green on this tree — the three coverage guards, `test:scripts`, `validate:core`, all four client validations, the per-file ≥90 coverage gate, `verify:build-gate`, `verify:bundle-externals`, all the smokes, and the Storybook play-function tests.

Nothing in the repo asserts a specific version value, so there is no test impact. No UI or TUI change, so no screenshots.

## Next

2. Merge `v2/main` → `main` through the milestone-merge branch (#2143) — it carries this bump as part of the payload.
3. Tag `origin/main` as bare `2.4.0` and draft the GitHub Release, which runs `pack:verify`, asserts the tag matches `package.json`, and publishes the `latest` dist-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hzwzS8UvBsr4yZm7o7sev
