### PR TITLE
fix: cap the re-auth banner width and move its flat CSS into the Paper theme

### DIFF
--- a/clients/web/src/components/groups/ReAuthBanner/ReAuthBannerBar.test.tsx
+++ b/clients/web/src/components/groups/ReAuthBanner/ReAuthBannerBar.test.tsx
@@ -13,4 +13,23 @@ describe("ReAuthBannerBar", () => {
     expect(bar.style.transform).toBe("translate(-50%, -50%)");
     expect(bar.style.zIndex).toBe("200");
   });
+
+  it("caps its width instead of fixing it, so a narrow viewport cannot clip its controls", () => {
+    renderWithMantine(
+      <ReAuthBannerBar data-testid="bar">contents</ReAuthBannerBar>,
+    );
+    const bar = screen.getByTestId("bar");
+    // Centered by `left: 50%` plus a -50% translate, so a width wider than the
+    // viewport would overflow both edges and clip the close button on one side
+    // and "Authorize again" on the other (#2218).
+    expect(bar.style.width).toBe("calc(100vw - 2rem)");
+    expect(bar.style.maxWidth).toBe("calc(26.25rem * var(--mantine-scale))");
+  });
+
+  it("takes its centering offset from the Paper theme rather than inline styles", () => {
+    renderWithMantine(
+      <ReAuthBannerBar data-testid="bar">contents</ReAuthBannerBar>,
+    );
+    expect(screen.getByTestId("bar")).toHaveAttribute("data-variant", "reauth");
+  });
 });

--- a/clients/web/src/components/groups/ReAuthBanner/ReAuthBannerBar.tsx
+++ b/clients/web/src/components/groups/ReAuthBanner/ReAuthBannerBar.tsx
@@ -1,7 +1,10 @@
 import { Paper } from "@mantine/core";
 
 // The re-auth popup. A `Paper` so every static style is a prop; the stacking
-// order goes through `styles.root` since Mantine has no `z` prop.
+// order and the centering offset go through the `reauth` variant in
+// `theme/Paper.ts`, since Mantine exposes neither `transform` nor `zIndex` as a
+// style prop and flat CSS belongs in the theme layer rather than in inline
+// `styles` (#2218).
 //
 // Floats rather than spanning the top as a sticky full-bleed bar. The bar cost
 // the whole view a band of vertical space for what is a notification about one
@@ -24,15 +27,21 @@ import { Paper } from "@mantine/core";
 // "Authorize again" also clears the stale OAuth state, which a plain reconnect
 // does not do. So it floats above the page and leaves it usable.
 //
-// `transform` goes through `styles.root` for the same reason `zIndex` does:
-// Mantine exposes neither as a style prop.
+// The width is CAPPED at 420, not fixed at it. Because the banner is centered
+// by `left: 50%` plus a -50% translate, a fixed width wider than the viewport
+// overflows BOTH edges equally — clipping the close button on one side and
+// "Authorize again" on the other, which are the only two controls it has. That
+// is reachable on a narrow desktop window, not just a phone, since the element
+// is positioned against the viewport rather than a panel. `maw` caps it while
+// `w` keeps a 1rem gutter on each side so the shadow and radius still read.
 export const ReAuthBannerBar = Paper.withProps({
+  variant: "reauth",
   pos: "fixed",
   top: "50%",
   left: "50%",
-  w: 420,
+  w: "calc(100vw - 2rem)",
+  maw: 420,
   bg: "var(--mantine-color-body)",
   shadow: "xl",
   radius: "md",
-  styles: { root: { transform: "translate(-50%, -50%)", zIndex: 200 } },
 });

--- a/clients/web/src/theme/Paper.ts
+++ b/clients/web/src/theme/Paper.ts
@@ -25,6 +25,17 @@ export const ThemePaper = Paper.extend({
         },
       };
     }
+    if (props.variant === "reauth") {
+      return {
+        root: {
+          // Centers the fixed-position re-auth banner against the viewport.
+          // Neither property is available as a Mantine style prop, so the
+          // theme layer is where they belong (#2218).
+          transform: "translate(-50%, -50%)",
+          zIndex: 200,
+        },
+      };
+    }
     if (props.variant === "panel") {
       return {
         root: {


### PR DESCRIPTION
Closes #2218

Both findings from the v2.5.0 milestone-merge review (#2215), filed on #2218 rather than fixed in the merge PR.

## 1. The fixed 420px width overflowed a narrow viewport

`ReAuthBannerBar` set an unconditional `w: 420`. Because the banner is centred by `left: 50%` plus a `translate(-50%, -50%)`, a viewport narrower than 420px made it overflow **both** edges equally — clipping the close button on one side and the action button on the other, which are the only two controls it has. Losing both is a dead end rather than a cosmetic clip: dismissing is not equivalent to re-authorizing, since "Authorize again" also clears the stale OAuth state that a plain reconnect leaves behind.

It is reachable on a narrow desktop window, not only a phone — the element is `fixed`-positioned against the viewport, so a browser docked to a third of a wide screen hits it.

The width is now **capped rather than fixed** — `maw={420}` with `w="calc(100vw - 2rem)"` — so the banner shrinks with a 1rem gutter on each side and the shadow and radius still read. Above 420px nothing changes.

### Before / after, at a 360px viewport

| Before | After |
| --- | --- |
| <img width="360" alt="Re-auth banner at a 360px viewport before the fix: the heading is clipped off the left edge and the close button off the right" src="https://github.com/user-attachments/assets/aeacfc37-e3ad-4829-b3ba-724657fc9a54" /> | <img width="360" alt="Re-auth banner at a 360px viewport after the fix: the whole banner fits with a gutter on each side, both the close button and the action button visible" src="https://github.com/user-attachments/assets/cc61cdf6-83a9-4df3-a0eb-01c3873f8b1b" /> |

## 2. `transform` / `zIndex` moved into a `Paper` theme variant

The same constant carried flat CSS in component-level `styles`. The file's existing comment is correct that Mantine exposes neither `transform` nor `zIndex` as a style prop — but that argues for the next tier in the repo's preference order (props → theme variant → CSS class), not for inline `styles`. Both now live in a `reauth` variant in `clients/web/src/theme/Paper.ts`, alongside the existing `code`, `contained` and `panel` variants, and the constant selects it with `variant: "reauth"`.

## Not actionable

The third finding on #2215 — an unterminated inline-code span in `clients/web/src/lib/authToken.ts:18` — is incorrect. The line carries exactly two backticks, balanced. No change.

## Tests

`ReAuthBannerBar.test.tsx` gains two cases beside the existing one: that the width is capped rather than fixed (`width: calc(100vw - 2rem)`, `max-width` at 420px scaled), and that the centring offset arrives via the theme variant rather than inline `styles`. Nothing exercised this component below 420px before.

`npm run local:gate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYcBw3Sftq5Yx4WpdzXttb