### PR TITLE
fix: two load-dependent Storybook flakes — SkillsScreen geometry and the Ace-worker wait

### DIFF
--- a/clients/web/src/components/elements/JsonObjectInput/JsonObjectInput.stories.tsx
+++ b/clients/web/src/components/elements/JsonObjectInput/JsonObjectInput.stories.tsx
@@ -209,9 +209,12 @@ export const AnnotatesTheOffendingLine: Story = {
         await expect(annotations.length).toBeGreaterThan(0);
         await expect(annotations.some((a) => a.type === "error")).toBe(true);
       },
-      // The worker is asynchronous and debounced, so this needs a real wait
-      // rather than a tick.
-      { timeout: 5000 },
+      // The worker is asynchronous, starts out of process and debounces its
+      // result, so this needs a real wait rather than a tick — and a budget
+      // that survives a loaded machine, where 5000ms did not (#2292). It also
+      // has to stay under the storybook project's `testTimeout`, or the test is
+      // killed before the wait can report what it saw.
+      { timeout: 10000 },
     );
   },
 };

--- a/clients/web/src/components/screens/SkillsScreen/SkillsScreen.stories.tsx
+++ b/clients/web/src/components/screens/SkillsScreen/SkillsScreen.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { ComponentProps } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import type { SkillEntry } from "@inspector/core/mcp/skillsSchemas";
 import { SkillsScreen } from "./SkillsScreen";
 import type { SkillsUiState } from "./SkillsScreen";
@@ -428,9 +428,22 @@ export const LongSkillDocument: Story = {
       detailCard.clientHeight + 1,
     );
 
-    // Collapse then reopen restores the same geometry.
+    // Collapse then reopen restores the same geometry. There is no panel
+    // animation to wait out — the accordion sets `transitionDuration={0}`
+    // because a height animation fights its flex sizing — but the reopen is
+    // still not settled when the click resolves: `userEvent.click` returns once
+    // the event is dispatched, ahead of React committing the `openSections`
+    // update, remounting the panel's content, and the browser running the
+    // layout pass that redistributes height across the flex sections. Sampling
+    // once lands mid-redistribution under load and fails intermittently
+    // (#2278), so read the geometry under `waitFor` and let it retry until the
+    // panes stop moving. The reopened layout only ever converges ON `before`
+    // rather than passing through it, so retrying cannot mask a real
+    // regression.
     await userEvent.click(viewerControl);
     await userEvent.click(viewerControl);
-    await expect(geometry()).toEqual(before);
+    await waitFor(async () => {
+      await expect(geometry()).toEqual(before);
+    });
   },
 };

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -375,6 +375,16 @@ export default defineConfig(({ command }) => {
           ],
           test: {
             name: "storybook",
+            // Vitest's default is 5000ms, which is the whole budget a play
+            // function gets — including work that is genuinely slow rather than
+            // racy. `JsonObjectInput`'s "Annotates The Offending Line" waits on
+            // Ace's JSON worker, which starts out of process and debounces its
+            // result; its own `waitFor` asked for 5000ms and so could never win
+            // against the per-test ceiling, and it lost on a loaded machine
+            // (#2292). A larger ceiling does not hide a defect here: a story
+            // that blows 15s has genuinely failed, and every assertion stays as
+            // strict as it was.
+            testTimeout: 15000,
             browser: {
               enabled: true,
               headless: true,


### PR DESCRIPTION
Closes #2278
Closes #2292

Two flaky Storybook tests, both load-dependent, both surfaced by `npm run local:gate` runs on a busy machine. They are different failure classes and get different fixes.

## 1. `SkillsScreen > Long Skill Document` — a missing wait (#2278)

The tail of the story collapsed and reopened the Skill Resource accordion and then compared all four section heights against the pre-collapse sample with an exact `toEqual`:

```tsx
await userEvent.click(viewerControl);
await userEvent.click(viewerControl);
await expect(geometry()).toEqual(before);
```

`userEvent.click` resolves once the event is dispatched — ahead of React committing the `openSections` update, the panel remounting its content, and the browser running the layout pass that redistributes height across the flex sections. Nothing waited for that settle, so the measurement sampled the panes mid-redistribution: `[48, 202, 178, 262]` against `[48, 202, 155, 285]`, two heights off by 23px in opposite directions and summing to the same total — the signature of a mid-flight read rather than a layout regression.

**No panel animation is involved**, and the first version of this description wrongly said otherwise (caught in review). `SkillsScreen.tsx:1270` sets `transitionDuration={0}` because Mantine's panel height animation fights the flex sizing, and `App.css` restores a transition only for the chevron transform. What is being waited on is React's commit plus the following layout pass.

**Fix:** read the geometry under `waitFor`, which retries until the panes settle.

- **Retrying cannot mask a real regression.** The reopened layout *converges on* the pre-collapse geometry; it does not pass through it and continue elsewhere. A genuinely broken reopen never reaches `before` and still fails, now at the `waitFor` timeout.
- **A tolerance would have been the wrong instrument.** It hides the race instead of removing it, and would still fail on a sample taken early enough — 23px was just the offset observed once.

## 2. `JsonObjectInput > Annotates The Offending Line` — a budget that could never be met (#2292)

This one is the opposite case: the wait was already there and already deliberate. The story waits for Ace's JSON worker to produce gutter annotations, and the worker starts **out of process** and debounces its result, so the story asked for `waitFor(..., { timeout: 5000 })`.

But the storybook vitest project set no `testTimeout` at all, leaving it on vitest's **5000ms default** — the same number. The wait could therefore never win: the test was killed at exactly the moment its own budget expired. On a loaded machine that is what happened, surfacing as `expected 0 to be greater than 0`.

**Fix:** raise the project's `testTimeout` to 15s and the story's own wait to 10s, so the wait has room to report what it actually saw. Neither loosens an assertion — a story that blows 15s has genuinely failed, and a worker that never starts still fails, just later. Reducing what the story waits on was the alternative, but the doc comment on it makes the case that end-to-end annotations are the only thing covering the worker's `ace.config.setModuleUrl` registration, so that coverage is worth keeping.

## Verification

- Both story files re-run in isolation after the change: 16/16 green across the two files; `JsonObjectInput` was separately 3/3 green on repeat runs, and `SkillsScreen` 3/3.
- `npm run local:gate` green — 123 Storybook files, 525 tests. (Two earlier gate runs each went red on one unrelated load flake, which is what turned up #2292 in the first place.)
- Test-and-config only, no production code: the diff is the two story files plus the `testTimeout` line in `clients/web/vite.config.ts`, so there are no screenshots to attach.

Neither failure has a deterministic reproduction — that is what both issues document — so this is not demonstrated by a red-to-green run. In each case the impossible condition is removed structurally: a sample that could land mid-layout, and a wait that could not outlast its own test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtdD6rzc1ddT28ZNE9wUjV