### PR TITLE
fix: force the Storybook dep pre-bundle on every run (#2340)

### DIFF
--- a/clients/web/server/vite-base-config.ts
+++ b/clients/web/server/vite-base-config.ts
@@ -59,11 +59,40 @@ export function getViteBaseConfig() {
       // That was one instance of a class, not the class: any package a story
       // or component starts importing after the cache was written is
       // discovered the same way, and pinning each one here would chase the
-      // symptom. The `storybook` project in `vite.config.ts` now sets
-      // `optimizeDeps.force` so every run re-scans the story entries up front
-      // (#2340); this entry stays as the explicit include it always was.
+      // symptom. `getStorybookOptimizeDeps` below adds `force` so every run
+      // re-scans the story entries up front (#2340); this entry stays as the
+      // explicit include it always was.
       include: ["@modelcontextprotocol/client"],
     },
+  };
+}
+
+/**
+ * Storybook (browser Vitest project) optimizeDeps: the base set, re-bundled
+ * on every run instead of read from the cache (#2340).
+ *
+ * Vite keys that cache on the lockfile and on the config, never on what the
+ * story graph imports, so a cached bundle stays "valid" after a story or
+ * component gains an import of a package that is already installed. With a
+ * valid cache Vite skips the scan, and the first request for the new package
+ * re-runs the optimizer mid-run: the shared chunks are rewritten, the `?v=`
+ * browser hash is bumped, and Vite sends a `full-reload` that the Vitest
+ * tester iframes do not act on. The `@storybook/react` renderer already loaded
+ * in a live iframe still holds the old hash for its lazy
+ * `import("@storybook/react-dom-shim")`, so every story that iframe renders
+ * from then on fails with "Failed to fetch dynamically imported module" — and
+ * the next run is green, because the cache has caught up. `force` discards the
+ * cache up front so the scanner crawls every story entry before the browser
+ * opens: the same cold path CI takes on every PR. Cost: ~0.8s per run.
+ *
+ * Spread from `getViteBaseConfig()` rather than left to Vitest's project merge
+ * so the include/exclude the base set carries are the helper's own claim, and
+ * tested as such.
+ */
+export function getStorybookOptimizeDeps() {
+  return {
+    ...getViteBaseConfig().optimizeDeps,
+    force: true,
   };
 }
 

--- a/clients/web/server/vite-base-config.ts
+++ b/clients/web/server/vite-base-config.ts
@@ -55,6 +55,13 @@ export function getViteBaseConfig() {
       // components import it at runtime (e.g. `protocolUtils`'s
       // `isInputRequiredResult` / `SUBSCRIPTION_ID_META_KEY`), so listing it
       // here keeps the dep graph stable across story files.
+      //
+      // That was one instance of a class, not the class: any package a story
+      // or component starts importing after the cache was written is
+      // discovered the same way, and pinning each one here would chase the
+      // symptom. The `storybook` project in `vite.config.ts` now sets
+      // `optimizeDeps.force` so every run re-scans the story entries up front
+      // (#2340); this entry stays as the explicit include it always was.
       include: ["@modelcontextprotocol/client"],
     },
   };

--- a/clients/web/src/test/integration/server/vite-base-config.test.ts
+++ b/clients/web/src/test/integration/server/vite-base-config.test.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   clearViteDepsCache,
+  getStorybookOptimizeDeps,
   getViteBaseConfig,
   getViteDevOptimizeDeps,
 } from "../../../../server/vite-base-config.js";
@@ -51,6 +52,30 @@ describe("getViteDevOptimizeDeps", () => {
       "@modelcontextprotocol/client/validators/ajv",
     ]);
     expect(config.exclude).toEqual(getViteBaseConfig().optimizeDeps.exclude);
+  });
+});
+
+describe("getStorybookOptimizeDeps", () => {
+  it("forces a re-bundle on every run so a stale cache cannot re-optimize mid-run (#2340)", () => {
+    const config = getStorybookOptimizeDeps();
+    expect(config.force).toBe(true);
+  });
+
+  it("keeps the base include and exclude sets", () => {
+    const config = getStorybookOptimizeDeps();
+    const base = getViteBaseConfig().optimizeDeps;
+    expect(config.include).toEqual(base.include);
+    expect(config.exclude).toEqual(base.exclude);
+    expect(config.include).toContain("@modelcontextprotocol/client");
+  });
+
+  it("does not carry the dev server's stale-request tolerance", () => {
+    // `ignoreOutdatedRequests` belongs to `vite dev`, where a full page reload
+    // follows a re-optimization; under Vitest a request for an outdated dep
+    // must fail loudly, since nothing reloads the tester iframe.
+    expect(getStorybookOptimizeDeps()).not.toHaveProperty(
+      "ignoreOutdatedRequests",
+    );
   });
 });
 

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -391,6 +391,24 @@ export default defineConfig(({ command }) => {
               configDir: path.join(dirname, ".storybook"),
             }),
           ],
+          optimizeDeps: {
+            // Re-bundle the browser dep pre-bundle on every run instead of
+            // trusting the cached one (#2340). Vite keys that cache on the
+            // lockfile and on this config, never on what the story graph
+            // imports, so a cached bundle stays "valid" after a story or
+            // component gains an import of a package that is already
+            // installed. The first request for it then re-runs the optimizer
+            // mid-run, which bumps the `?v=` browser hash and rewrites the
+            // shared chunks; the `@storybook/react` renderer already loaded in
+            // a live test iframe still holds the old hash for its lazy
+            // `import("@storybook/react-dom-shim")`, so every story that
+            // iframe renders from then on fails with "Failed to fetch
+            // dynamically imported module", and the next run is green because
+            // the cache has caught up. `force` discards the cache up front, so
+            // the scanner crawls every story entry before the browser opens —
+            // the same cold path CI takes on every PR. Cost: ~0.8s per run.
+            force: true,
+          },
           test: {
             name: "storybook",
             // Vitest's default is 5000ms, which is the whole budget a play

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -9,6 +9,7 @@ import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { playwright } from "@vitest/browser-playwright";
 import { honoMiddlewarePlugin } from "./server/vite-hono-plugin";
 import {
+  getStorybookOptimizeDeps,
   getViteBaseConfig,
   getViteDevOptimizeDeps,
 } from "./server/vite-base-config";
@@ -391,24 +392,10 @@ export default defineConfig(({ command }) => {
               configDir: path.join(dirname, ".storybook"),
             }),
           ],
-          optimizeDeps: {
-            // Re-bundle the browser dep pre-bundle on every run instead of
-            // trusting the cached one (#2340). Vite keys that cache on the
-            // lockfile and on this config, never on what the story graph
-            // imports, so a cached bundle stays "valid" after a story or
-            // component gains an import of a package that is already
-            // installed. The first request for it then re-runs the optimizer
-            // mid-run, which bumps the `?v=` browser hash and rewrites the
-            // shared chunks; the `@storybook/react` renderer already loaded in
-            // a live test iframe still holds the old hash for its lazy
-            // `import("@storybook/react-dom-shim")`, so every story that
-            // iframe renders from then on fails with "Failed to fetch
-            // dynamically imported module", and the next run is green because
-            // the cache has caught up. `force` discards the cache up front, so
-            // the scanner crawls every story entry before the browser opens —
-            // the same cold path CI takes on every PR. Cost: ~0.8s per run.
-            force: true,
-          },
+          // Re-bundled on every run rather than read from the cache — the
+          // stale-cache failure it prevents, and why `force` is the lever, are
+          // on the helper (#2340).
+          optimizeDeps: getStorybookOptimizeDeps(),
           test: {
             name: "storybook",
             // Vitest's default is 5000ms, which is the whole budget a play


### PR DESCRIPTION
Closes #2340

## What it is

Not a timeout, and not a race with the machine: **a stale Vite dep pre-bundle cache**. Vite keys the Storybook project's cache (`node_modules/.cache/storybook/<ver>/<hash>/sb-vitest/deps/_metadata.json`) on the lockfile hash and a config hash — never on what the story graph imports. So after a story or component gains an import of a package that is *already installed* (no lockfile change), the cached bundle is still "valid" (`Hash is consistent. Skipping.`), Vite does no scan, and the first browser request for the new package registers a missing import mid-run. The optimizer re-bundles, the shared chunks change, `needsReload` flips, the browser hash is bumped and Vite sends a `full-reload` that the Vitest tester iframes do not act on. The `@storybook/react` renderer already loaded in a live iframe still holds the old `?v=` for its lazy `import("@storybook/react-dom-shim")`, so every story that iframe renders from then on fails with exactly the issue's error. The next run is green because the cache has caught up — hence "1 of 2, both idle".

The fix is `optimizeDeps.force: true` on the `storybook` project: the cache is discarded up front and the scanner crawls every story entry before the browser opens — the same cold path CI takes on every PR (which is why CI has never shown this). Measured cost: scan ~200ms + bundle ~560ms per run against a ~25s stage.

`vite-base-config.ts` already pinned one package into `optimizeDeps.include` for this exact symptom (#1705); that was one instance of the class, and per-package pins chase the symptom. The entry stays; its comment now says so and points here.

## Measurements

Worktree at `04024fe3`, ambient load 7–20 (other sessions' gates running), `DEBUG=vite:deps` on every run so the optimizer's decisions are in the log. "Stale" = delete the cache, run once to warm it, then add `import "@mantine/form";` (installed, never imported by a story) to `SkillsScreen.stories.tsx` and run again.

| Arm | Runs | Result | Optimizer log |
| --- | --- | --- | --- |
| Warm, consistent cache, baseline | 3 | 3/3 green | `Hash is consistent` |
| Cold, baseline | 3 | 3/3 green | `scanner found every used dependency` |
| **Stale, baseline** | 3 | **3/3 red** (6, 7, 6 files; 39, 30, 30 stories) | `new dependencies found: @mantine/form` → `optimized dependencies changed. reloading` |
| **Stale, fix** | 3 | **3/3 green** | `Forced re-optimization` → `scanner found every used dependency` |
| **Stale, fix reverted** | 3 | **3/3 red** (1, 5, 6 files; 10, 35, 37 stories) | same as baseline |

Every red run carries the issue's exact error and chunk (`@storybook_addon-docs_n_@storybook_react-dom-shim.js?v=<old browserHash>`), zero `Test timed out`, and the failing set always includes `SkillsScreen.stories.tsx` and `InspectorView.stories.tsx` — the files in flight when the reload lands. The reverted arm's run 1 failed exactly the 10 SkillsScreen stories the issue lists.

**Load correlation: refuted as a cause.** Six warm/cold baseline runs under load 8–12 produced zero occurrences; the re-optimization happens if and only if the cache is missing something the graph requests, which is a property of the checkout's history, not the machine. Load only moves *which* files are in flight when it fires. So this stays independent of #2336/#2339 and is not folded in.

One unrelated failure surfaced while measuring: `SkillsScreen > Long Skill Document` failed a geometry assertion once (`expected [48,202,178,262] to deeply equal [48,202,155,285]`), zero fetch errors — that is #2327's surface and is left there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsmUAZ6aLUAFqenjJKSSRp
