### PR TITLE
chore: bump version to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/inspector",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/inspector",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "The Model Context Protocol Inspector",
   "keywords": [
     "MCP",


### PR DESCRIPTION
Closes #2212

Bumps the root `package.json` version from `2.4.0` to `2.5.0` on `v2/main`, ahead of the v2.5.0 milestone merge into `main`.

## What changed

- `package.json`: `2.4.0` → `2.5.0`
- `package-lock.json`: the two matching `version` fields, updated by npm

That is the whole diff — the repo has **one** version number, and the clients under `clients/*` carry none.

## How

```sh
npm version minor --no-git-tag-version
```

`--no-git-tag-version` is load-bearing: a bare `npm version` would also create a tag, and it would land on a `v2/main` commit. The release is cut from `main`, so the tag has to point at the milestone merge commit there — tagging here would produce a tag on a commit that is never released.

## Why the bump goes on `v2/main` first

Per the `release` skill and #2010: the bump is part of the milestone's work, so it belongs on the develop branch and flows into `main` with everything else. Doing it on the milestone-merge branch instead leaves the bump only *downstream* of `v2/main` — which is how `v2/main` sat at `2.0.0` through both the 2.1.0 and 2.2.0 releases, and how a `2.0.0 → 2.2.0` diff leaked into an unrelated container bugfix (#2009).

Between this merge and the milestone merge, `v2/main` reading `2.5.0` while `main` still reads `2.4.0` is expected — a release is in flight, not drift.

## Verification

- `npm run format` — clean, no files rewritten
- `npm run local:gate` — passes
- No `2.5.0` git tag was created

No user-facing behavior change, so no screenshots apply.
