### PR TITLE
fix(web): surface failed resource subscribe/unsubscribe

### DIFF
--- a/clients/web/src/hooks/useServerCommands.test.tsx
+++ b/clients/web/src/hooks/useServerCommands.test.tsx
@@ -862,6 +862,118 @@ describe("subscriptions and completion", () => {
     expect(h.api().onSubscribeResource).toBeTypeOf("function");
   });
 
+  // #2174. Both used to discard the promise with a bare `void`, so a failure
+  // was invisible in the UI and surfaced only as an unhandled rejection.
+  it("toasts a failed subscribe rather than swallowing it", async () => {
+    const h = harness({
+      client: client({
+        subscribeToResource: vi
+          .fn()
+          .mockRejectedValue(
+            new Error("Server does not support resource subscriptions"),
+          ),
+      }),
+    });
+    await act(async () => h.api().onSubscribeResource("u"));
+    await waitFor(() =>
+      expect(notificationsMock.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Failed to subscribe to resource",
+          message: "Server does not support resource subscriptions",
+        }),
+      ),
+    );
+  });
+
+  it("toasts a failed unsubscribe rather than swallowing it", async () => {
+    const h = harness({
+      client: client({
+        unsubscribeFromResource: vi
+          .fn()
+          .mockRejectedValue(new Error("Client is not connected")),
+      }),
+    });
+    await act(async () => h.api().onUnsubscribeResource("u"));
+    await waitFor(() =>
+      expect(notificationsMock.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Failed to unsubscribe from resource",
+          message: "Client is not connected",
+        }),
+      ),
+    );
+  });
+
+  it("recovers a lapsed authorization on subscribe, and retries", async () => {
+    const recover = vi.fn().mockResolvedValue(true);
+    const subscribeToResource = vi
+      .fn()
+      .mockRejectedValueOnce(authError())
+      .mockResolvedValue(undefined);
+    const h = harness({
+      client: client({ subscribeToResource }),
+      activeServerId: "a",
+      recovery: { handleCommandScopedAuthRecovery: recover },
+    });
+    await act(async () => h.api().onSubscribeResource("u"));
+    await waitFor(() => expect(subscribeToResource).toHaveBeenCalledTimes(2));
+    // `ambient`, not `resource`: a `resource` step-up failure is routed into
+    // the read-preview panel, which this command has nothing to do with.
+    expect(recover).toHaveBeenCalledWith(
+      expect.any(AuthRecoveryRequiredError),
+      {
+        serverId: "a",
+        source: "ambient",
+        retryOperation: expect.any(Function),
+      },
+    );
+    // The recovery owns the prompt, so the command itself stays quiet.
+    expect(notificationsMock.show).not.toHaveBeenCalled();
+  });
+
+  it("recovers a lapsed authorization on unsubscribe, and retries", async () => {
+    const recover = vi.fn().mockResolvedValue(true);
+    const unsubscribeFromResource = vi
+      .fn()
+      .mockRejectedValueOnce(authError())
+      .mockResolvedValue(undefined);
+    const h = harness({
+      client: client({ unsubscribeFromResource }),
+      activeServerId: "a",
+      recovery: { handleCommandScopedAuthRecovery: recover },
+    });
+    await act(async () => h.api().onUnsubscribeResource("u"));
+    await waitFor(() =>
+      expect(unsubscribeFromResource).toHaveBeenCalledTimes(2),
+    );
+    expect(recover).toHaveBeenCalledWith(
+      expect.any(AuthRecoveryRequiredError),
+      {
+        serverId: "a",
+        source: "ambient",
+        retryOperation: expect.any(Function),
+      },
+    );
+    expect(notificationsMock.show).not.toHaveBeenCalled();
+  });
+
+  it("does not toast a subscribe whose recovery was left unsatisfied", async () => {
+    // The recovery has taken over — a redirect is pending or a step-up prompt
+    // is open — so the wrapper resolves `undefined` rather than rejecting, and
+    // a toast here would talk over the prompt the user is looking at.
+    const recover = vi.fn().mockResolvedValue(false);
+    const h = harness({
+      client: client({
+        subscribeToResource: vi.fn().mockRejectedValue(authError()),
+      }),
+      activeServerId: "a",
+      recovery: { handleCommandScopedAuthRecovery: recover },
+    });
+    await act(async () => h.api().onSubscribeResource("u"));
+    await waitFor(() => expect(recover).toHaveBeenCalled());
+    expect(notificationsMock.show).not.toHaveBeenCalled();
+  });
+
   it("returns the completion values", async () => {
     const c = client();
     const h = harness({ client: c });

--- a/clients/web/src/hooks/useServerCommands.tsx
+++ b/clients/web/src/hooks/useServerCommands.tsx
@@ -564,20 +564,45 @@ export function useServerCommands({
     [inspectorClient, activeServerId, handleCommandScopedAuthRecovery],
   );
 
+  // Both route through the shared recovery like every other command (#2174).
+  // They used to discard the promise with a bare `void`, which neither the
+  // callee nor anything else owned: `subscribeToResource` throws when the
+  // client is disconnected, when the server declares no subscription support,
+  // and (wrapped) on a failed request, so a subscribe that failed did nothing
+  // visible and surfaced only as an unhandled rejection.
+  //
+  // The source is `ambient`, not `resource`. A `resource` step-up failure is
+  // routed into `readResourceState` — the *preview* panel — which describes a
+  // read of whatever resource is selected, not this subscribe; marking it
+  // errored would contradict a read that succeeded. Subscribing has no panel
+  // of its own (the tile only flips its button label), which is the same
+  // position the refreshes and the pagination toggle are in, and they are
+  // `ambient` for the same reason.
+  //
+  // Both pass an `errorTitle`: nothing else records these failures, so without
+  // one the button would go on silently doing nothing.
   const onSubscribeResource = useCallback(
     (uri: string) => {
       if (!inspectorClient) return;
-      void inspectorClient.subscribeToResource(uri);
+      runCommandInBackground(
+        () => inspectorClient.subscribeToResource(uri),
+        "ambient",
+        "Failed to subscribe to resource",
+      );
     },
-    [inspectorClient],
+    [inspectorClient, runCommandInBackground],
   );
 
   const onUnsubscribeResource = useCallback(
     (uri: string) => {
       if (!inspectorClient) return;
-      void inspectorClient.unsubscribeFromResource(uri);
+      runCommandInBackground(
+        () => inspectorClient.unsubscribeFromResource(uri),
+        "ambient",
+        "Failed to unsubscribe from resource",
+      );
     },
-    [inspectorClient],
+    [inspectorClient, runCommandInBackground],
   );
 
   const onCompleteArgument = useCallback(


### PR DESCRIPTION
Closes #2174

#2173 merged while this was being written, so this targets `v2/main` directly rather than stacking on it.

Raised by Copilot on #2173 and deliberately deferred out of it: that PR is a decomposition step with a "no behavior change" contract, and this is a behavior change.

## The bug

Both handlers discarded their promise with a bare `void`:

```ts
const onSubscribeResource = useCallback(
  (uri: string) => {
    if (!inspectorClient) return;
    void inspectorClient.subscribeToResource(uri);
  },
  [inspectorClient],
);
```

Nothing owned those failures. `InspectorClient.subscribeToResource` throws when the client is disconnected, when the server declares no subscription support, and rethrows a wrapped error after rolling its subscription state back on a failed request; `unsubscribeFromResource` is the same shape. So a failed subscribe did **nothing visible** — the button just didn't work — and surfaced only as an unhandled rejection in the console. [`AGENTS.md`](../blob/v2/main/AGENTS.md) permits a bare `void` only "when the callee already owns its failures", which is not the case here.

These were also the only two commands in the hook skipping the shared recovery, so a mid-session 401 on a subscribe did not trigger re-auth the way a 401 on a refresh does.

## The fix

Both now route through `runCommandInBackground`, like every neighbouring command.

**The source is `ambient`, not `resource`** — the issue proposed `resource`, and that turns out to be wrong. A `resource` step-up failure is routed by `setSourceScopedError` into `readResourceState`, which is the read-*preview* panel; it describes a read of whatever resource is selected, not this subscribe. Marking it errored would contradict a read that actually succeeded, and it would do so by mutating a panel the user is looking at. Subscribing has no panel of its own — the tile only flips its button label — which is exactly the position the refreshes, the load-mores and the pagination toggle are in, and they are `ambient` for the same reason.

Both pass an `errorTitle`, per the guidance on `runCommandInBackground`: nothing else records these failures, so without one the button goes on silently doing nothing.

## Tests

Five new cases (80 total in the file):

- a failed subscribe toasts rather than being swallowed
- a failed unsubscribe toasts rather than being swallowed
- a lapsed authorization on subscribe recovers and retries, asserting `source: "ambient"` and the `retryOperation`
- the same for unsubscribe
- a subscribe whose recovery is left unsatisfied does **not** toast — the recovery has taken over (a redirect is pending or a step-up prompt is open), so a toast would talk over the prompt the user is looking at

Coverage on the hook is unchanged: 100% statements / lines / functions, 96.58% branches.

## Verification

`npm run local:gate` green end to end.

One caveat worth stating plainly: the gate initially failed three runs in a row on an **unrelated** flake in `scripts/lib/render-smoke.test.mjs`, which gives itself a 150ms budget that has to cover PTY + Node startup. That is filed as #2177 and fixed by #2178. The gate run backing this PR was done with that fix cherry-picked in locally; the borrowed commit was then dropped, so the diff here is only the two files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hzwzS8UvBsr4yZm7o7sev
