### PR TITLE
chore: grant artifact-metadata:write to the GHCR publish job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,6 +283,11 @@ jobs:
       contents: read
       packages: write
       attestations: write
+      # Lets `attest-build-provenance` write the artifact metadata storage
+      # record alongside the provenance itself (#2228). See the long comment on
+      # the "Generate artifact attestation" step for why this is separate from
+      # `attestations: write` and what to check after the next release.
+      artifact-metadata: write
       id-token: write
     steps:
       - name: Checkout code
@@ -326,6 +331,38 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation
+        # Two scopes, two different things, and only the first is the
+        # attestation (#2228). `attestations: write` persists the signed SLSA
+        # provenance — that half has always worked, and
+        # `gh attestation verify oci://ghcr.io/modelcontextprotocol/inspector:<version>
+        # --repo modelcontextprotocol/inspector` passed on 2.5.0 without the
+        # second scope. `artifact-metadata: write` persists the separate
+        # *storage record*: GitHub's org-level index of where a published
+        # artifact lives (registry, active/eol status), surfaced at
+        # https://github.com/orgs/modelcontextprotocol/artifacts. The action
+        # emits one automatically when `push-to-registry` is true AND the
+        # workflow carries this scope; with only the first condition met, every
+        # release logged two warning annotations on an otherwise-green job:
+        #
+        #   Failed to create storage record: Error: Failed to persist storage
+        #   record: no artifacts found
+        #   Please check that the "artifact-metadata:write" permission has been
+        #   included
+        #
+        # `no artifacts found` reads like it is about this job uploading no
+        # *workflow* artifact, and is not: it is the generic 404 body of the org
+        # artifact-metadata API that @actions/attest POSTs to. The same message
+        # comes back from the sibling read endpoint for 2.5.0's real digest, and
+        # from an all-zeros digest that cannot exist — so it carries no
+        # information beyond "nothing resolved", and the documented precondition
+        # we were failing is this permission.
+        #
+        # ⚠️ Confirm at the next release rather than assuming: the job should be
+        # annotation-free, and
+        # `gh api /orgs/modelcontextprotocol/artifacts/<digest>/metadata/storage-records`
+        # should return a record instead of 404. If the warning persists, the
+        # honest fix is `create-storage-record: false` plus a note here saying
+        # the record is unavailable to us — not carrying an unexplained warning.
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/${{ github.repository }}


### PR DESCRIPTION
Closes #2228

The `publish-github-container-registry` job emitted two warning annotations on every release — the only annotations on an otherwise-green release run:

```
Failed to create storage record: Error: Failed to persist storage record: no artifacts found
Please check that the "artifact-metadata:write" permission has been included
```

This adds `artifact-metadata: write` to that job, plus a comment on the attestation step recording the evidence and the exact post-release check.

## The issue asked for two things to be confirmed rather than assumed

**1. Is `artifact-metadata` actually a valid permission key?** Yes — it is [documented in the workflow syntax reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) alongside `attestations`, taking `read` / `write` / `none`, and described as allowing an action to "create storage records on behalf of a build artifact". Pushing this branch runs CI on `push:`, so an unrecognized key would have failed the run as an invalid workflow file rather than waiting for a release.

**2. Is the missing permission even the cause, or is `no artifacts found` about this job uploading no *workflow* artifact?** It is not about workflow artifacts, and here is why:

- I traced the string to its throw site. `@actions/attest`'s `createStorageRecord` POSTs to `/orgs/{owner}/artifacts/metadata/storage-record` and rethrows the API's response as `Failed to persist storage record: <message>`. So `no artifacts found` is the **org artifact-metadata API's 404 body**, reached through the release job's attestation step — nothing to do with `actions/upload-artifact`.
- That message carries no information beyond "nothing resolved". The sibling read endpoint returns it verbatim for 2.5.0's real digest **and** for an all-zeros digest that cannot exist:

  ```console
  $ gh api /orgs/modelcontextprotocol/artifacts/sha256:cc589d705669c1b864501af3f1b18a9aff3e518ca102eb54de5bc06c910b2765/metadata/storage-records
  {"message":"no artifacts found", ... "status":"404"}

  $ gh api /orgs/modelcontextprotocol/artifacts/sha256:0000…0000/metadata/storage-records
  {"message":"no artifacts found", ... "status":"404"}
  ```

- The precondition we were actually failing is the permission. Both [`actions/attest`'s README](https://github.com/actions/attest) and the [linked-artifacts docs](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/establish-provenance-and-integrity/upload-linked-artifacts) state the record is emitted when `push-to-registry` is true **and** the workflow carries `artifact-metadata: write`. We satisfied the first and not the second. The remaining documented constraint — the repo must be organization-owned — is satisfied.

The action's own source agrees, wrapping only this call: *"Because creating a storage record requires the `artifact-metadata:write` permission, we wrap this in a try/catch to avoid failing the entire attestation process if the token does not have the correct permissions."*

## What this does not change

The attestation itself was never broken. It signed, uploaded to Rekor, to the repository and to the registry, and consumer-side verification of the published image passes:

```sh
gh attestation verify oci://ghcr.io/modelcontextprotocol/inspector:2.5.0 --repo modelcontextprotocol/inspector   # exit 0
```

## Honest limit, and why the comment is part of the fix

Whether the record actually lands can only be observed on a release run, and my token carries `read:org` only, so I could not exercise the write path locally. The step therefore carries a comment stating the evidence, the check to run at the next release (`gh api /orgs/modelcontextprotocol/artifacts/<digest>/metadata/storage-records` should return a record instead of 404), and the fallback if the warning survives — `create-storage-record: false` plus a note saying the record is unavailable to us. That way the issue's acceptance criterion holds on either branch instead of the release channel carrying an unexplained warning.

## Testing

`npm run format` clean; `npm run local:gate` green end to end (guards, format, lint, typecheck, build, coverage, build gate, bundle externals, smokes, Storybook 123 files / 521 tests). Workflow YAML re-parsed to confirm the job's permission block. No screenshots — no UI surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgCNAyMgKX1Fm3uhrAyeP9