### PR TITLE
fix(web): remove the wall-clock race in the import-JSON debounce guard test

### DIFF
--- a/clients/web/src/components/groups/ServerImportJsonModal/ServerImportJsonModal.test.tsx
+++ b/clients/web/src/components/groups/ServerImportJsonModal/ServerImportJsonModal.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import {
+  act,
   renderWithMantine,
   screen,
   fireEvent,
   waitFor,
 } from "../../../test/renderWithMantine";
 import { setAceText } from "../../../test/aceEditor";
+import { VALIDATE_DEBOUNCE_MS } from "../../../hooks/useServerJsonImport";
 import { ServerImportJsonModal } from "./ServerImportJsonModal";
 
 const npmJson = JSON.stringify({
@@ -221,28 +223,41 @@ describe("ServerImportJsonModal", () => {
     expect(screen.getByRole("button", { name: "Add Server" })).toBeDisabled();
   });
 
+  // The window this exercises is the one between an edit and the debounce that
+  // re-disables the button, so the whole test runs on fake timers: the pending
+  // re-validation then cannot land unless this test advances it, and the window
+  // stops depending on how long the machine takes to get from the paste to the
+  // click. On real timers a loaded box could spend more than
+  // VALIDATE_DEBOUNCE_MS there, re-disable the button, and turn the click into a
+  // no-op that sets no submit error at all (#2250).
   it("guards against a live edit made before the debounce re-validates", async () => {
-    const onAddServer = vi.fn();
-    renderWithMantine(
-      <ServerImportJsonModal
-        opened
-        existingIds={[]}
-        onClose={vi.fn()}
-        onAddServer={onAddServer}
-      />,
-    );
-    await pasteJson(npmJson);
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Add Server" })).toBeEnabled(),
-    );
-    // Replace with invalid content; the button hasn't re-disabled yet (the
-    // debounce is still pending), so clicking exercises the submit-time guard.
-    await pasteJson("{not json");
-    fireEvent.click(screen.getByRole("button", { name: "Add Server" }));
-    expect(onAddServer).not.toHaveBeenCalled();
-    expect(
-      await screen.findByText(/Fix the validation errors/),
-    ).toBeInTheDocument();
+    vi.useFakeTimers();
+    try {
+      const onAddServer = vi.fn();
+      renderWithMantine(
+        <ServerImportJsonModal
+          opened
+          existingIds={[]}
+          onClose={vi.fn()}
+          onAddServer={onAddServer}
+        />,
+      );
+      await pasteJson(npmJson);
+      // Let the first validation land, so the button is enabled to click.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(VALIDATE_DEBOUNCE_MS);
+      });
+      expect(screen.getByRole("button", { name: "Add Server" })).toBeEnabled();
+      // Replace with invalid content and do *not* advance: the debounce stays
+      // pending, the button stays enabled, and clicking exercises the
+      // submit-time guard that re-parses the live text.
+      await pasteJson("{not json");
+      fireEvent.click(screen.getByRole("button", { name: "Add Server" }));
+      expect(onAddServer).not.toHaveBeenCalled();
+      expect(screen.getByText(/Fix the validation errors/)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("loads server.json from a chosen file", async () => {


### PR DESCRIPTION
Closes #2250

`ServerImportJsonModal` › *guards against a live edit made before the debounce re-validates* was a genuine timing race, not merely a slow-machine symptom, and it is fixed by removing the race rather than by widening a timeout.

## The race

The test needs the window between an edit and the `VALIDATE_DEBOUNCE_MS` (300 ms) debounce that re-disables **Add Server** — that is the window the submit-time guard in `useServerJsonImport.submit()` exists for. It opened that window on the **real** clock:

```ts
await pasteJson("{not json");
fireEvent.click(screen.getByRole("button", { name: "Add Server" }));
```

If more than 300 ms of wall clock elapses between those two lines, the debounce lands first, `canAdd` goes false, the button is disabled, and `fireEvent.click` on a disabled button is a **no-op**. `onAddServer` is still not called — so the first assertion passes and hides the problem — but `submit()` never runs, no `submitError` is set, and `findByText(/Fix the validation errors/)` times out. That is exactly the reported failure, and it explains why run 4 in the issue failed on a *quiet* machine with the test itself taking only 1.6 s: it only needs one 300 ms scheduling gap, which parallel workers make likely without needing sustained load.

## Proof, before and after

A throwaway probe held both shapes side by side with a deterministic 400 ms stall injected between the paste and the click:

| shape | 400 ms stall before the click | result |
| --- | --- | --- |
| old (real timers) | yes | **fails** — `findByText(/Fix the validation errors/)` times out |
| new (fake timers) | yes, 400 ms of real wall clock | **passes** |

The old shape reproduces the reported failure exactly; the new shape is indifferent to the same stall, because the debounce cannot advance at all unless the test advances it.

## The fix

Run that one test on fake timers end to end:

- `vi.useFakeTimers()` before the render, restored in a `finally`, so no other test in the file is affected.
- The first validation is landed explicitly with `await act(async () => vi.advanceTimersByTimeAsync(VALIDATE_DEBOUNCE_MS))` rather than a `waitFor` on the real clock — `VALIDATE_DEBOUNCE_MS` is imported from the hook, so the test cannot drift from the value it depends on.
- After the second paste the timers are simply **not** advanced. The pending re-validation therefore cannot land, the window stays open by construction, and `findByText` becomes a synchronous `getByText` because there is nothing left to wait for.

No timeout was widened and no production code changed — the guard being tested is unchanged.

## On the second suspect

The issue asked to check `ServerSettingsModal` › *maps the OAuth insufficient-scope policy into settings (SEP-2350)* before assuming the two are independent. They are independent: that test has no debounce and no timer window at all — it is a `userEvent` click sequence through a Mantine `Select` — and it failed once, on the run where the box was at load ~150 and the file took 90 787 ms. There is no analogous "state changes underneath the assertion after N ms" shape to remove there, so nothing in this PR touches it. If it recurs on a quiet machine it should get its own issue with that evidence.

## Verification

Full `npm run local:gate` in a clean worktree, several consecutive runs — see the comment thread on the PR for the run log.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQgwZ1kGzhkdkMJ81JVg42
