### PR TITLE
test(scripts): anchor the render-smoke overlap paint to the parent's clock

### DIFF
--- a/scripts/lib/render-smoke.test.mjs
+++ b/scripts/lib/render-smoke.test.mjs
@@ -86,43 +86,71 @@ test("passes when the child paints the marker and keeps running", async () => {
 // visibly contains the marker. A slow-but-fine TUI would fail, intermittently,
 // with a diagnostic pointing at the wrong thing entirely.
 test("a paint landing just under the deadline is not failed by the render timer", async () => {
-  const paintAt = 250;
+  // The two clocks start at different moments: the child's `setTimeout` runs
+  // from its own first JS tick, while `renderTimer` is armed in the parent at
+  // spawn. A delay written as a plain `setTimeout(paint, N)` therefore lands at
+  // `N + startup`, so the deadline has to carry a startup allowance — and the
+  // case fails, as "did not render", whenever the machine is loaded enough to
+  // exceed it. It failed three `local:gate` runs in a row that way while
+  // passing every time standalone (#2177), and widening the allowance only
+  // moved the threshold (#2180).
+  //
+  // So the paint is anchored to the PARENT's clock instead: the child is told
+  // the wall-clock instant to paint at, and sleeps for whatever is left of it
+  // when it gets there. Startup is then *absorbed* by the sleep rather than
+  // added to it, and the paint lands at ~`PAINT_AT` measured from spawn no
+  // matter how slow the boot was.
+  const spawnedAt = Date.now();
+  const PAINT_AT = 300;
+  const timeoutMs = 600;
+  const surviveMs = 900;
+
   const r = await runRenderSmoke({
     ...opts,
     ...stub(
-      `setTimeout(() => { console.log(${JSON.stringify(MARKER)}); ` +
-        `setInterval(() => {}, 1000); }, ${paintAt});`,
+      `const at = ${spawnedAt + PAINT_AT};` +
+        `setTimeout(() => { console.log(${JSON.stringify(MARKER)}); ` +
+        `setInterval(() => {}, 1000); }, Math.max(0, at - Date.now()));`,
     ),
     // The shape being reproduced is an overlap, and only an overlap:
     //
     //   actual paint  <  timeoutMs  <  actual paint + surviveMs
     //
     // i.e. the render deadline expires while the survival window is still
-    // open. Both margins are deliberately wide, because the two clocks start
-    // at different moments: `paintAt` is measured from the child's first JS
-    // tick, while `renderTimer` is armed in the parent at spawn. The left
-    // margin therefore has to absorb everything in between — child process
-    // startup, plus whatever scheduling delay the machine is under.
+    // open. `done` is first-caller-wins, so an armed render timer firing in
+    // that gap settles the run as "did not render <marker>" while quoting an
+    // output tail that visibly contains the marker.
     //
-    // `stub()` spawns `process.execPath` directly, so there is no `script(1)`
-    // in this path: the PTY wrapper lives in `smoke-tui.mjs`, the caller. Node
-    // boot alone measured 46-59ms idle here. That fits the old `paintAt + 150`
-    // budget with room to spare, which is exactly why this read as a flake
-    // rather than a bug — but under the load of a full `local:gate` run the
-    // remaining ~90ms of slack is not enough to cover scheduling delay on both
-    // the child's boot and the parent's timer, and it failed three gate runs
-    // in a row while passing every time standalone (#2177). The diagnostic it
-    // failed with, "did not render", is the misreport this test exists to
-    // catch.
+    // `timeoutMs < surviveMs` is what makes the right-hand side hold for ANY
+    // paint time, including 0 — so a boot slow enough to swallow the anchor
+    // still reproduces the overlap rather than degrading into a different
+    // case. The only startup assumption left is that boot finishes before the
+    // deadline at all, and 600ms is an order of magnitude over the 46-59ms
+    // measured here idle.
     //
-    // Do not tighten these back up to make the test faster: the overlap is the
-    // point, not the tightness. 1200ms clears any plausible paint time, and
-    // still falls inside a survival window that cannot close before ~1750ms.
-    timeoutMs: 1200,
-    surviveMs: 1500,
+    // Do not tighten these to make the test faster, and do not reorder them so
+    // that `surviveMs <= timeoutMs`: the overlap is the point.
+    timeoutMs,
+    surviveMs,
   });
   assert.equal(r.code, 0, `expected pass, got: ${r.message}`);
   assert.doesNotMatch(r.message, /did not render/);
+
+  // Passing is not on its own evidence that the overlap was reproduced — a
+  // paint late enough to land past `timeoutMs` fails, but one landing so early
+  // that the deadline falls outside the survival window would pass while
+  // testing nothing. Read the paint time back out of the verdict and assert
+  // the shape actually held, so the case cannot go vacuous.
+  const paintedAt = Number(/ at (\d+)ms/.exec(r.message)?.[1]);
+  assert.ok(
+    Number.isFinite(paintedAt),
+    `no first-paint time in verdict: ${r.message}`,
+  );
+  assert.ok(
+    paintedAt < timeoutMs && timeoutMs < paintedAt + surviveMs,
+    `deadline did not fall inside the survival window: painted at ${paintedAt}ms, ` +
+      `timeoutMs ${timeoutMs}, surviveMs ${surviveMs}`,
+  );
 });
 
 test("fails when the child exits before painting", async () => {


### PR DESCRIPTION
Closes #2180

> Stacked on #2178 (`v2/fix/2177-render-smoke-startup-budget`), which touches the same test case. Merge that first; this PR's diff is only the second commit.

`scripts/lib/render-smoke.test.mjs` → **"a paint landing just under the deadline is not failed by the render timer"** buys the overlap it tests with a *startup allowance*, and that is what makes it flake.

## Why widening didn't settle it

`paintAt` is measured from the child's **first JS tick**; `renderTimer` is armed in the **parent, at spawn**. So a plain `setTimeout(paint, N)` lands at `N + startup`, and `timeoutMs` has to cover whatever startup turns out to be:

```js
const paintAt = 250;
timeoutMs: paintAt + 150,   // the whole budget for spawn + Node boot
```

#2178 widened that allowance from 150ms to 950ms. That **moves the threshold rather than removing it** — the case still fails, as `did not render`, on any machine loaded enough to blow the new number. Which is precisely the misdiagnosis this test exists to catch, and precisely what #2180 asked to stop depending on.

## The fix

Anchor the paint to the **parent's** clock. The child is told the wall-clock instant to paint at and sleeps for whatever is left of it when it gets there:

```js
const spawnedAt = Date.now();
const PAINT_AT = 300;
// in the child:
const at = <spawnedAt + PAINT_AT>;
setTimeout(paint, Math.max(0, at - Date.now()));
```

Startup is now **absorbed by the sleep instead of added to it**, so the paint lands at ~300ms measured from spawn however slow the boot was.

The constants then close the remaining gap. The shape under test is an overlap, and only an overlap:

```
actual paint  <  timeoutMs  <  actual paint + surviveMs
```

`timeoutMs: 600` / `surviveMs: 900` satisfies the right-hand side for **any** paint time, including 0 — so a boot slow enough to swallow the anchor entirely still reproduces the overlap rather than degrading into some other case. The one startup assumption left is that boot completes before the deadline *at all*, an order of magnitude over the 46-59ms measured idle here.

## It can no longer pass vacuously

A widened timing test can go green while testing nothing, so passing is not taken as evidence on its own. The first-paint time is read back out of the verdict and the overlap asserted:

```js
const paintedAt = Number(/ at (\d+)ms/.exec(r.message)?.[1]);
assert.ok(paintedAt < timeoutMs && timeoutMs < paintedAt + surviveMs, ...);
```

A paint landing early enough to put the deadline *outside* the survival window now fails loudly instead of passing.

## Verification

**Mutation.** Removing the `clearTimeout(renderTimer)` on first paint (`render-smoke.mjs:267`) — the line this case guards:

```
✖ a paint landing just under the deadline is not failed by the render timer (607.493125ms)
ℹ pass 14
ℹ fail 1
```

It fails at 607ms, i.e. the render timer still fires *inside* the survival window. Restored, 15/15 pass.

**Under load.** 8 consecutive runs with 16 busy loops pinning all 8 cores: **8/8 pass**. (The old fixture is what failed three gate runs in a row on a far lighter machine.)

**Gate.** `npm run local:gate` green end to end.

**Cost.** Runtime *drops*, ~1.75s → ~1.2s.

## Acceptance criteria

- [x] The case pins the deadline-vs-survival-window overlap it was written for, without depending on process startup fitting in a fixed budget
- [x] It passes under concurrent load, not only on an idle machine
- [x] The other cases in the file keep their current meaning (`forbidOutput`, the exit-before-paint case, the survival assertions) — untouched, 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hzwzS8UvBsr4yZm7o7sev
