### PR TITLE
chore(deps): refresh fast-uri, qs and browserslist to clear npm audit

### DIFF
--- a/clients/tui/package-lock.json
+++ b/clients/tui/package-lock.json
@@ -1816,9 +1816,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1843,9 +1843,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -1863,11 +1863,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1903,9 +1903,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -2099,9 +2099,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.376",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
-      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3366,9 +3366,9 @@
       "peer": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4151,9 +4151,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2856,9 +2856,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -4383,9 +4383,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
Closes #2244
Closes #2225

All three outstanding advisories turned out to be **stale lockfile resolutions, not upward-blocked pins**. Every fixed version already sits inside the range its declaring parent asks for, so refreshing the lock entry is the whole fix:

| Package | Install | Was | Now | Parent's declared range |
| --- | --- | --- | --- | --- |
| `fast-uri` | root | 3.1.5 | **3.1.7** | `ajv@8.18.0` → `^3.0.1` |
| `qs` | root | 6.15.3 | **6.16.0** | `express@5.2.1` → `^6.14.0` |
| `browserslist` | `clients/tui` | 4.28.2 | **4.28.9** | `@babel/core` → (unconstrained above 4.28.7) |

Two lockfiles changed. **No manifest changed**, nothing moved between manifests, and no client re-declares a root-owned package.

## Why no `overrides` entry

Both #2244 and #2225 proposed an `overrides` pin, and `AGENTS.md` does say to pin a transitive with `overrides` rather than with `npm audit fix`. That rule is about *how* to pin when a pin is needed — it does not call for one where the declared range already admits the fix.

A pin here would buy nothing and would cost something later: `"fast-uri": "^3.1.6"` forbids `fast-uri@4.x` for as long as it stands, **including after `ajv` moves to it**, and an override is applied by npm with no upward-bound check and no signal when it becomes obsolete. The three lock entries were refreshed with targeted `npm update <pkg>` calls rather than `npm audit fix`, so nothing was silently downgraded — the diff is the fixed versions plus their in-family transitives (`caniuse-lite`, `electron-to-chromium`, `node-releases`, `update-browserslist-db`, `baseline-browser-mapping`) and nothing else.

Regression cover is the two sweeps that just landed in this milestone (#2232, #2239, #2243) plus the release-time `npm audit --audit-level=high` report. npm never downgrades an existing lock entry, so the refreshed resolutions hold across an ordinary `npm install`.

## Reachability — assessed, not assumed

The issue asked for this to be established rather than taken from the advisory headline.

**`fast-uri` is the one that ships, and its impact is well below its headline.** `ajv` is a root runtime dependency, and Vite pre-bundles it into the published `clients/web/dist` (`getViteDevOptimizeDeps().include` names both `ajv` and `@modelcontextprotocol/client/validators/ajv`), so the vulnerable code was *inlined into the shipped SPA*, not merely resolved at install time. The input is attacker-influenced: `schemaUtils.ts` compiles the `outputSchema` a server under test supplies, and ajv resolves that schema's `$id`/`$ref` through fast-uri (`ajv/dist/runtime/uri.js`). But both **SSRF** advisories (GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf) require a consumer that *fetches* the parsed URI, and ajv never performs a network request. The realistic worst case is the host-confusion pair (GHSA-5jgf-p345-68v8, GHSA-jqff-g426-hqxp) mis-normalizing a crafted `$id`, yielding a wrong or failed validation of one tool's output. Real, worth fixing before the release build, not user-facing SSRF.

**`qs` is installed in production, but nothing shipped runs it.** *(Corrected during review — my first pass called this dev-only, and that was wrong.)* `express` is a root `devDependency`, but that is not its only path into the tree. `npm ls express --omit=dev` shows it reaching a **production** install two other ways:

```
@modelcontextprotocol/inspector@2.5.0
├─┬ @modelcontextprotocol/ext-apps@1.7.5
│ └─┬ @modelcontextprotocol/sdk@1.30.0
│   └── express@5.2.1 deduped
└─┬ @modelcontextprotocol/server-legacy@2.0.0
  ├─┬ express-rate-limit@8.6.2
  │ └── express@5.2.1 deduped
  └── express@5.2.1
```

`@modelcontextprotocol/server-legacy` is a root **runtime dependency**, so `qs` is present in every user install — a real supply-chain footprint, not nothing. What does hold is that no shipped code ever instantiates it: nothing in `core/`, `clients/*/src` or `clients/web/server` calls `express()`, the web backend is Hono, and `server-legacy` is imported only from `test-servers/src`, which the root `files` list does not publish. Both advisories (GHSA-x5fp-wj9c-mxmx, GHSA-4mjr-xmp4-gh2g) require express to parse an attacker-supplied query string, which needs a live express app. So: in the tree, not on any executed path.

**`browserslist` is dev tooling**, as #2225 established: it arrives in the `clients/tui` install through `eslint-plugin-react-hooks` → `@babel/core`, is reached only by lint, and is in no published bundle. What identified it as a *stale lock* rather than a constrained one is that the **root** install already resolved a patched `4.28.8` from the same plugin at the same version — same range, newer resolution — so no pin was ever required, only a refresh.

## Verification

`npm audit` is clean in **all five** installs, both with and without dev dependencies (10/10):

```
.                  dev+prod: found 0 vulnerabilities     prod-only: found 0 vulnerabilities
clients/web        dev+prod: found 0 vulnerabilities     prod-only: found 0 vulnerabilities
clients/cli        dev+prod: found 0 vulnerabilities     prod-only: found 0 vulnerabilities
clients/tui        dev+prod: found 0 vulnerabilities     prod-only: found 0 vulnerabilities
clients/launcher   dev+prod: found 0 vulnerabilities     prod-only: found 0 vulnerabilities
```

`npm run format` clean; `npm run local:gate` passes.

No UI change, so no screenshots.

## On #2225

#2244 is a superset of #2225 — same `browserslist` finding, same tui install, same chain. This PR satisfies every box in #2225's "Done when" (dev audit clean in all five, `--omit=dev` clean in all five, gate passes); it just reaches the last one without the `overrides` entry that issue proposed, for the reason above. Closing both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YahVxMTGpigLbZBh1JGPDr
